### PR TITLE
Add rightCalloutAccessory

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@
 | `rotateEnabled` | `bool`  |  Optional | `true`  | Whether the map can rotate |
 |`showsUserLocation` | `bool` | Optional | `false` | Whether the user's location is shown on the map. Note - the map will not zoom to their location.|
 | `styleURL` | `string` | Optional | Mapbox Streets |  A Mapbox GL style sheet. Defaults to `mapbox-streets`. More styles [can be viewed here](https://www.mapbox.com/mapbox-gl-styles).
-| `annotations` | `array` | Optional | NA |  An array of annotation objects. `latitude`/`longitude` are required, both `title` and `subtitle` are optional.
+| `annotations` | `array` | Optional | NA |  An array of annotation objects. See [annotation detail](https://github.com/bsudekum/react-native-mapbox-gl/blob/master/API.md#annotations)
 | `direction`  | `double` | Optional | `0` | Heading of the map in degrees where 0 is north and 180 is south |
 | `debugActive`  | `bool` | Optional | `false` | Turns on debug mode. |
 | `style`  | flexbox `view` | Optional | NA | Styles the actual map view container |
@@ -31,7 +31,7 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `setZoomLevelAnimated` | `mapViewRef`, `zoomLevel` | Zooms the map to a new zoom level
 | `setCenterCoordinateAnimated` | `mapViewRef`, `latitude`, `longitude` | Moves the map to a new coordinate. Note, the zoom level stay at the current zoom level
 | `setCenterCoordinateZoomLevelAnimated` | `mapViewRef`, `latitude`, `longitude`, `zoomLevel` | Moves the map to a new coordinate and zoom level
-| `addAnnotations` | `mapViewRef`, `[{latitude: number, longitude: number, title: string, subtitle: string}]` (array of objects) | Adds an annotation to the map without redrawing the map. Note, this will remove all previous annotations from the map.
+| `addAnnotations` | `mapViewRef`, `[{latitude: number, longitude: number, title: string, subtitle: string, id: string, rightCalloutAccessory: { url: string, height: int, width: int }}]` (array of objects) | Adds an annotation to the map without redrawing the map. Note, this will remove all previous annotations from the map.
 | `selectAnnotationAnimated` | `mapViewRef`, `annotationPlaceInArray` | Open the callout of the selected annotation. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
 | `removeAnnotation`  | `mapViewRef`, `annotationPlaceInArray` | Removes the selected annotation from the map. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
 
@@ -47,3 +47,52 @@ You can change the `styleURL` to any valid GL stylesheet, here are a few:
 * `asset://styles/mapbox-streets-v7.json`
 * `asset://styles/outdoors-v7.json`
 * `asset://styles/satellite-v7.json`
+
+## Annotations
+```json
+[{
+  "latitude": "required",
+  "longitude":  "required",
+  "title": "optional string",
+  "subtitle": "optional string",
+  "id": "optional string, unique identifier.",
+  "rightCalloutAccessory": {
+    "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
+    "height": "required if url specified",
+    "width": "required if url specified",
+  }
+}]
+```
+**For adding local images via `image!yourImage.png` see [adding static resources to your app using Images.xcassets  docs](https://facebook.github.io/react-native/docs/image.html#adding-static-resources-to-your-app-using-images-xcassets)**.
+
+#### Example
+```json
+annotations: [{
+  "latitude": 40.72052634,
+  "longitude":  -73.94686958312988,
+  "title": "This is a title",
+  "subtitle": "this is a subtitle",
+  "id": "foobar1234",
+  "rightCalloutAccessory": {
+    "url": "image!myIcon.jpg",
+    "height": 30,
+    "width": 30
+  }
+}, {
+  "latitude": 40.72052634,
+  "longitude":  -73.95686958312988,
+  "title": "This is another title",
+  "subtitle": "this is a subtitle",
+  "id": "010101",
+  "rightCalloutAccessory": {
+    "url": "http://png-3.findicons.com/files/icons/2799/flat_icons/256/gear.png",
+    "height": 30,
+    "width": 30
+  }
+}, {
+  "latitude": 40.82052634,
+  "longitude":  -73.85686958312988,
+  "title": "This is another title",
+  "subtitle": "this is a subtitle"
+}]
+```

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -68,10 +68,16 @@ var MapView = React.createClass({
       longitude: React.PropTypes.number.isRequired,
       title: React.PropTypes.string,
       subtitle: React.PropTypes.string,
+      rightCalloutAccessory: React.PropTypes.object({
+        height: React.PropTypes.number,
+        width: React.PropTypes.number,
+        url: React.PropTypes.string,
+      })
     })),
     onRegionChange: React.PropTypes.func,
     onOpenAnnotation: React.PropTypes.func,
-    onUpdateUserLocation: React.PropTypes.func
+    onUpdateUserLocation: React.PropTypes.func,
+    rightCalloutAccessory: React.PropTypes.string
   },
 
   render: function() {

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -44,6 +44,12 @@ var MapView = React.createClass({
     }
     this.props.onOpenAnnotation(event.nativeEvent.annotation);
   },
+  _onRightAnnotationTapped(event: Event) {
+    if (!this.props.onRightAnnotationTapped) {
+      return;
+    }
+    this.props.onRightAnnotationTapped(event.nativeEvent.annotation);
+  },
   _onUpdateUserLocation(event: Event) {
     if (!this.props.onUpdateUserLocation) {
       return;
@@ -68,6 +74,7 @@ var MapView = React.createClass({
       longitude: React.PropTypes.number.isRequired,
       title: React.PropTypes.string,
       subtitle: React.PropTypes.string,
+      id: React.PropTypes.string,
       rightCalloutAccessory: React.PropTypes.object({
         height: React.PropTypes.number,
         width: React.PropTypes.number,
@@ -77,7 +84,7 @@ var MapView = React.createClass({
     onRegionChange: React.PropTypes.func,
     onOpenAnnotation: React.PropTypes.func,
     onUpdateUserLocation: React.PropTypes.func,
-    rightCalloutAccessory: React.PropTypes.string
+    onRightAnnotationTapped: React.PropTypes.func
   },
 
   render: function() {
@@ -92,6 +99,7 @@ var MapView = React.createClass({
       {...props}
       onChange={this._onChange}
       onBlur={this._onOpenAnnotation}
+      topTap={this._onRightAnnotationTapped}
       onLoadingFinish={this._onUpdateUserLocation} />;
   }
 });

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -17,7 +17,7 @@
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
 - (void)setAccessToken:(NSString *)accessToken;
-- (void)setAnnotations:(NSMutableDictionary *)annotations;
+- (void)setAnnotations:(NSArray *)annotations;
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate;
 - (void)setClipsToBounds:(BOOL)clipsToBounds;
 - (void)setDebugActive:(BOOL)debugActive;
@@ -33,14 +33,22 @@
 - (void)addAnnotation:(NSArray *)annotation;
 - (void)selectAnnotationAnimated:(NSUInteger)annotationInArray;
 - (void)removeAnnotation:(NSUInteger)annotationInArray;
+- (void)buttonPushed;
 
 @end
 
 @interface RCTMGLAnnotation : NSObject <MGLAnnotation>
 
+@property (nonatomic, strong) UIButton *rightCalloutAccessory;
+
 + (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
 
++ (instancetype)annotationWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle rightCalloutAccessory:(UIButton *) rightCalloutAccessory;
+
 - (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+
+- (instancetype)initWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle rightCalloutAccessory:(UIButton *) rightCalloutAccessory;
+
 
 
 @end

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -30,25 +30,23 @@
 - (void)setDirectionAnimated:(int)heading;
 - (void)setCenterCoordinateAnimated:(CLLocationCoordinate2D)coordinates;
 - (void)setCenterCoordinateZoomLevelAnimated:(CLLocationCoordinate2D)coordinates zoomLevel:(double)zoomLevel;
-- (void)addAnnotation:(NSArray *)annotation;
 - (void)selectAnnotationAnimated:(NSUInteger)annotationInArray;
 - (void)removeAnnotation:(NSUInteger)annotationInArray;
-- (void)buttonPushed;
 
 @end
 
 @interface RCTMGLAnnotation : NSObject <MGLAnnotation>
 
 @property (nonatomic, strong) UIButton *rightCalloutAccessory;
+@property (nonatomic) NSString *id;
 
-+ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
++ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id;
 
-+ (instancetype)annotationWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle rightCalloutAccessory:(UIButton *) rightCalloutAccessory;
++ (instancetype)annotationWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id rightCalloutAccessory:(UIButton *)rightCalloutAccessory;
 
-- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id;
 
-- (instancetype)initWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle rightCalloutAccessory:(UIButton *) rightCalloutAccessory;
-
+- (instancetype)initWithLocationRightCallout:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id rightCalloutAccessory:(UIButton *)rightCalloutAccessory;
 
 
 @end

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -132,9 +132,15 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                         if ([anObject objectForKey:@"subtitle"]){
                             subtitle = [RCTConvert NSString:[anObject valueForKey:@"subtitle"]];
                         }
+                    
                         
-                        RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
-                        [pins addObject:pin];
+                        UIView *rightCalloutAccessory;
+                            rightCalloutAccessory = [RCTConvert NSString:[anObject valueForKey:@"rightCalloutAccessory"]];
+                            
+                            RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle rightCalloutAccessory:rightCalloutAccessory];
+                        
+                            [pins addObject:pin];
+                        
                     }
                 }
                 mapView.annotations = pins;
@@ -162,14 +168,60 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                 if ([anObject objectForKey:@"subtitle"]){
                     subtitle = [RCTConvert NSString:[anObject valueForKey:@"subtitle"]];
                 }
+                
+                if ([anObject objectForKey:@"rightCalloutAccessory"]){
+                    NSObject *rightCalloutAccessory = [anObject valueForKey:@"rightCalloutAccessory"];
+                    NSString *url = [rightCalloutAccessory valueForKey:@"url"];
+                    //CGFloat *height = [[rightCalloutAccessory valueForKey:@"height"] integerValue];
+                    //CGFloat *width = [[rightCalloutAccessory valueForKey:@"width"] integerValue];
+                    CGFloat height = 50;
+                    CGFloat width = 50;
+                    NSLog(@"%@", rightCalloutAccessory);
+                
+                    UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+                    UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
+                        [imageView setImage:image];
+                    imageView.userInteractionEnabled = YES;
+                    imageView.frame = CGRectMake(0, 0, width, height);
+                    
+                    UIButton *imageButton = [UIButton buttonWithType:UIButtonTypeCustom];
+                    imageButton.frame = CGRectMake(0, 0, 100, 100);
+                    [imageButton setImage:image forState:UIControlStateNormal];
+                    [self.view addSubview:imageButton];
+                    [imageButton addTarget:self action:@selector(buttonPushed:) forControlEvents:UIControlEventTouchUpInside];
 
-                RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
-                [pins addObject:pin];
+                    
+                    
+                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle rightCalloutAccessory:imageButton];
+                    [pins addObject:pin];
+                    
+                } else {
+                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
+                    [pins addObject:pin];
+                }
+            
             }
         }
 
         view.annotations = pins;
+        NSLog(@"%@", pins);
     }
+}
+
+//RCT_EXPORT_METHOD(rightCalloutAccessory:(NSNumber *)reactTag
+//                  rightCalloutAccessory:(UIView *)rightCalloutAccessory)
+//{
+//    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+//        RCTMapboxGL *mapView = viewRegistry[reactTag];
+//        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+//            [mapView setRightCalloutAccessory:rightCalloutAccessory];
+//        }
+//    }];
+//}
+
+- (void) buttonPushed:(id)sender
+{
+    NSLog(@"you clicked on button %@", sender);
 }
 
 @end

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -115,6 +115,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            
             if ([annotations isKindOfClass:[NSArray class]]) {
                 NSMutableArray* pins = [NSMutableArray array];
                 id anObject;
@@ -132,14 +133,40 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                         if ([anObject objectForKey:@"subtitle"]){
                             subtitle = [RCTConvert NSString:[anObject valueForKey:@"subtitle"]];
                         }
+                        
+                        NSString *id = @"";
+                        if ([anObject objectForKey:@"id"]) {
+                            id = [RCTConvert NSString:[anObject valueForKey:@"id"]];
+                        }
                     
-                        
-                        UIView *rightCalloutAccessory;
-                            rightCalloutAccessory = [RCTConvert NSString:[anObject valueForKey:@"rightCalloutAccessory"]];
+                        if ([anObject objectForKey:@"rightCalloutAccessory"]) {
+                            NSObject *rightCalloutAccessory = [anObject valueForKey:@"rightCalloutAccessory"];
+                            NSString *url = [rightCalloutAccessory valueForKey:@"url"];
+                            CGFloat height = (CGFloat)[[rightCalloutAccessory valueForKey:@"height"] floatValue];
+                            CGFloat width = (CGFloat)[[rightCalloutAccessory valueForKey:@"width"] floatValue];
                             
-                            RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle rightCalloutAccessory:rightCalloutAccessory];
-                        
+                            UIImage *image = nil;
+                            
+                            if ([url hasPrefix:@"image!"]) {
+                                NSString* localImagePath = [url substringFromIndex:6];
+                                image = [UIImage imageNamed:localImagePath];
+                            }
+                            
+                            NSURL* checkURL = [NSURL URLWithString:url];
+                            if (checkURL && checkURL.scheme && checkURL.host) {
+                                image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+                            }
+                            
+                            UIButton *imageButton = [UIButton buttonWithType:UIButtonTypeCustom];
+                            imageButton.frame = CGRectMake(0, 0, height, width);
+                            [imageButton setImage:image forState:UIControlStateNormal];
+                            
+                            RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
                             [pins addObject:pin];
+                        } else {
+                            RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id];
+                            [pins addObject:pin];
+                        }
                         
                     }
                 }
@@ -160,43 +187,46 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
             CLLocationCoordinate2D coordinate = [RCTConvert CLLocationCoordinate2D:anObject];
             if (CLLocationCoordinate2DIsValid(coordinate)){
                 NSString *title = @"";
-                if ([anObject objectForKey:@"title"]){
+                if ([anObject objectForKey:@"title"]) {
                     title = [RCTConvert NSString:[anObject valueForKey:@"title"]];
                 }
 
                 NSString *subtitle = @"";
-                if ([anObject objectForKey:@"subtitle"]){
+                if ([anObject objectForKey:@"subtitle"]) {
                     subtitle = [RCTConvert NSString:[anObject valueForKey:@"subtitle"]];
                 }
                 
-                if ([anObject objectForKey:@"rightCalloutAccessory"]){
+                NSString *id = @"";
+                if ([anObject objectForKey:@"id"]) {
+                    id = [RCTConvert NSString:[anObject valueForKey:@"id"]];
+                }
+                
+                if ([anObject objectForKey:@"rightCalloutAccessory"]) {
                     NSObject *rightCalloutAccessory = [anObject valueForKey:@"rightCalloutAccessory"];
                     NSString *url = [rightCalloutAccessory valueForKey:@"url"];
-                    //CGFloat *height = [[rightCalloutAccessory valueForKey:@"height"] integerValue];
-                    //CGFloat *width = [[rightCalloutAccessory valueForKey:@"width"] integerValue];
-                    CGFloat height = 50;
-                    CGFloat width = 50;
-                    NSLog(@"%@", rightCalloutAccessory);
-                
-                    UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
-                    UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
-                        [imageView setImage:image];
-                    imageView.userInteractionEnabled = YES;
-                    imageView.frame = CGRectMake(0, 0, width, height);
+                    CGFloat height = (CGFloat)[[rightCalloutAccessory valueForKey:@"height"] floatValue];
+                    CGFloat width = (CGFloat)[[rightCalloutAccessory valueForKey:@"width"] floatValue];
+                    
+                    UIImage *image = nil;
+                    
+                    if ([url hasPrefix:@"image!"]) {
+                        NSString* localImagePath = [url substringFromIndex:6];
+                        image = [UIImage imageNamed:localImagePath];
+                    }
+
+                    NSURL* checkURL = [NSURL URLWithString:url];
+                    if (checkURL && checkURL.scheme && checkURL.host) {
+                        image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+                    }
                     
                     UIButton *imageButton = [UIButton buttonWithType:UIButtonTypeCustom];
-                    imageButton.frame = CGRectMake(0, 0, 100, 100);
+                    imageButton.frame = CGRectMake(0, 0, height, width);
                     [imageButton setImage:image forState:UIControlStateNormal];
-                    [self.view addSubview:imageButton];
-                    [imageButton addTarget:self action:@selector(buttonPushed:) forControlEvents:UIControlEventTouchUpInside];
-
-                    
-                    
-                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle rightCalloutAccessory:imageButton];
+        
+                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
                     [pins addObject:pin];
-                    
                 } else {
-                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle];
+                    RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id];
                     [pins addObject:pin];
                 }
             
@@ -204,24 +234,8 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
         }
 
         view.annotations = pins;
-        NSLog(@"%@", pins);
     }
 }
 
-//RCT_EXPORT_METHOD(rightCalloutAccessory:(NSNumber *)reactTag
-//                  rightCalloutAccessory:(UIView *)rightCalloutAccessory)
-//{
-//    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
-//        RCTMapboxGL *mapView = viewRegistry[reactTag];
-//        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
-//            [mapView setRightCalloutAccessory:rightCalloutAccessory];
-//        }
-//    }];
-//}
-
-- (void) buttonPushed:(id)sender
-{
-    NSLog(@"you clicked on button %@", sender);
-}
 
 @end

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": false,
   "scripts": {
     "start": "node_modules/react-native/packager/packager.sh",
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.3.1"
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.3.4"
   },
   "peerDependencies": {
     "react-native": "^0.4.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": false,
   "scripts": {
     "start": "node_modules/react-native/packager/packager.sh",
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.3.4"
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.3.1"
   },
   "peerDependencies": {
     "react-native": "^0.4.3"


### PR DESCRIPTION
This updates the annotation prop to look like:

``` json
{
  "latitude": "required",
  "longitude":  "required",
  "title": "optional string",
  "subtitle": "optional string",
  "id": "optional string, unique identifier.",
  "rightCalloutAccessory": {
    "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
    "height": "required if url specified",
    "width": "required if url specified",
  }
}
```

Results in:
![](https://cldup.com/W6le7nLAs4.png)

An image can be added via http or `image!yourImage.png` which follows react-natives image [api in place currently](https://facebook.github.io/react-native/docs/image.html#adding-static-resources-to-your-app-using-images-xcassets)

This also adds the event `onRightAnnotationTapped` which is fired when the rightcalloutaccessory is tapped. It returns the annotation object. 

Finally, I added the key `id` to the annotation object. This is a string and decided upon by the dev. I'm thinking it will come in handy when the user taps the accessory.

/cc @1ec5 
