### PR TITLE
Implement new property #updateLocationInBackground

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,6 +9,7 @@
 | `scrollEnabled` | `bool`  |  Optional | `true`  | Whether the map can be scrolled |
 | `zoomEnabled` | `bool`  |  Optional | `true`  | Whether the map zoom level can be changed |
 |`showsUserLocation` | `bool` | Optional | `false` | Whether the user's location is shown on the map. Note - the map will not zoom to their location.|
+|`updateLocationInBackground` | `bool` | Optional | `true` | When `showsUserLocation` is `true`, whether to update location when app is in background.|
 | `styleURL` | `string` | Optional | Mapbox Streets |  A Mapbox GL style sheet. Defaults to `mapbox-streets`. More styles [can be viewed here](https://www.mapbox.com/mapbox-gl-styles).
 | `annotations` | `array` | Optional | NA |  An array of annotation objects. See [annotation detail](https://github.com/bsudekum/react-native-mapbox-gl/blob/master/API.md#annotations)
 | `direction`  | `double` | Optional | `0` | Heading of the map in degrees where 0 is north and 180 is south |

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -4,6 +4,9 @@ var React = require('react-native');
 var { NativeModules, requireNativeComponent } = React;
 
 var MapMixins = {
+  _findHandle(mapRef) {
+    return React.findNodeHandle(this.refs[mapRef]);
+  },
   setDirectionAnimated(mapRef, heading) {
     NativeModules.MapboxGLManager.setDirectionAnimated(React.findNodeHandle(this.refs[mapRef]), heading);
   },
@@ -11,7 +14,7 @@ var MapMixins = {
     NativeModules.MapboxGLManager.setZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), zoomLevel);
   },
   setCenterCoordinateAnimated(mapRef, latitude, longitude) {
-    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude);
+    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(this._findHandle(mapRef), latitude, longitude);
   },
   setCenterCoordinateZoomLevelAnimated(mapRef, latitude, longitude, zoomLevel) {
     NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
@@ -24,6 +27,12 @@ var MapMixins = {
   },
   removeAnnotation(mapRef, annotationInArray) {
     NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
+  },
+  setShowsUserLocation(mapRef, value) {
+    NativeModules.MapboxGLManager.setShowsUserLocation(this._findHandle(mapRef), value);
+  },
+  setUserTrackingMode(mapRef, value) {
+    NativeModules.MapboxGLManager.setUserTrackingMode(this._findHandle(mapRef), value);
   }
 };
 

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -48,6 +48,7 @@ var MapView = React.createClass({
   },
   propTypes: {
     showsUserLocation: React.PropTypes.bool,
+    updateLocationInBackground: React.PropTypes.bool,
     rotateEnabled: React.PropTypes.bool,
     scrollEnabled: React.PropTypes.bool,
     zoomEnabled: React.PropTypes.bool,

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -8,25 +8,25 @@ var MapMixins = {
     return React.findNodeHandle(this.refs[mapRef]);
   },
   setDirectionAnimated(mapRef, heading) {
-    NativeModules.MapboxGLManager.setDirectionAnimated(React.findNodeHandle(this.refs[mapRef]), heading);
+    NativeModules.MapboxGLManager.setDirectionAnimated(this._findHandle(mapRef), heading);
   },
   setZoomLevelAnimated(mapRef, zoomLevel) {
-    NativeModules.MapboxGLManager.setZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), zoomLevel);
+    NativeModules.MapboxGLManager.setZoomLevelAnimated(this._findHandle(mapRef), zoomLevel);
   },
   setCenterCoordinateAnimated(mapRef, latitude, longitude) {
     NativeModules.MapboxGLManager.setCenterCoordinateAnimated(this._findHandle(mapRef), latitude, longitude);
   },
   setCenterCoordinateZoomLevelAnimated(mapRef, latitude, longitude, zoomLevel) {
-    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
+    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(this._findHandle(mapRef), latitude, longitude, zoomLevel);
   },
   addAnnotations(mapRef, annotations) {
-    NativeModules.MapboxGLManager.addAnnotations(React.findNodeHandle(this.refs[mapRef]), annotations);
+    NativeModules.MapboxGLManager.addAnnotations(this._findHandle(mapRef), annotations);
   },
   selectAnnotationAnimated(mapRef, annotationInArray) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(this._findHandle(mapRef), annotationInArray);
   },
   removeAnnotation(mapRef, annotationInArray) {
-    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
+    NativeModules.MapboxGLManager.removeAnnotation(this._findHandle(mapRef), annotationInArray);
   },
   setShowsUserLocation(mapRef, value) {
     NativeModules.MapboxGLManager.setShowsUserLocation(this._findHandle(mapRef), value);

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -35,6 +35,7 @@ extern NSString *const RCTMGLOnUpdateUserLocation;
 - (void)setZoomEnabled:(BOOL)zoomEnabled;
 - (void)setShowsUserLocation:(BOOL)showsUserLocation;
 - (void)setUpdateLocationInBackground:(BOOL)value;
+- (void)setUserTrackingMode:(MGLUserTrackingMode)trackingMode;
 - (void)setStyleURL:(NSURL *)styleURL;
 - (void)setZoomLevel:(double)zoomLevel;
 - (void)setZoomLevelAnimated:(double)zoomLevel;

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -20,6 +20,8 @@ extern NSString *const RCTMGLOnUpdateUserLocation;
 
 @interface RCTMapboxGL : RCTView <MGLMapViewDelegate, RCTBridgeModule>
 
+@property (nonatomic) BOOL updateLocationInBackground;
+
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
 - (void)setAccessToken:(NSString *)accessToken;
@@ -32,6 +34,7 @@ extern NSString *const RCTMGLOnUpdateUserLocation;
 - (void)setScrollEnabled:(BOOL)scrollEnabled;
 - (void)setZoomEnabled:(BOOL)zoomEnabled;
 - (void)setShowsUserLocation:(BOOL)showsUserLocation;
+- (void)setUpdateLocationInBackground:(BOOL)value;
 - (void)setStyleURL:(NSURL *)styleURL;
 - (void)setZoomLevel:(double)zoomLevel;
 - (void)setZoomLevelAnimated:(double)zoomLevel;

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -435,4 +435,10 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
 @end

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -51,6 +51,7 @@ RCT_EXPORT_MODULE();
         _eventDispatcher = eventDispatcher;
         _clipsToBounds = YES;
         _finishedLoading = NO;
+        _updateLocationInBackground = YES;
     }
     
     return self;
@@ -99,18 +100,23 @@ RCT_EXPORT_MODULE();
     [self updateMap];
     [self addSubview:_map];
     [self layoutSubviews];
-
+    
+    // Listen to pause/resume events in order to toggle #updateLocationInBackground
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onSuspend:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume:) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
 - (void) onSuspend:(NSNotification*)notification
 {
-    _map.showsUserLocation = NO;
+    if (!_updateLocationInBackground) {
+        _map.showsUserLocation = NO;
+    }
 }
 - (void) onResume:(NSNotification*)notification
 {
-    _map.showsUserLocation = YES;
+    if (_showsUserLocation) {
+        _map.showsUserLocation = YES;
+    }
 }
 
 - (void)layoutSubviews
@@ -237,6 +243,11 @@ RCT_EXPORT_MODULE();
                                         @"isUpdating": [NSNumber numberWithBool:userLocation.isUpdating]} };
     
     [_eventDispatcher sendInputEventWithName:RCTMGLOnUpdateUserLocation body:event];
+}
+
+- (void)setUpdateLocationInBackground:(BOOL)value
+{
+    _updateLocationInBackground = value;
 }
 
 

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -99,8 +99,19 @@ RCT_EXPORT_MODULE();
     [self updateMap];
     [self addSubview:_map];
     [self layoutSubviews];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onSuspend:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume:) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
+- (void) onSuspend:(NSNotification*)notification
+{
+    _map.showsUserLocation = NO;
+}
+- (void) onResume:(NSNotification*)notification
+{
+    _map.showsUserLocation = YES;
+}
 
 - (void)layoutSubviews
 {

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -178,9 +178,17 @@ RCT_EXPORT_MODULE();
 - (void)setShowsUserLocation:(BOOL)showsUserLocation
 {
     _showsUserLocation = showsUserLocation;
-    [self updateMap];
+    
+    if (_map) {
+        _map.showsUserLocation = _showsUserLocation;
+    }
 }
-
+- (void)setUserTrackingMode:(MGLUserTrackingMode)value
+{
+    if (_map) {
+        _map.userTrackingMode = value;
+    }
+}
 - (void)setClipsToBounds:(BOOL)clipsToBounds
 {
     _clipsToBounds = clipsToBounds;

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -64,7 +64,6 @@ RCT_EXPORT_VIEW_PROPERTY(zoomEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(styleURL, NSURL);
 RCT_EXPORT_VIEW_PROPERTY(zoomLevel, double);
-//RCT_EXPORT_VIEW_PROPERTY(updateLocationInBackground, BOOL);
 
 RCT_EXPORT_METHOD(setZoomLevelAnimated:(NSNumber *)reactTag
                   zoomLevel:(double)zoomLevel)

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -65,6 +65,26 @@ RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(styleURL, NSURL);
 RCT_EXPORT_VIEW_PROPERTY(zoomLevel, double);
 
+
+RCT_EXPORT_METHOD(setShowsUserLocation:(NSNumber *)reactTag value:(BOOL)value)
+{
+    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+        RCTMapboxGL *mapView = viewRegistry[reactTag];
+        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            [mapView setShowsUserLocation:value];
+        }
+    }];
+}
+RCT_EXPORT_METHOD(setUserTrackingMode:(NSNumber *)reactTag value:(int)value)
+{
+    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+        RCTMapboxGL *mapView = viewRegistry[reactTag];
+        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            [mapView setUserTrackingMode:value];
+        }
+    }];
+}
+
 RCT_EXPORT_METHOD(setZoomLevelAnimated:(NSNumber *)reactTag
                   zoomLevel:(double)zoomLevel)
 {

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -64,6 +64,8 @@ RCT_EXPORT_VIEW_PROPERTY(zoomEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(styleURL, NSURL);
 RCT_EXPORT_VIEW_PROPERTY(zoomLevel, double);
+//RCT_EXPORT_VIEW_PROPERTY(updateLocationInBackground, BOOL);
+
 RCT_EXPORT_METHOD(setZoomLevelAnimated:(NSNumber *)reactTag
                   zoomLevel:(double)zoomLevel)
 {
@@ -230,6 +232,9 @@ RCT_EXPORT_METHOD(addAnnotations:(NSNumber *)reactTag
     }];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(updateLocationInBackground, BOOL, RCTMapboxGL) {
+    view.updateLocationInBackground = [json boolValue];
+}
 RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
     if ([json isKindOfClass:[NSArray class]]) {
         NSMutableArray* pins = [NSMutableArray array];

--- a/example.js
+++ b/example.js
@@ -101,6 +101,7 @@ var Example = React.createClass({
           scrollEnabled={true}
           zoomEnabled={true}
           showsUserLocation={true}
+          updateLocationInBackground={true}
           ref={mapRef}
           accessToken={'your-mapbox.com-access-token'}
           styleURL={'asset://styles/mapbox-streets-v7.json'}


### PR DESCRIPTION
This property defaults to `true` (the current behaviour).  When set to `false` (with `showsUserLocation` set to `true`), the component will not update the location while app is in background.

This allows 3rd-party location-manager modules [such as mine](http://transistorsoft.github.io/react-native-background-geolocation/) to better handle background geolocation, since a View component should not be responsible for updating location while app is running in background.
