### PR TITLE
When returing/redrawing a map, redraw annotations

### DIFF
--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -97,7 +97,9 @@ RCT_EXPORT_MODULE();
 
 - (void)layoutSubviews
 {
-    [self updateMap];
+    if (_annotations.count == 0) {
+        [self updateMap];
+    }
     _map.frame = self.bounds;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mapbox/react-native-mapbox-gl/issues/82

For some reason, when leaving and returning to a map view, the annotations on the map would disappear.
