### PR TITLE
Add polyline and polygon API

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,7 +36,7 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `setZoomLevelAnimated` | `mapViewRef`, `zoomLevel` | Zooms the map to a new zoom level
 | `setCenterCoordinateAnimated` | `mapViewRef`, `latitude`, `longitude` | Moves the map to a new coordinate. Note, the zoom level stay at the current zoom level
 | `setCenterCoordinateZoomLevelAnimated` | `mapViewRef`, `latitude`, `longitude`, `zoomLevel` | Moves the map to a new coordinate and zoom level
-| `addAnnotations` | `mapViewRef`, `[{latitude: number, longitude: number, title: string, subtitle: string, id: string, rightCalloutAccessory: { url: string, height: int, width: int }, annotationImage: { url: string, height: int, width: int }}]` (array of objects) | Adds an annotation to the map without redrawing the map. Note, this will remove all previous annotations from the map.
+| `addAnnotations` | `mapViewRef`, `` (array of annotation objects, see [#annotations](https://github.com/bsudekum/react-native-mapbox-gl/blob/master/API.md#annotations)) | Adds annotation(s) to the map without redrawing the map. Note, this will remove all previous annotations from the map.
 | `selectAnnotationAnimated` | `mapViewRef`, `annotationPlaceInArray` | Open the callout of the selected annotation. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
 | `removeAnnotation`  | `mapViewRef`, `annotationPlaceInArray` | Removes the selected annotation from the map. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
 
@@ -53,10 +53,15 @@ You can change the `styleURL` to any valid GL stylesheet, here are a few:
 ## Annotations
 ```json
 [{
-  "latitude": "required",
-  "longitude":  "required",
+  "coordinates": "required. For type polyline and polygon must be an array of arrays. For type point, single array",
+  "type": "required: point, polyline or polygon",
   "title": "optional string",
   "subtitle": "optional string",
+  "fillAlpha": "optional, only used for type=polygon. Controls the opacity of polygon",
+  "fillColor": "optional string hex color including #, only used for type=polygon",
+  "strokeAlpha": "optional number from 0-1. Only used for type=poyline. Controls opacity of line",
+  "strokeColor": "optional string hex color including #, used for type=polygon and type=polyline",
+  "strokeWidth": "optional number. Only used for type=poyline. Controls line width",
   "id": "optional string, unique identifier.",
   "rightCalloutAccessory": {
     "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
@@ -75,36 +80,45 @@ You can change the `styleURL` to any valid GL stylesheet, here are a few:
 #### Example
 ```json
 annotations: [{
-  "latitude": 40.72052634,
-  "longitude":  -73.94686958312988,
-  "title": "This is a title",
-  "subtitle": "this is a subtitle",
-  "id": "foobar1234",
+  "coordinates": [40.72052634, -73.97686958312988],
+  "type": "point",
+  "title": "This is marker 1",
+  "subtitle": "It has a rightCalloutAccessory too",
   "rightCalloutAccessory": {
-    "url": "image!myIcon.jpg",
-    "height": 30,
-    "width": 30
-  }
-}, {
-  "latitude": 40.72052634,
-  "longitude":  -73.95686958312988,
-  "title": "This is another title",
-  "subtitle": "this is a subtitle",
-  "id": "010101",
-  "rightCalloutAccessory": {
-    "url": "http://png-3.findicons.com/files/icons/2799/flat_icons/256/gear.png",
-    "height": 30,
-    "width": 30
-  },
-  "annotationImage": {
-    "url": "https://avatars3.githubusercontent.com/u/600935?v=3&s=84",
+    "url": "https://cldup.com/9Lp0EaBw5s.png",
     "height": 25,
     "width": 25
-  }
+  },
+  "annotationImage": {
+    "url": "https://cldup.com/CnRLZem9k9.png",
+    "height": 25,
+    "width": 25
+  },
+  "id": "marker1"
 }, {
-  "latitude": 40.82052634,
-  "longitude":  -73.85686958312988,
-  "title": "This is another title",
-  "subtitle": "this is a subtitle"
+  "coordinates": [40.714541341726175,-74.00579452514648],
+  "type": "point",
+  "title": "Important",
+  "subtitle": "Neat, this is a custom annotation image",
+  "annotationImage": {
+    "url": "https://cldup.com/7NLZklp8zS.png",
+    "height": 25,
+    "width": 25
+  },
+  "id": "marker2"
+}, {
+  "coordinates": [[40.76572150042782,-73.99429321289062],[40.743485405490695, -74.00218963623047],[40.728266950429735,-74.00218963623047],[40.728266950429735,-73.99154663085938],[40.73633186448861,-73.98983001708984],[40.74465591168391,-73.98914337158203],[40.749337730454826,-73.9870834350586]],
+  "type": "polyline",
+  "strokeColor": "#00FB00",
+  "strokeWidth": 3,
+  "strokeAlpha": 0.5,
+  "id": "foobar"
+}, {
+  "coordinates": [[40.749857912194386, -73.96820068359375], [40.741924698522055,-73.9735221862793], [40.735681504432264,-73.97523880004883], [40.7315190495212,-73.97438049316406], [40.729177554196376,-73.97180557250975], [40.72345355209305,-73.97438049316406], [40.719290332250544,-73.97455215454102], [40.71369559554873,-73.97729873657227], [40.71200407096382,-73.97850036621094], [40.71031250340588,-73.98691177368163], [40.71031250340588,-73.99154663085938]],
+  "type": "polygon",
+  "fillAlpha":1,
+  "fillColor": "#C32C2C",
+  "strokeColor": "#DDDDD",
+  "id": "zap"
 }]
 ```

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -66,6 +66,7 @@ var MapView = React.createClass({
       coordinates: React.PropTypes.arrayOf().isRequired,
       title: React.PropTypes.string,
       subtitle: React.PropTypes.string,
+      fillAlpha: React.PropTypes.number,
       fillColor: React.PropTypes.sting,
       strokeAlpha: React.PropTypes.number,
       strokeColor: React.PropTypes.sting,

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -57,12 +57,13 @@ var MapView = React.createClass({
     styleURL: React.PropTypes.string,
     clipsToBounds: React.PropTypes.bool,
     debugActive: React.PropTypes.bool,
+    attributionButton: React.PropTypes.bool,
     centerCoordinate: React.PropTypes.shape({
       latitude: React.PropTypes.number.isRequired,
       longitude: React.PropTypes.number.isRequired
     }),
     annotations: React.PropTypes.arrayOf(React.PropTypes.shape({
-      coordinates: React.PropTypes.arrayOf(),
+      coordinates: React.PropTypes.arrayOf().isRequired,
       title: React.PropTypes.string,
       subtitle: React.PropTypes.string,
       fillColor: React.PropTypes.sting,
@@ -70,7 +71,7 @@ var MapView = React.createClass({
       strokeColor: React.PropTypes.sting,
       strokeWidth: React.PropTypes.number,
       id: React.PropTypes.string,
-      type: React.PropTypes.string,
+      type: React.PropTypes.stringisRequired,
       rightCalloutAccessory: React.PropTypes.object({
         height: React.PropTypes.number,
         width: React.PropTypes.number,

--- a/RCTMapboxGL.ios.js
+++ b/RCTMapboxGL.ios.js
@@ -62,14 +62,14 @@ var MapView = React.createClass({
       longitude: React.PropTypes.number.isRequired
     }),
     annotations: React.PropTypes.arrayOf(React.PropTypes.shape({
+      coordinates: React.PropTypes.arrayOf(),
       title: React.PropTypes.string,
       subtitle: React.PropTypes.string,
-      id: React.PropTypes.string,
-      coordinates: React.PropTypes.arrayOf(),
       fillColor: React.PropTypes.sting,
+      strokeAlpha: React.PropTypes.number,
       strokeColor: React.PropTypes.sting,
       strokeWidth: React.PropTypes.number,
-      alpha: React.PropTypes.number,
+      id: React.PropTypes.string,
       type: React.PropTypes.string,
       rightCalloutAccessory: React.PropTypes.object({
         height: React.PropTypes.number,

--- a/RCTMapboxGL.xcodeproj/project.pbxproj
+++ b/RCTMapboxGL.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		C5DBB3551AF2EF2B00E611A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -345,6 +346,7 @@
 		C5DBB3561AF2EF2B00E611A9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/RCTMapboxGL/RCTMapboxGL.h
+++ b/RCTMapboxGL/RCTMapboxGL.h
@@ -54,3 +54,32 @@
 
 
 @end
+
+@interface RCTMGLAnnotationPolyline : MGLPolyline
+
+@property (nonatomic) NSString *id;
+@property (nonatomic) double strokeAlpha;
+@property (nonatomic) NSString *strokeColor;
+@property (nonatomic) double strokeWidth;
+@property (nonatomic) NSString *type;
+@property (nonatomic) NSUInteger count;
+@property (nonatomic) CLLocationCoordinate2D *coordinates;
+
++ (instancetype)polylineAnnotation:(CLLocationCoordinate2D *)coordinates strokeAlpha:(double)strokeAlpha strokeColor:(NSString *)strokeColor strokeWidth:(double)strokeWidth id:(NSString *)id type:(NSString *)type count:(NSUInteger)count;
+
+@end
+
+@interface RCTMGLAnnotationPolygon : MGLPolygon
+
+@property (nonatomic) NSString *id;
+@property (nonatomic) double fillAlpha;
+@property (nonatomic) NSString *fillColor;
+@property (nonatomic) double strokeAlpha;
+@property (nonatomic) NSString *strokeColor;
+@property (nonatomic) NSString *type;
+@property (nonatomic) NSUInteger count;
+@property (nonatomic) CLLocationCoordinate2D *coordinates;
+
++ (instancetype)polygonAnnotation:(CLLocationCoordinate2D *)coordinates fillAlpha:(double)fillAlpha fillColor:(NSString *)fillColor  strokeColor:(NSString *)strokeColor strokeAlpha:(double)strokeAlpha id:(NSString *)id type:(NSString *)type count:(NSUInteger)count;
+
+@end

--- a/RCTMapboxGL/RCTMapboxGL.m
+++ b/RCTMapboxGL/RCTMapboxGL.m
@@ -136,7 +136,13 @@ RCT_EXPORT_MODULE();
 
 - (UIColor *)mapView:(MGLMapView *)mapView strokeColorForShapeAnnotation:(RCTMGLAnnotationPolyline *)shape
 {
-    return [self getUIColorObjectFromHexString:shape.strokeColor alpha:1];
+    if ([shape isKindOfClass:[RCTMGLAnnotationPolyline class]]) {
+        return [self getUIColorObjectFromHexString:shape.strokeColor alpha:1];
+    } else if ([shape isKindOfClass:[RCTMGLAnnotationPolygon class]]) {
+        return [self getUIColorObjectFromHexString:[(RCTMGLAnnotationPolygon *) shape strokeColor] alpha:1];
+    } else {
+        return [UIColor blueColor];
+    }
 }
 
 - (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(RCTMGLAnnotationPolyline *)shape

--- a/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/RCTMapboxGL/RCTMapboxGLManager.m
@@ -59,7 +59,7 @@ RCT_EXPORT_METHOD(setZoomLevelAnimated:(nonnull NSNumber *)reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView setZoomLevelAnimated:zoomLevel];
         }
     }];
@@ -69,7 +69,7 @@ RCT_EXPORT_METHOD(setDirectionAnimated:(nonnull NSNumber *)reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView setDirectionAnimated:heading];
         }
     }];
@@ -81,7 +81,7 @@ RCT_EXPORT_METHOD(setCenterCoordinateAnimated:(nonnull NSNumber *)reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView setCenterCoordinateAnimated:CLLocationCoordinate2DMake(latitude, longitude)];
         }
     }];
@@ -94,7 +94,7 @@ RCT_EXPORT_METHOD(setCenterCoordinateZoomLevelAnimated:(nonnull NSNumber *)react
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView setCenterCoordinateZoomLevelAnimated:CLLocationCoordinate2DMake(latitude, longitude) zoomLevel:zoomLevel];
         }
     }];
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(selectAnnotationAnimated:(nonnull NSNumber *) reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView selectAnnotationAnimated:annotationInArray];
         }
     }];
@@ -116,7 +116,7 @@ RCT_EXPORT_METHOD(removeAnnotation:(nonnull NSNumber *) reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        if([mapView isKindOfClass:[RCTMapboxGL class]]) {
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
             [mapView removeAnnotation:annotationInArray];
         }
     }];
@@ -129,61 +129,68 @@ RCT_EXPORT_METHOD(addAnnotations:(nonnull NSNumber *)reactTag
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if([mapView isKindOfClass:[RCTMapboxGL class]]) {
             
-            if ([annotations isKindOfClass:[NSArray class]]) {
-                NSMutableArray* pins = [NSMutableArray array];
-                id anObject;
-                NSEnumerator *enumerator = [annotations objectEnumerator];
-                
-                while (anObject = [enumerator nextObject]) {
-                    CLLocationCoordinate2D coordinate = [RCTConvert CLLocationCoordinate2D:anObject];
-                    if (CLLocationCoordinate2DIsValid(coordinate)){
+            NSMutableArray* annotationsArray = [NSMutableArray array];
+            id annotationObject;
+            NSEnumerator *enumerator = [annotations objectEnumerator];
+            
+            while (annotationObject = [enumerator nextObject]) {
+                CLLocationCoordinate2D coordinate = [RCTConvert CLLocationCoordinate2D:annotationObject];
+                if (CLLocationCoordinate2DIsValid(coordinate)){
+                    if (![annotationObject objectForKey:@"type"]) {
+                        RCTLogError(@"type point, polyline or polygon required");
+                        return;
+                    }
+                    
+                    NSString *type = [RCTConvert NSString:[annotationObject valueForKey:@"type"]];
+                    
+                    if ([type  isEqual: @"point"]) {
                         NSString *title = @"";
-                        if ([anObject objectForKey:@"title"]){
-                            title = [RCTConvert NSString:[anObject valueForKey:@"title"]];
+                        if ([annotationObject objectForKey:@"title"]) {
+                            title = [RCTConvert NSString:[annotationObject valueForKey:@"title"]];
                         }
-
+                        
                         NSString *subtitle = @"";
-                        if ([anObject objectForKey:@"subtitle"]){
-                            subtitle = [RCTConvert NSString:[anObject valueForKey:@"subtitle"]];
+                        if ([annotationObject objectForKey:@"subtitle"]) {
+                            subtitle = [RCTConvert NSString:[annotationObject valueForKey:@"subtitle"]];
                         }
-
+                        
                         NSString *id = @"";
-                        if ([anObject objectForKey:@"id"]) {
-                            id = [RCTConvert NSString:[anObject valueForKey:@"id"]];
+                        if ([annotationObject objectForKey:@"id"]) {
+                            id = [RCTConvert NSString:[annotationObject valueForKey:@"id"]];
                         }
-
-                        if ([anObject objectForKey:@"rightCalloutAccessory"]) {
-                            NSObject *rightCalloutAccessory = [anObject valueForKey:@"rightCalloutAccessory"];
+                        
+                        if ([annotationObject objectForKey:@"rightCalloutAccessory"]) {
+                            NSObject *rightCalloutAccessory = [annotationObject valueForKey:@"rightCalloutAccessory"];
                             NSString *url = [rightCalloutAccessory valueForKey:@"url"];
                             CGFloat height = (CGFloat)[[rightCalloutAccessory valueForKey:@"height"] floatValue];
                             CGFloat width = (CGFloat)[[rightCalloutAccessory valueForKey:@"width"] floatValue];
-
+                            
                             UIImage *image = nil;
-
+                            
                             if ([url hasPrefix:@"image!"]) {
                                 NSString* localImagePath = [url substringFromIndex:6];
                                 image = [UIImage imageNamed:localImagePath];
                             }
-
+                            
                             NSURL* checkURL = [NSURL URLWithString:url];
                             if (checkURL && checkURL.scheme && checkURL.host) {
                                 image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:url]]];
                             }
-
+                            
                             UIButton *imageButton = [UIButton buttonWithType:UIButtonTypeCustom];
                             imageButton.frame = CGRectMake(0, 0, height, width);
                             [imageButton setImage:image forState:UIControlStateNormal];
                             
-                            NSArray *coordinate = [RCTConvert NSArray:[anObject valueForKey:@"coordinates"]];
+                            NSArray *coordinate = [RCTConvert NSArray:[annotationObject valueForKey:@"coordinates"]];
                             CLLocationDegrees lat = [coordinate[0] doubleValue];
                             CLLocationDegrees lng = [coordinate[1] doubleValue];
-
-                            RCTMGLAnnotation *annotation = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(lat, lng) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
-
-                            [pins addObject:annotation];
-
-                            if ([anObject objectForKey:@"annotationImage"]) {
-                                NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                            
+                            RCTMGLAnnotation *pin = [[RCTMGLAnnotation alloc] initWithLocationRightCallout:CLLocationCoordinate2DMake(lat, lng) title:title subtitle:subtitle id:id rightCalloutAccessory:imageButton];
+                            [annotationsArray addObject:pin];
+                            
+                            
+                            if ([annotationObject objectForKey:@"annotationImage"]) {
+                                NSObject *annotationImage = [annotationObject valueForKey:@"annotationImage"];
                                 NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
                                 CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
@@ -192,38 +199,153 @@ RCT_EXPORT_METHOD(addAnnotations:(nonnull NSNumber *)reactTag
                                     return;
                                 }
                                 CGSize annotationImageSize =  CGSizeMake(height, width);
-                                annotation.annotationImageURL = annotationImageURL;
-                                annotation.annotationImageSize = annotationImageSize;
+                                pin.annotationImageURL = annotationImageURL;
+                                pin.annotationImageSize = annotationImageSize;
                             }
-
+                            
                         } else {
                             
-                            NSArray *coordinate = [RCTConvert NSArray:[anObject valueForKey:@"coordinates"]];
+                            NSArray *coordinate = [RCTConvert NSArray:[annotationObject valueForKey:@"coordinates"]];
                             CLLocationDegrees lat = [coordinate[0] doubleValue];
                             CLLocationDegrees lng = [coordinate[1] doubleValue];
-
-                            RCTMGLAnnotation *annotation = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(lat, lng) title:title subtitle:subtitle id:id];
-                            [pins addObject:annotation];
-
-                            if ([anObject objectForKey:@"annotationImage"]) {
-                                NSObject *annotationImage = [anObject valueForKey:@"annotationImage"];
+                            
+                            RCTMGLAnnotation *point = [[RCTMGLAnnotation alloc] initWithLocation:CLLocationCoordinate2DMake(lat, lng) title:title subtitle:subtitle id:id];
+                            
+                            if ([annotationObject objectForKey:@"annotationImage"]) {
+                                NSObject *annotationImage = [annotationObject valueForKey:@"annotationImage"];
                                 NSString *annotationImageURL = [annotationImage valueForKey:@"url"];
                                 CGFloat height = (CGFloat)[[annotationImage valueForKey:@"height"] floatValue];
                                 CGFloat width = (CGFloat)[[annotationImage valueForKey:@"width"] floatValue];
-                                CGSize annotationImageSize =  CGSizeMake(height, width);
                                 if (!height || !width) {
                                     RCTLogError(@"Height and width for image required");
                                     return;
                                 }
-                                annotation.annotationImageURL = annotationImageURL;
-                                annotation.annotationImageSize = annotationImageSize;
+                                CGSize annotationImageSize =  CGSizeMake(height, width);
+                                point.annotationImageURL = annotationImageURL;
+                                point.annotationImageSize = annotationImageSize;
+                            }
+                            
+                            [annotationsArray addObject:point];
+                        }
+                        
+                    } else if ([type  isEqual: @"polyline"]) {
+                        
+                        NSString *title = @"";
+                        if ([annotationObject objectForKey:@"title"]) {
+                            title = [RCTConvert NSString:[annotationObject valueForKey:@"title"]];
+                        }
+                        
+                        NSString *subtitle = @"";
+                        if ([annotationObject objectForKey:@"subtitle"]) {
+                            subtitle = [RCTConvert NSString:[annotationObject valueForKey:@"subtitle"]];
+                        }
+                        
+                        NSString *id = @"";
+                        if ([annotationObject objectForKey:@"id"]) {
+                            id = [RCTConvert NSString:[annotationObject valueForKey:@"id"]];
+                        }
+                        
+                        NSString *type = @"";
+                        if ([annotationObject objectForKey:@"type"]) {
+                            type = [RCTConvert NSString:[annotationObject valueForKey:@"type"]];
+                        }
+                        
+                        CGFloat strokeAlpha = 1.0;
+                        if ([annotationObject objectForKey:@"strokeAlpha"]) {
+                            strokeAlpha = [RCTConvert CGFloat:[annotationObject valueForKey:@"strokeAlpha"]];
+                        }
+                        
+                        NSString *strokeColor = nil;
+                        if ([annotationObject objectForKey:@"strokeColor"]) {
+                            strokeColor = [RCTConvert NSString:[annotationObject valueForKey:@"strokeColor"]];
+                        }
+                        
+                        double strokeWidth = 3;
+                        if ([annotationObject objectForKey:@"strokeWidth"]) {
+                            strokeWidth = [RCTConvert double:[annotationObject valueForKey:@"strokeWidth"]];
+                        }
+                        
+                        NSArray *coordinates = [RCTConvert NSArray:[annotationObject valueForKey:@"coordinates"]];
+                        NSUInteger numberOfPoints = coordinates.count;
+                        int count = 0;
+                        CLLocationCoordinate2D *coord = malloc(sizeof(CLLocationCoordinate2D) * numberOfPoints);
+                        
+                        if ([annotationObject objectForKey:@"coordinates"]) {
+                            for (int i = 0; i < [coordinates count]; i++) {
+                                CLLocationDegrees lat = [coordinates[i][0] doubleValue];
+                                CLLocationDegrees lng = [coordinates[i][1] doubleValue];
+                                coord[count] = CLLocationCoordinate2DMake(lat, lng);
+                                count++;
                             }
                         }
-
+                        
+                        [annotationsArray addObject:[RCTMGLAnnotationPolyline polylineAnnotation:coord strokeAlpha:strokeAlpha strokeColor:strokeColor strokeWidth:strokeWidth id:id type:@"polyline" count:count]];
+                        
+                    } else if ([type  isEqual: @"polygon"]) {
+                        
+                        NSString *title = @"";
+                        if ([annotationObject objectForKey:@"title"]) {
+                            title = [RCTConvert NSString:[annotationObject valueForKey:@"title"]];
+                        }
+                        
+                        NSString *subtitle = @"";
+                        if ([annotationObject objectForKey:@"subtitle"]) {
+                            subtitle = [RCTConvert NSString:[annotationObject valueForKey:@"subtitle"]];
+                        }
+                        
+                        NSString *id = @"";
+                        if ([annotationObject objectForKey:@"id"]) {
+                            id = [RCTConvert NSString:[annotationObject valueForKey:@"id"]];
+                        }
+                        
+                        NSString *type = @"";
+                        if ([annotationObject objectForKey:@"type"]) {
+                            type = [RCTConvert NSString:[annotationObject valueForKey:@"type"]];
+                        }
+                        
+                        CGFloat fillAlpha = 1.0;
+                        if ([annotationObject objectForKey:@"fillAlpha"]) {
+                            fillAlpha = [RCTConvert CGFloat:[annotationObject valueForKey:@"fillAlpha"]];
+                        }
+                        
+                        NSString *fillColor = @"";
+                        if ([annotationObject objectForKey:@"fillColor"]) {
+                            fillColor = [RCTConvert NSString:[annotationObject valueForKey:@"fillColor"]];
+                        }
+                        
+                        CGFloat strokeAlpha = 1.0;
+                        if ([annotationObject objectForKey:@"strokeAlpha"]) {
+                            strokeAlpha = [RCTConvert CGFloat:[annotationObject valueForKey:@"strokeAlpha"]];
+                        }
+                        
+                        NSString *strokeColor = @"";
+                        if ([annotationObject objectForKey:@"strokeColor"]) {
+                            strokeColor = [RCTConvert NSString:[annotationObject valueForKey:@"strokeColor"]];
+                        }
+                        
+                        NSArray *coordinates = [RCTConvert NSArray:[annotationObject valueForKey:@"coordinates"]];
+                        NSUInteger numberOfPoints = coordinates.count;
+                        int count = 0;
+                        CLLocationCoordinate2D *coord = malloc(sizeof(CLLocationCoordinate2D) * numberOfPoints);
+                        
+                        if ([annotationObject objectForKey:@"coordinates"]) {
+                            for (int i = 0; i < [coordinates count]; i++) {
+                                CLLocationDegrees lat = [coordinates[i][0] doubleValue];
+                                CLLocationDegrees lng = [coordinates[i][1] doubleValue];
+                                coord[count] = CLLocationCoordinate2DMake(lat, lng);
+                                count++;
+                            }
+                        }
+                        
+                        [annotationsArray addObject:[RCTMGLAnnotationPolygon polygonAnnotation:coord fillAlpha:fillAlpha fillColor:fillColor strokeColor:strokeColor strokeAlpha:strokeAlpha id:id type:@"polygon" count:count]];
+                        
+                    } else {
+                        RCTLogError(@"type point, polyline or polygon required");
+                        return;
                     }
                 }
-                mapView.annotations = pins;
             }
+            mapView.annotations = annotationsArray;
         }
     }];
 }

--- a/example.js
+++ b/example.js
@@ -8,46 +8,60 @@ var {
   StyleSheet,
   Text,
   StatusBarIOS,
-  View,
+  View
 } = React;
 
 var Example = React.createClass({
   mixins: [MapboxGLMap.Mixin],
   getInitialState() {
     return {
-       center: {
-         latitude: 40.72052634,
-         longitude: -73.97686958312988
-       },
-       zoom: 11,
-       annotations: [{
-         latitude: 40.72052634,
-         longitude:  -73.97686958312988,
-         title: 'This is marker 1',
-         subtitle: 'It has a rightCalloutAccessory too',
-         rightCalloutAccessory: {
-             url: 'https://cldup.com/9Lp0EaBw5s.png',
-             height: 25,
-             width: 25
-         },
-         annotationImage: {
-           url: 'https://cldup.com/CnRLZem9k9.png',
-           height: 25,
-           width: 25
-         },
-         id: 'marker1'
-       },{
-         latitude: 40.714541341726175,
-         longitude:  -74.00579452514648,
-         title: 'Important!',
-         subtitle: 'Neat, this is a custom annotation image',
-         annotationImage: {
-           url: 'https://cldup.com/7NLZklp8zS.png',
-           height: 25,
-           width: 25
-         },
-         id: 'marker2'
-       }]
+      center: {
+        latitude: 40.72052634,
+        longitude: -73.97686958312988
+      },
+      zoom: 11,
+      annotations: [{
+        coordinates: [40.72052634, -73.97686958312988],
+        "type": "point",
+        title: 'This is marker 1',
+        subtitle: 'It has a rightCalloutAccessory too',
+        rightCalloutAccessory: {
+          url: 'https://cldup.com/9Lp0EaBw5s.png',
+          height: 25,
+          width: 25
+        },
+        annotationImage: {
+          url: 'https://cldup.com/CnRLZem9k9.png',
+          height: 25,
+          width: 25
+        },
+        id: 'marker1'
+      }, {
+        coordinates: [40.714541341726175,-74.00579452514648],
+        "type": "point",
+        title: 'Important!',
+        subtitle: 'Neat, this is a custom annotation image',
+        annotationImage: {
+          url: 'https://cldup.com/7NLZklp8zS.png',
+          height: 25,
+          width: 25
+        },
+        id: 'marker2'
+      }, {
+        "coordinates": [[40.76572150042782,-73.99429321289062],[40.743485405490695, -74.00218963623047],[40.728266950429735,-74.00218963623047],[40.728266950429735,-73.99154663085938],[40.73633186448861,-73.98983001708984],[40.74465591168391,-73.98914337158203],[40.749337730454826,-73.9870834350586]],
+        "type": "polyline",
+        "strokeColor": "#00FB00",
+        "strokeWidth": 4,
+        "strokeAlpha": .5,
+        "id": "foobar"
+      }, {
+        "coordinates": [[40.749857912194386, -73.96820068359375], [40.741924698522055,-73.9735221862793], [40.735681504432264,-73.97523880004883], [40.7315190495212,-73.97438049316406], [40.729177554196376,-73.97180557250975], [40.72345355209305,-73.97438049316406], [40.719290332250544,-73.97455215454102], [40.71369559554873,-73.97729873657227], [40.71200407096382,-73.97850036621094], [40.71031250340588,-73.98691177368163], [40.71031250340588,-73.99154663085938]],
+        "type": "polygon",
+        "fillAlpha":1,
+        "strokeColor": "#fffff",
+        "fillColor": "blue",
+        "id": "zap"
+      }]
      };
   },
   onRegionChange(location) {
@@ -82,10 +96,18 @@ var Example = React.createClass({
           Go to Tokyo at fixed zoom level 14
         </Text>
         <Text style={styles.text} onPress={() => this.addAnnotations(mapRef, [{
-          latitude: 40.73312,
-          longitude:  -73.989,
-          title: 'This is a new marker'
-          }])}>
+          coordinates: [40.73312,-73.989],
+          type: 'point',
+          title: 'This is a new marker',
+          id: 'foo'
+        }, {
+          "coordinates": [[40.749857912194386, -73.96820068359375], [40.741924698522055,-73.9735221862793], [40.735681504432264,-73.97523880004883], [40.7315190495212,-73.97438049316406], [40.729177554196376,-73.97180557250975], [40.72345355209305,-73.97438049316406], [40.719290332250544,-73.97455215454102], [40.71369559554873,-73.97729873657227], [40.71200407096382,-73.97850036621094], [40.71031250340588,-73.98691177368163], [40.71031250340588,-73.99154663085938]],
+          "type": "polygon",
+          "fillAlpha": 1,
+          "fillColor": "#000",
+          "strokeAlpha": 1,
+          "id": "new-black-polygon"
+        }])}>
           Add new marker
         </Text>
         <Text style={styles.text} onPress={() => this.selectAnnotationAnimated(mapRef, 0)}>
@@ -120,14 +142,13 @@ var Example = React.createClass({
 
 var styles = StyleSheet.create({
   container: {
-    flexDirection: 'column',
     flex: 1
   },
   map: {
-    flex: 5
+    flex: 1
   },
   text: {
-    padding: 2
+    padding: 3
   }
 });
 


### PR DESCRIPTION
Took another stab at https://github.com/mapbox/react-native-mapbox-gl/pull/66, this time I was way more successful! Some notes:
- This will be a `1.0.0` release due to the breaking changes around annotations
- `type` is now required on each object in the annotations array. Enum values `point`, `polyline` and `polygon` are valid
- The annotations object will now look like:

``` json
[{
  "coordinates": "required. For type polyline and polygon must be an array of arrays. For type point, single array",
  "type": "required: point, polyline or polygon",
  "title": "optional string. Only used for type=point",
  "subtitle": "optional string. Only used for type=point",
  "fillAlpha": "optional, only used for type=polygon. Controls the opacity of polygon",
  "fillColor": "optional string hex color including #, only used for type=polygon",
  "strokeAlpha": "optional number from 0-1. Only used for type=poyline. Controls opacity of line",
  "strokeColor": "optional string hex color including #, used for type=polygon and type=polyline",
  "strokeWidth": "optional number. Only used for type=poyline. Controls line width",
  "id": "optional string, unique identifier",
  "rightCalloutAccessory": {
    "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
    "height": "required if url specified",
    "width": "required if url specified"
  },
  "annotationImage": {
    "url": "Optional. Either remote image or specify via 'image!yourImage.png'",
    "height": "required if url specified",
    "width": "required if url specified"
  }
}]
```

@1ec5 a review would be :100: 
