### PR TITLE
Add geocoding API

### DIFF
--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -23,6 +23,11 @@ var MapView = React.createClass({
   statics: {
     Mixin: MapMixins
   },
+  getInitialState() {
+    return {
+      userLocation: null
+    }
+  },
   _onChange(event: Event) {
     if (!this.props.onRegionChange) {
       return;
@@ -40,6 +45,25 @@ var MapView = React.createClass({
       return;
     }
     this.props.onUpdateUserLocation(event.nativeEvent.userLocation);
+    this.setState({userLocation: event.nativeEvent.userLocation });
+  },
+  geocode(query, proximity, callback) {
+    if (!query) return callback('No query');
+    var request = new XMLHttpRequest();
+    var url;
+
+    request.onreadystatechange = (e) => {
+      if (request.readyState !== 4) return;
+      if (request.status !== 200) return callback(request.status, request.responseText);
+
+      return callback(null, request.responseText);
+    };
+
+    if (!proximity || !this.state.userLocation) url = `http://api.tiles.mapbox.com/v4/geocode/mapbox.places/${query}.json?access_token=${this.props.accessToken}`;
+    if (proximity && this.state.userLocation) url = `http://api.tiles.mapbox.com/v4/geocode/mapbox.places/${query}.json?proximity=${this.state.userLocation.longitude},${this.state.userLocation.latitude}&access_token=${this.props.accessToken}`;
+
+    request.open('GET', url);
+    request.send();
   },
   propTypes: {
     showsUserLocation: React.PropTypes.bool,


### PR DESCRIPTION
Adds a geocoding function:

``` js
this.refs.mapRef.geocode('Chicago', true, (err, res) => {
  if(err) console.log(err);
  console.log(res)
})
```

Args:
- query, string
- proximity, bool
- callback

I'm not sold the this. My biggest complaint is that it differs from how the other methods work, IE it is not a mixin. Ideally methods and this function are implemented in the same manner. `geocode` does not need a `ref` because it is not actually manipulating the map. Perhaps in the future it would be a good idea to tack on a function which centers the map at the results from `geocode`. In this case, it will need a `ref` and called in the same way as mixin.

``` jsx
<Text style={styles.text} onPress={() => this.setDirectionAnimated(mapRef, 0)}>
  Set direction to 0
</Text>
<Text style={styles.text} onPress={() => this.refs.mapRef.geocode('Chicago', true, (err, res) => { if(err) console.log(err); console.log(res) })}>
geocode 'Chicago'
</Text>
```
