### PR TITLE
add select annotation method

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,6 +32,7 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `setCenterCoordinateAnimated` | `mapViewRef`, `latitude`, `longitude` | Moves the map to a new coordinate. Note, the zoom level stay at the current zoom level
 | `setCenterCoordinateZoomLevelAnimated` | `mapViewRef`, `latitude`, `longitude`, `zoomLevel` | Moves the map to a new coordinate and zoom level
 | `addAnnotations` | `mapViewRef`, `[{latitude: number, longitude: number, title: string, subtitle: string}]` (array of objects) | Adds an annotation to the map without redrawing the map. Note, this will remove all previous annotations from the map.
+| `selectAnnotationAnimated` | `mapViewRef`, `annotationPlaceInArray` | Open the callout of the selected annotation. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
 
 ## GL Styles
 

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -19,6 +19,9 @@ var MapMixins = {
   },
   addAnnotations(mapRef, annotations) {
     NativeModules.MapboxGLManager.addAnnotations(React.findNodeHandle(this.refs[mapRef]), annotations);
+  },
+  selectAnnotationAnimated(mapRef, annotationInArray) {
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
   }
 };
 

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -31,6 +31,7 @@
 - (void)setCenterCoordinateAnimated:(CLLocationCoordinate2D)coordinates;
 - (void)setCenterCoordinateZoomLevelAnimated:(CLLocationCoordinate2D)coordinates zoomLevel:(double)zoomLevel;
 - (void)addAnnotation:(NSArray *)annotation;
+- (void)selectAnnotationAnimated:(NSUInteger)annotationInArray;
 
 @end
 

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -103,11 +103,8 @@ RCT_EXPORT_MODULE();
     if (_newAnnotations) {
         // Take into account any already placed pins
         if (_annotations.count) {
-            NSMutableArray *removeableKeys = [NSMutableArray array];
-            for (RCTMGLAnnotation *oldKey in _annotations){
-                [removeableKeys addObject:oldKey];
-                [_map removeAnnotation: oldKey];
-            }
+            [_map removeAnnotations: _annotations];
+            _annotations = nil;
         }
 
         _annotations = _newAnnotations;
@@ -192,7 +189,7 @@ RCT_EXPORT_MODULE();
                                                  @"magneticHeading": @(userLocation.heading.magneticHeading),
                                                  @"trueHeading": @(userLocation.heading.trueHeading),
                                                  @"isUpdating": [NSNumber numberWithBool:userLocation.isUpdating]} };
-  
+    
     [_eventDispatcher sendInputEventWithName:@"topLoadingFinish" body:event];
 }
 
@@ -213,14 +210,14 @@ RCT_EXPORT_MODULE();
 
 - (void)mapView:(RCTMapboxGL *)mapView regionDidChangeAnimated:(BOOL)animated
 {
-
+    
     CLLocationCoordinate2D region = _map.centerCoordinate;
-
+    
     NSDictionary *event = @{ @"target": self.reactTag,
                              @"region": @{ @"latitude": @(region.latitude),
                                            @"longitude": @(region.longitude),
                                            @"zoom": [NSNumber numberWithDouble:_map.zoomLevel] } };
-
+    
     [_eventDispatcher sendInputEventWithName:@"topChange" body:event];
 }
 
@@ -230,12 +227,10 @@ RCT_EXPORT_MODULE();
 
 - (void)selectAnnotationAnimated:(NSUInteger)annotationInArray
 {
-    if (_annotations) {
-        if ([_annotations count] <= annotationInArray) return NSLog(@"%s", "Annotation not found in annotations array");
-        if ([_annotations count] != 0)
-        {
-            [_map selectAnnotation:_annotations[annotationInArray] animated:YES];
-        }
+    if ([_annotations count] <= annotationInArray) NSAssert(NO, @"Could not find annotation in array.");
+    if ([_annotations count] != 0)
+    {
+        [_map selectAnnotation:_annotations[annotationInArray] animated:YES];
     }
 }
 
@@ -265,7 +260,7 @@ RCT_EXPORT_MODULE();
         _title = title;
         _subtitle = subtitle;
     }
-
+    
     return self;
 }
 

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -14,14 +14,14 @@
 @implementation RCTMapboxGL {
     /* Required to publish events */
     RCTEventDispatcher *_eventDispatcher;
-
+    
     /* Our map subview instance */
     MGLMapView *_map;
-
+    
     /* Map properties */
     NSString *_accessToken;
-    NSMutableDictionary *_annotations;
-    NSMutableDictionary *_newAnnotations;
+    NSArray *_annotations;
+    NSArray *_newAnnotations;
     CLLocationCoordinate2D _centerCoordinate;
     BOOL _clipsToBounds;
     BOOL _debugActive;
@@ -38,12 +38,11 @@ RCT_EXPORT_MODULE();
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
 {
     if (self = [super init]) {
-      _eventDispatcher = eventDispatcher;
-      _clipsToBounds = YES;
-      _finishedLoading = NO;
-      _annotations = [NSMutableDictionary dictionary];
+        _eventDispatcher = eventDispatcher;
+        _clipsToBounds = YES;
+        _finishedLoading = NO;
     }
-
+    
     return self;
 }
 
@@ -64,9 +63,9 @@ RCT_EXPORT_MODULE();
         _map.showsUserLocation = _showsUserLocation;
         _map.styleURL = _styleURL;
         _map.zoomLevel = _zoomLevel;
-    } else {
         /* A bit of a hack because hooking into the fully rendered event didn't seem to work */
         [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:1];
+    } else {
         /* We need to have a height/width specified in order to render */
         if (_accessToken && _styleURL && self.bounds.size.height > 0 && self.bounds.size.width > 0) {
             [self createMap];
@@ -93,7 +92,7 @@ RCT_EXPORT_MODULE();
     _map.frame = self.bounds;
 }
 
-- (void)setAnnotations:(NSMutableDictionary *)annotations
+- (void)setAnnotations:(NSArray *)annotations
 {
     _newAnnotations = annotations;
     [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:0.1];
@@ -102,36 +101,18 @@ RCT_EXPORT_MODULE();
 - (void)updateAnnotations
 {
     if (_newAnnotations) {
-        NSArray *oldKeys = [_annotations allKeys];
-        NSArray *newKeys = [_newAnnotations allKeys];
-
         // Take into account any already placed pins
-        if (oldKeys.count) {
+        if (_annotations.count) {
             NSMutableArray *removeableKeys = [NSMutableArray array];
-            for (NSValue *oldKey in oldKeys){
-                // Collect all keys that existed in "oldKeys" but not in "newKeys"
-                // anymore, so they can be removed
-                if (![newKeys containsObject:oldKey]){
-                    [removeableKeys addObject:oldKey];
-                }
+            for (RCTMGLAnnotation *oldKey in _annotations){
+                [removeableKeys addObject:oldKey];
+                [_map removeAnnotation: oldKey];
             }
-
-            // Remove each of the "removableKeys" from the map
-            if (removeableKeys.count){
-                NSArray *removed = [_annotations objectsForKeys:removeableKeys notFoundMarker:[NSNull null]];
-                [_map removeAnnotations: removed];
-            }
-
-            // Remove any annotations that exist in both new and old from
-            // newAnnotations, so we don't create duplicates
-            [_newAnnotations removeObjectsForKeys:[_annotations allKeys]];
         }
 
-        [_annotations addEntriesFromDictionary:_newAnnotations];
-        [_map addAnnotations:[_newAnnotations allValues]];
-
-        _newAnnotations = nil;
-  }
+        _annotations = _newAnnotations;
+        [_map addAnnotations:_newAnnotations];
+    }
 }
 
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
@@ -221,9 +202,9 @@ RCT_EXPORT_MODULE();
     if (annotation.title && annotation.subtitle) {
         NSDictionary *event = @{ @"target": self.reactTag,
                                  @"annotation": @{ @"title": annotation.title,
-                                                @"subtitle": annotation.subtitle,
-                                                @"latitude": @(annotation.coordinate.latitude),
-                                                @"longitude": @(annotation.coordinate.longitude)} };
+                                                   @"subtitle": annotation.subtitle,
+                                                   @"latitude": @(annotation.coordinate.latitude),
+                                                   @"longitude": @(annotation.coordinate.longitude)} };
         
         [_eventDispatcher sendInputEventWithName:@"topBlur" body:event];
     }
@@ -245,6 +226,17 @@ RCT_EXPORT_MODULE();
 
 - (BOOL)mapView:(RCTMapboxGL *)mapView annotationCanShowCallout:(id <MGLAnnotation>)annotation {
     return YES;
+}
+
+- (void)selectAnnotationAnimated:(NSUInteger)annotationInArray
+{
+    if (_annotations) {
+        if ([_annotations count] <= annotationInArray) return NSLog(@"%s", "Annotation not found in annotations array");
+        if ([_annotations count] != 0)
+        {
+            [_map selectAnnotation:_annotations[annotationInArray] animated:YES];
+        }
+    }
 }
 
 @end

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -87,6 +87,17 @@ RCT_EXPORT_METHOD(setCenterCoordinateZoomLevelAnimated:(NSNumber *)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(selectAnnotationAnimated:(NSNumber *) reactTag
+                  annotationInArray:(NSUInteger)annotationInArray)
+{
+    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+        RCTMapboxGL *mapView = viewRegistry[reactTag];
+        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            [mapView selectAnnotationAnimated:annotationInArray];
+        }
+    }];
+}
+
 RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                   annotations:(NSArray*) annotations)
 {
@@ -94,7 +105,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if([mapView isKindOfClass:[RCTMapboxGL class]]) {
             if ([annotations isKindOfClass:[NSArray class]]) {
-                NSMutableDictionary *pins = [NSMutableDictionary dictionary];
+                NSMutableArray* pins = [[NSMutableArray alloc] init];
                 id anObject;
                 NSEnumerator *enumerator = [annotations objectEnumerator];
                 
@@ -112,9 +123,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                         }
                         
                         RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
-                        
-                        NSValue *key = [NSValue valueWithMKCoordinate:pin.coordinate];
-                        [pins setObject:pin forKey:key];
+                        [pins addObject:pin];
                     }
                 }
                 mapView.annotations = pins;
@@ -126,7 +135,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
 
 RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
     if ([json isKindOfClass:[NSArray class]]) {
-        NSMutableDictionary *pins = [NSMutableDictionary dictionary];
+        NSMutableArray* pins = [[NSMutableArray alloc] init];
         id anObject;
         NSEnumerator *enumerator = [json objectEnumerator];
 
@@ -144,11 +153,10 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                 }
 
                 RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
-
-                NSValue *key = [NSValue valueWithMKCoordinate:pin.coordinate];
-                [pins setObject:pin forKey:key];
+                [pins addObject:pin];
             }
         }
+
         view.annotations = pins;
     }
 }

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if([mapView isKindOfClass:[RCTMapboxGL class]]) {
             if ([annotations isKindOfClass:[NSArray class]]) {
-                NSMutableArray* pins = [[NSMutableArray alloc] init];
+                NSMutableArray* pins = [NSMutableArray array];
                 id anObject;
                 NSEnumerator *enumerator = [annotations objectEnumerator];
                 
@@ -135,7 +135,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
 
 RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
     if ([json isKindOfClass:[NSArray class]]) {
-        NSMutableArray* pins = [[NSMutableArray alloc] init];
+        NSMutableArray* pins = [NSMutableArray array];
         id anObject;
         NSEnumerator *enumerator = [json objectEnumerator];
 

--- a/example.md
+++ b/example.md
@@ -72,6 +72,9 @@ var map = React.createClass({
      }])}>
       Add new marker
     </Text>
+    <Text style={styles.text} onPress={() => this.selectAnnotationAnimated(mapRef, 0)}>
+     Open first popup
+   </Text>
        <MapboxGLMap
          style={styles.map}
          direction={10}


### PR DESCRIPTION
This adds `selectAnnotationAnimated(mapref, annotationPlaceInArray)` function which opens an annotation callout.

This changes how annotations are stored internally. I changed `annotations` from a dictionary to an array because of the way `selectAnnotationAnimated` works. The second argument is the annotations in the annotation array, IE pass in `0` and the first annotation's callout will open. This would not be possible with a dictionary as dictionaries are not ordered. 

@1ec5 a review here would be great. 
