### PR TITLE
Updates steps explaining header_search_paths

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -20,5 +20,5 @@ Notes:
   * `libsqlite3.tbd`
   * `libz.tbd`
   * ![](https://cldup.com/KuSEgMQQSy.gif)
-1. Click on the `RCTMapboxGL` project. Under the `Build Settings` tab, search for `header_search_path`. Make sure `$(SRCROOT)/../../React` and `$(SRCROOT)/../react-native/React` are added and set to `recursive`. ![](https://cldup.com/81zUEHaKoX.png)
+1. Click on the `RCTMapboxGL` project. Under the `Build Settings` tab, search for `header_search_path`. Make sure `$(SRCROOT)/../../../React` and `$(SRCROOT)/../../react-native/React` are added and set to `recursive`. ![](https://cldup.com/81zUEHaKoX.png)
 1. You can now `require('react-native-mapbox-gl')` and build.


### PR DESCRIPTION
The React Native module is actually 1 more level up in the folder structure now since the `RCTMapboxGL.xcodeproj` is in the nested `ios` folder.
