### PR TITLE
Delay adding annotations to the map view

### DIFF
--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -17,7 +17,7 @@
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
 - (void)setAccessToken:(NSString *)accessToken;
-- (void)setAnnotations:(NSArray *)annotations;
+- (void)setAnnotations:(NSMutableArray *)annotations;
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate;
 - (void)setClipsToBounds:(BOOL)clipsToBounds;
 - (void)setDebugActive:(BOOL)debugActive;

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -75,7 +75,7 @@ RCT_EXPORT_MODULE();
         _map.zoomLevel = _zoomLevel;
     } else {
         /* A bit of a hack because hooking into the fully rendered event didn't seem to work */
-        [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:1];
+        [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:2];
         /* We need to have a height/width specified in order to render */
         if (_accessToken && _styleURL && self.bounds.size.height > 0 && self.bounds.size.width > 0) {
             [self createMap];
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE();
 - (void)setRightCalloutAccessory:(UIButton *)rightCalloutAccessory
 {
     _rightCalloutAccessory = rightCalloutAccessory;
-    [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:0.1];
+    [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:2];
 }
 
 -(void)setDirectionAnimated:(int)heading
@@ -325,6 +325,7 @@ RCT_EXPORT_MODULE();
 {
     NSString *id = [(RCTMGLAnnotation *) annotation id];
     NSString *url = [(RCTMGLAnnotation *) annotation annotationImageURL];
+    if (!url) { return nil; }
     CGSize imageSize = [(RCTMGLAnnotation *) annotation annotationImageSize];
     MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:id];
 


### PR DESCRIPTION
I am seeing more timing issues when adding a custom image to an annotation or rightCalloutAccessory when running on device.

The error is very nondescript, but giving the annotations more time before adding to the map view solved the issue:

![](https://cldup.com/171w7-LNZy.png)

I think some of this might be attributed to https://github.com/mapbox/mapbox-gl-native/issues/1675

/cc @1ec5 
