### PR TITLE
Fix iOS install doc

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -10,7 +10,7 @@ If you already use [CocoaPods](https://cocoapods.org/) in your react-native proj
 part of Mapbox GL with just one line of code:
 
 1. `npm install react-native-mapbox-gl --save`
-1. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'` to your `Podspec` file and re-run `pod install`.
+1. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'` to your `Podfile` file and re-run `pod install`.
 
 See also the react-native [0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
 


### PR DESCRIPTION
The guide mentions a `Podspec` file, but it should be `Podfile` instead.
