### PR TITLE
Support react native 0.8.0, add custom annotation image

### DIFF
--- a/API.md
+++ b/API.md
@@ -48,6 +48,7 @@ You can change the `styleURL` to any valid GL stylesheet, here are a few:
 * `asset://styles/light-v7.json`
 * `asset://styles/emerald-v7.json`
 * `asset://styles/mapbox-streets-v7.json`
+* `asset://styles/satellite-v7.json`
 
 ## Annotations
 ```json
@@ -60,8 +61,13 @@ You can change the `styleURL` to any valid GL stylesheet, here are a few:
   "rightCalloutAccessory": {
     "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
     "height": "required if url specified",
-    "width": "required if url specified",
-  }
+    "width": "required if url specified"
+  },
+  "annotationImage": {
+    "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
+    "height": "required if url specified",
+    "width": "required if url specified"
+  },
 }]
 ```
 **For adding local images via `image!yourImage.png` see [adding static resources to your app using Images.xcassets  docs](https://facebook.github.io/react-native/docs/image.html#adding-static-resources-to-your-app-using-images-xcassets)**.
@@ -89,6 +95,11 @@ annotations: [{
     "url": "http://png-3.findicons.com/files/icons/2799/flat_icons/256/gear.png",
     "height": 30,
     "width": 30
+  },
+  "annotationImage": {
+    "url": "https://avatars3.githubusercontent.com/u/600935?v=3&s=84",
+    "height": 25,
+    "width": 25
   }
 }, {
   "latitude": 40.82052634,

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -75,6 +75,11 @@ var MapView = React.createClass({
         height: React.PropTypes.number,
         width: React.PropTypes.number,
         url: React.PropTypes.string
+      }),
+      annotationImage: React.PropTypes.object({
+        height: React.PropTypes.number,
+        width: React.PropTypes.number,
+        url: React.PropTypes.string
       })
     })),
     onRegionChange: React.PropTypes.func,

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -47,6 +47,8 @@ extern NSString *const RCTMGLOnUpdateUserLocation;
 
 @property (nonatomic, strong) UIButton *rightCalloutAccessory;
 @property (nonatomic) NSString *id;
+@property (nonatomic) NSString *annotationImageURL;
+@property (nonatomic) CGSize *annotationImageSize;
 
 + (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id;
 

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -48,7 +48,7 @@ extern NSString *const RCTMGLOnUpdateUserLocation;
 @property (nonatomic, strong) UIButton *rightCalloutAccessory;
 @property (nonatomic) NSString *id;
 @property (nonatomic) NSString *annotationImageURL;
-@property (nonatomic) CGSize *annotationImageSize;
+@property (nonatomic) CGSize annotationImageSize;
 
 + (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle id:(NSString *)id;
 

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -91,8 +91,8 @@ RCT_EXPORT_MODULE();
 
 - (void)createMap
 {
-    _map = [[MGLMapView alloc] initWithFrame:self.bounds styleURL:_styleURL];
     [MGLAccountManager setAccessToken:_accessToken];
+    _map = [[MGLMapView alloc] initWithFrame:self.bounds styleURL:_styleURL];
     _map.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _map.delegate = self;
     _map.userTrackingMode = MGLUserTrackingModeFollow;
@@ -187,6 +187,7 @@ RCT_EXPORT_MODULE();
     _styleURL = styleURL;
     [self updateMap];
 }
+
 
 - (void)setRightCalloutAccessory:(UIButton *)rightCalloutAccessory
 {
@@ -325,6 +326,27 @@ RCT_EXPORT_MODULE();
         [_eventDispatcher sendInputEventWithName:RCTMGLOnRightAnnotationTapped body:event];
     }
 }
+
+- (MGLAnnotationImage *)mapView:(MGLMapView *)mapView imageForAnnotation:(id<MGLAnnotation>)annotation
+{
+    NSString *id = [(RCTMGLAnnotation *) annotation id];
+    NSString *url = [(RCTMGLAnnotation *) annotation annotationImageURL];
+    CGSize imageSize = *[(RCTMGLAnnotation *) annotation annotationImageSize];
+    MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:id];
+    
+    if (!annotationImage) {
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+        
+        UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0.0);
+        [image drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];
+        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        annotationImage = [MGLAnnotationImage annotationImageWithImage:newImage reuseIdentifier:id];
+    }
+    
+    return annotationImage;
+}
+
 @end
 
 /* RCTMGLAnnotation */

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -331,7 +331,7 @@ RCT_EXPORT_MODULE();
 {
     NSString *id = [(RCTMGLAnnotation *) annotation id];
     NSString *url = [(RCTMGLAnnotation *) annotation annotationImageURL];
-    CGSize imageSize = *[(RCTMGLAnnotation *) annotation annotationImageSize];
+    CGSize imageSize = [(RCTMGLAnnotation *) annotation annotationImageSize];
     MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:id];
     
     if (!annotationImage) {

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -338,12 +338,11 @@ RCT_EXPORT_MODULE();
         
         UIImage *image = nil;
         if ([url hasPrefix:@"image!"]) {
-            NSString* localImagePath = [url substringFromIndex:6]; //image!myImage.jpg
+            NSString* localImagePath = [url substringFromIndex:6];
             image = [UIImage imageNamed:localImagePath];
         } else {
             image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
         }
-
         
         UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0.0);
         [image drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -335,7 +335,15 @@ RCT_EXPORT_MODULE();
     MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:id];
     
     if (!annotationImage) {
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+        
+        UIImage *image = nil;
+        if ([url hasPrefix:@"image!"]) {
+            NSString* localImagePath = [url substringFromIndex:6]; //image!myImage.jpg
+            image = [UIImage imageNamed:localImagePath];
+        } else {
+            image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
+        }
+
         
         UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0.0);
         [image drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -186,9 +186,31 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                             
                             RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
                             [pins addObject:pin];
+                            
+                            if ([anObject objectForKey:@"annotationImage"]) {
+                                NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                                NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
+                                CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
+                                CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                                CGSize annotationImageSize =  CGSizeMake(height, width);
+                                pin.annotationImageURL = annotationImageURL;
+                                pin.annotationImageSize = &(annotationImageSize);
+                            }
+                            
                         } else {
+
                             RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id];
                             [pins addObject:pin];
+                            
+                            if ([anObject objectForKey:@"annotationImage"]) {
+                                NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                                NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
+                                CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
+                                CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                                CGSize annotationImageSize =  CGSizeMake(height, width);
+                                pin.annotationImageURL = annotationImageURL;
+                                pin.annotationImageSize = &(annotationImageSize);
+                            }
                         }
                         
                     }
@@ -248,8 +270,32 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                     
                     RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
                     [pins addObject:pin];
+
+
+                    if ([anObject objectForKey:@"annotationImage"]) {
+                        NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                        NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
+                        CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
+                        CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                        CGSize annotationImageSize =  CGSizeMake(height, width);
+                        pin.annotationImageURL = annotationImageURL;
+                        pin.annotationImageSize = &(annotationImageSize);
+                    }
+                    
                 } else {
+
                     RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(coordinate.latitude, coordinate.longitude) title:title subtitle:subtitle id:id];
+
+                    if ([anObject objectForKey:@"annotationImage"]) {
+                        NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                        NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
+                        CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
+                        CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                        CGSize annotationImageSize =  CGSizeMake(height, width);
+                        pin.annotationImageURL = annotationImageURL;
+                        pin.annotationImageSize = &(annotationImageSize);
+                    }
+
                     [pins addObject:pin];
                 }
                 

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -192,6 +192,10 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                                 NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
                                 CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                                if (!height || !width) {
+                                    RCTLogError(@"Height and width for image required");
+                                    return;
+                                }
                                 CGSize annotationImageSize =  CGSizeMake(height, width);
                                 pin.annotationImageURL = annotationImageURL;
                                 pin.annotationImageSize = annotationImageSize;
@@ -208,6 +212,10 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                                 CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
                                 CGSize annotationImageSize =  CGSizeMake(height, width);
+                                if (!height || !width) {
+                                    RCTLogError(@"Height and width for image required");
+                                    return;
+                                }
                                 pin.annotationImageURL = annotationImageURL;
                                 pin.annotationImageSize = annotationImageSize;
                             }
@@ -277,6 +285,10 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                         NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
                         CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                         CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                        if (!height || !width) {
+                            RCTLogError(@"Height and width for image required");
+                            return;
+                        }
                         CGSize annotationImageSize =  CGSizeMake(height, width);
                         pin.annotationImageURL = annotationImageURL;
                         pin.annotationImageSize = annotationImageSize;
@@ -291,6 +303,10 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                         NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
                         CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                         CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
+                        if (!height || !width) {
+                            RCTLogError(@"Height and width for image required");
+                            return;
+                        }
                         CGSize annotationImageSize =  CGSizeMake(height, width);
                         pin.annotationImageURL = annotationImageURL;
                         pin.annotationImageSize = annotationImageSize;

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
                                 CGSize annotationImageSize =  CGSizeMake(height, width);
                                 pin.annotationImageURL = annotationImageURL;
-                                pin.annotationImageSize = &(annotationImageSize);
+                                pin.annotationImageSize = annotationImageSize;
                             }
                             
                         } else {
@@ -209,7 +209,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
                                 CGSize annotationImageSize =  CGSizeMake(height, width);
                                 pin.annotationImageURL = annotationImageURL;
-                                pin.annotationImageSize = &(annotationImageSize);
+                                pin.annotationImageSize = annotationImageSize;
                             }
                         }
                         
@@ -279,7 +279,7 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                         CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
                         CGSize annotationImageSize =  CGSizeMake(height, width);
                         pin.annotationImageURL = annotationImageURL;
-                        pin.annotationImageSize = &(annotationImageSize);
+                        pin.annotationImageSize = annotationImageSize;
                     }
                     
                 } else {
@@ -293,7 +293,7 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
                         CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
                         CGSize annotationImageSize =  CGSizeMake(height, width);
                         pin.annotationImageURL = annotationImageURL;
-                        pin.annotationImageSize = &(annotationImageSize);
+                        pin.annotationImageSize = annotationImageSize;
                     }
 
                     [pins addObject:pin];

--- a/example.js
+++ b/example.js
@@ -34,7 +34,12 @@ var Example = React.createClass({
          latitude: 40.714541341726175,
          longitude:  -74.00579452514648,
          title: 'Important!',
-         subtitle: 'Neat, this is a subtitle'
+         subtitle: 'Neat, this is a custon annotation image',
+         annotationImage: {
+           url: 'https://avatars3.githubusercontent.com/u/600935?v=3&s=84',
+           height: 25,
+           width: 25
+         }
        }]
      };
   },

--- a/example.js
+++ b/example.js
@@ -26,20 +26,27 @@ var Example = React.createClass({
          title: 'This is marker 1',
          subtitle: 'It has a rightCalloutAccessory too',
          rightCalloutAccessory: {
-             url: 'http://png-3.findicons.com/files/icons/2799/flat_icons/256/gear.png',
+             url: 'https://cldup.com/9Lp0EaBw5s.png',
              height: 25,
              width: 25
-         }
+         },
+         annotationImage: {
+           url: 'https://cldup.com/CnRLZem9k9.png',
+           height: 25,
+           width: 25
+         },
+         id: 'marker1'
        },{
          latitude: 40.714541341726175,
          longitude:  -74.00579452514648,
          title: 'Important!',
-         subtitle: 'Neat, this is a custon annotation image',
+         subtitle: 'Neat, this is a custom annotation image',
          annotationImage: {
-           url: 'https://avatars3.githubusercontent.com/u/600935?v=3&s=84',
+           url: 'https://cldup.com/7NLZklp8zS.png',
            height: 25,
            width: 25
-         }
+         },
+         id: 'marker2'
        }]
      };
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.4.0",
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 0.5.1",
     "test": "eslint example.js RCTMapboxGL.ios.js",
     "start": "node_modules/react-native/packager/packager.sh"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "main": "RCTMapboxGL.ios.js",
   "peerDependencies": {
-    "react-native": ">=0.4.3 <0.8.0"
+    "react-native": ">=0.4.3 <0.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds support for react native 0.8.0 and adds `annotationImage` support. 

API looks as follows:

```
annotationImage: {
  url: 'https://avatars3.githubusercontent.com/u/600935?v=3&s=84',
  height: 25,
  width: 25
},
```

@1ec5 I'm having some issues resizing the image. I'm following something similar [too here](http://stackoverflow.com/a/24498221/1522419) but I'm having issues constructing the [CGSize](https://github.com/mapbox/react-native-mapbox-gl/compare/080?expand=1#diff-bea3f6469d29a272c0cf23632fe64853R334). Maybe we can take a look at this tomorrow morning. 

I still need to add support for local images via the `!image` api. 
