### PR TITLE
docs - fixing showsUserLocation option note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ _[Information on installing Mapbox GL for iOS normally](https://github.com/mapbo
 | `centerCoordinate` | `object` | Optional | `0,0`| Initial `latitude`/`longitude` the map will load at, defaults to `0,0`.
 | `zoomLevel` | `double` | Optional | `0` | Initial zoom level the map will load at. 0 is the entire world, 18 is rooftop level. Defaults to 0.
 | `rotateEnabled` | `bool`  |  Optional | `true`  | Whether the map can rotate |
-|`showsUserLocation` | `bool` | Optional | `false` | Whether the users location is shown on the map. Note - the map will |
+|`showsUserLocation` | `bool` | Optional | `false` | Whether the user's location is shown on the map. Note - the map will not zoom to their location.|
 | `styleURL` | `string` | Optional | Mapbox Streets |  A Mapbox GL style sheet. Defaults to `mapbox-streets`. More styles [can be viewed here](https://www.mapbox.com/mapbox-gl-styles).
 | `annotations` | `array` | Optional | NA |  An array of annotation objects. `latitude`/`longitude` are required, both `title` and `subtitle` are optional.  
 | `direction`  | `double` | Optional | `0` | Heading of the map in degrees where 0 is north and 180 is south |


### PR DESCRIPTION
Looks like some of the note was lost in this commit: https://github.com/bsudekum/react-native-mapbox-gl/commit/88de3bda0a1f7983f9a0ba9d43ac3946bae1850a
