### PR TITLE
Remove UserTrackingLocationMode

### DIFF
--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -88,7 +88,6 @@ RCT_EXPORT_MODULE();
     _map = [[MGLMapView alloc] initWithFrame:self.bounds styleURL:_styleURL];
     _map.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _map.delegate = self;
-    _map.userTrackingMode = MGLUserTrackingModeFollow;
     [self updateMap];
     [self addSubview:_map];
     [self layoutSubviews];


### PR DESCRIPTION
It's not necessary to specify tracking mode. This causes the app to ask for location permissions even when it's not necessary. 
