### PR TITLE
refactor: upgrade to react-native 0.14.+ native component configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ android/gradlew
 android/gradlew.bat
 android/local.properties
 reactnativemapboxgl.iml
+.idea

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile 'com.facebook.react:react-native:0.14.+'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:2.2.0@aar') {
         transitive = true
     }

--- a/index.android.js
+++ b/index.android.js
@@ -10,7 +10,7 @@ var ReactMapView = requireNativeComponent('RCTMapbox', {
       annotations: React.PropTypes.arrayOf(React.PropTypes.shape({
         title: React.PropTypes.string,
         subtitle: React.PropTypes.string,
-        coordinates: React.PropTypes.arrayOf(),
+        coordinates: React.PropTypes.array,
         alpha: React.PropTypes.number,
         fillColor: React.PropTypes.string,
         strokeColor: React.PropTypes.string,


### PR DESCRIPTION
Changes: 
- update build.gradle rn version
- refactor native component property setters

In react-native 0.14, updateView is now deprecated.
the use of property setters is now being used to declutter the logic
