### PR TITLE
Add CocoaPods spec file to simplify project setup.

### DIFF
--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name                = "RCTMapboxGL"
+  s.version             = "1.0.0"
+  s.summary             = "A Mapbox GL react native module for creating custom maps."
+  s.homepage            = "https://github.com/mapbox/react-native-mapbox-gl#readme"
+  s.license             = "BSD"
+  s.author              = "Bobby Sudekum"
+  s.source              = { :git => "https://github.com/mapbox/react-native-mapbox-gl.git", :tag => "#{s.version}" }
+  s.platform            = :ios, "7.0"
+
+  s.source_files        = "RCTMapboxGL/RCTMapboxGL.{h,m}", "RCTMapboxGL/RCTMapboxGLManager.{h,m}"
+  s.dependency            "Mapbox-iOS-SDK", "2.1.2"
+
+  # These resources, library, frameworks and libraries spec is already part of
+  # the Mapbox-iOS-SDK dependency above. The npm `preinstall` hock download
+  # them automatically. Instead of the dependency we could also use the
+  # following attributes to use the local files...
+  # I keep this it it makes development easier of fix somes "troubles" later.
+
+#  s.resources           = "RCTMapboxGL/Mapbox.bundle", "RCTMapboxGL/Settings.bundle"
+#  s.vendored_libraries  = "RCTMapboxGL/libMapbox.a"
+#  s.framework           = "CoreTelephony", "GLKit", "ImageIO", "MobileCoreServices", "QuartzCore", "SystemConfiguration"
+#  s.libraries           = "c++", "sqlite3", "z"
+
+end

--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   # following attributes to use the local files...
   # I keep this it it makes development easier of fix somes "troubles" later.
 
+#  s.source_files        = "RCTMapboxGL/*.{h,m}"
 #  s.resources           = "RCTMapboxGL/Mapbox.bundle", "RCTMapboxGL/Settings.bundle"
 #  s.vendored_libraries  = "RCTMapboxGL/libMapbox.a"
 #  s.framework           = "CoreTelephony", "GLKit", "ImageIO", "MobileCoreServices", "QuartzCore", "SystemConfiguration"

--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "RCTMapboxGL"
-  s.version             = "1.0.0"
+  s.version             = "1.1.0"
   s.summary             = "A Mapbox GL react native module for creating custom maps."
   s.homepage            = "https://github.com/mapbox/react-native-mapbox-gl#readme"
   s.license             = "BSD"

--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "7.0"
 
   s.source_files        = "RCTMapboxGL/RCTMapboxGL.{h,m}", "RCTMapboxGL/RCTMapboxGLManager.{h,m}"
+  s.resources           = "RCTMapboxGL/Settings.bundle"
   s.dependency            "Mapbox-iOS-SDK", "2.1.2"
 
   # These resources, library, frameworks and libraries spec is already part of

--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -5,6 +5,10 @@ Pod::Spec.new do |s|
   s.homepage            = "https://github.com/mapbox/react-native-mapbox-gl#readme"
   s.license             = "BSD"
   s.author              = "Bobby Sudekum"
+  s.screenshot          = "https://cldup.com/A8S_7rLg1L.png"
+  s.social_media_url    = "https://twitter.com/mapbox"
+  s.documentation_url   = "https://github.com/mapbox/react-native-mapbox-gl/blob/master/ios/API.md"
+
   s.source              = { :git => "https://github.com/mapbox/react-native-mapbox-gl.git", :tag => "#{s.version}" }
   s.platform            = :ios, "7.0"
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -1,7 +1,20 @@
 # Installation Process
 
 Notes:
+
 * `react-native ^v0.4.3` is required
+
+## Use CocoaPods
+
+If you already use [CocoaPods](https://cocoapods.org/) in your react-native project you add the native
+part of Mapbox GL with just one line of code:
+
+1. `npm install react-native-mapbox-gl --save`
+1. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'` to your `Podspec` file and re-run `pod install`.
+
+See also the react-native [0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
+
+## Manually
 
 1. `npm install react-native-mapbox-gl --save`
 1. In the XCode's `Project navigator`, right click on project's name ➜ `Add Files to <...>` ![](https://cldup.com/k0oJwOUKPN.png)


### PR DESCRIPTION
For example this fix the setup requirement that the Xcode header search path must be changed anymore / and anytime the node_modules folder was resetted.

See changed ios/installation for more details.
