### PR TITLE
v2.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# v2.0.0
+
+* [iOS] Adds optional pod installation
+* [iOS] If showsUserLocation is false the Mapbox layer will no longer require location permissions
+* [iOS] Fixed a bug where icons would overwrite other icons
+* [iOS] Minimum deployment level set to 7.0
+* [iOS] Fixed a bug where when returning to map/rotating the UI, markers would disappear
+* [iOS] An empty popup will no longer be shown when there is no title and text
+* [iOS] Adds userTrackingMode
+* [Android] Upgrades to react-native v0.14.x
+
+### Breaking changes
+iOS no longer supports the `assets://` path for styles. Styles can be set via normal `mapbox://` url or via:
+
+```js
+this.mapStyles.light
+this.mapStyles.streets
+this.mapStyles.dark
+this.mapStyles.satellite
+this.mapStyles.hybrid
+this.mapStyles.emerald
+```
+
+`this.mapStyles` is passed in via mixins. If you prefer not pass in mixins, you can just as easily reference the emerald style via `styleURL={'mapbox://styles/mapbox/emerald-v8'}`
+
 # v1.1.0
 
 * Fixed a regression in the `Header Search Paths`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-mapbox-gl",
   "description": "A Mapbox GL react native module for creating custom maps",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Bobby Sudekum",
   "keywords": [
     "gl",


### PR DESCRIPTION
# v2.0.0
- [iOS] Adds optional pod installation
- [iOS] If showsUserLocation is false the Mapbox layer will no longer require location permissions
- [iOS] Fixed a bug where icons would overwrite other icons
- [iOS] Minimum deployment level set to 7.0
- [iOS] Fixed a bug where when returning to map/rotating the UI, markers would disappear
- [iOS] An empty popup will no longer be shown when there is no title and text
- [iOS] Adds userTrackingMode
- [Android] Upgrades to react-native v0.14.x
### Breaking changes

iOS no longer supports the `assets://` path for styles. Styles can be set via normal `mapbox://` url or via:

``` js
this.mapStyles.light
this.mapStyles.streets
this.mapStyles.dark
this.mapStyles.satellite
this.mapStyles.hybrid
this.mapStyles.emerald
```

`this.mapStyles` is passed in via mixins. If you prefer not pass in mixins, you can just as easily reference the emerald style via `styleURL={'mapbox://styles/mapbox/emerald-v8'}`
