### PR TITLE
Access requireNativeComponent through public module interface

### DIFF
--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var React = require('react-native');
-var requireNativeComponent = require('requireNativeComponent');
-var { NativeModules } = React;
+var { NativeModules, requireNativeComponent, } = React;
 
 var MapMixins = {
   setDirectionAnimated(mapRef, heading) {


### PR DESCRIPTION
As per https://github.com/facebook/react-native/issues/1821 - with 0.7.0+, requiring of any React Native internal modules will need to go through the public interface :smile: :+1:
