### PR TITLE
Add onTap and onLongPress

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -54,6 +54,12 @@ var MapView = React.createClass({
   _onUpdateUserLocation(event: Event) {
     if (this.props.onUpdateUserLocation) this.props.onUpdateUserLocation(event.nativeEvent.src);
   },
+  _onTap(event: Event) {
+    if (this.props.onTap) this.props.onTap(event.nativeEvent.src);
+  },
+  _onLongPress(event: Event) {
+    if (this.props.onLongPress) this.props.onLongPress(event.nativeEvent.src);
+  },
   propTypes: {
     showsUserLocation: React.PropTypes.bool,
     rotateEnabled: React.PropTypes.bool,
@@ -122,7 +128,9 @@ var MapView = React.createClass({
       onRegionWillChange={this._onRegionWillChange}
       onOpenAnnotation={this._onOpenAnnotation}
       onRightAnnotationTapped={this._onRightAnnotationTapped}
-      onUpdateUserLocation={this._onUpdateUserLocation} />;
+      onUpdateUserLocation={this._onUpdateUserLocation}
+      onTap={this._onTap}
+      onLongPress={this._onLongPress} />;
   }
 });
 

--- a/ios/API.md
+++ b/ios/API.md
@@ -27,6 +27,8 @@
 | `onOpenAnnotation` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when focusing a an annotation.
 | `onUpdateUserLocation` | `{latitude: 0, longitude: 0, headingAccuracy: 0, magneticHeading: 0, trueHeading: 0, isUpdating: false}` | Fired when the users location updates.
 | `onRightAnnotationTapped` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps `rightCalloutAccessory`
+| `onTap` | `{latitude: 0, longitude: 0}` | Fired when the users taps the screen.
+| `onLongPress` | `{latitude: 0, longitude: 0}` | Fired when the user taps and holds screen for 1 second.
 
 
 ## Methods for Modifying the Map State

--- a/ios/API.md
+++ b/ios/API.md
@@ -27,8 +27,8 @@
 | `onOpenAnnotation` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when focusing a an annotation.
 | `onUpdateUserLocation` | `{latitude: 0, longitude: 0, headingAccuracy: 0, magneticHeading: 0, trueHeading: 0, isUpdating: false}` | Fired when the users location updates.
 | `onRightAnnotationTapped` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps `rightCalloutAccessory`
-| `onTap` | `{latitude: 0, longitude: 0}` | Fired when the users taps the screen.
-| `onLongPress` | `{latitude: 0, longitude: 0}` | Fired when the user taps and holds screen for 1 second.
+| `onTap` | `{latitude: 0, longitude: 0, screenCoordY, screenCoordX}` | Fired when the users taps the screen.
+| `onLongPress` | `{latitude: 0, longitude: 0, screenCoordY, screenCoordX}` | Fired when the user taps and holds screen for 1 second.
 
 
 ## Methods for Modifying the Map State

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -231,11 +231,6 @@ RCT_EXPORT_MODULE();
     _styleURL = styleURL;
     [self updateMap];
 }
-- (void)setAttributionButtonVisibility:(BOOL)isVisible
-{
-    _attributionButtonVisibility = isVisible;
-    [self updateMap];
-}
 
 - (void)setUserTrackingMode:(int)userTrackingMode
 {
@@ -418,18 +413,21 @@ RCT_EXPORT_MODULE();
         UIGraphicsEndImageContext();
         annotationImage = [MGLAnnotationImage annotationImageWithImage:newImage reuseIdentifier:url];
     }
-
+    
     return annotationImage;
 }
 
-- (void)handleSingleTap:(UITapGestureRecognizer *)tap
+- (void)handleSingleTap:(UITapGestureRecognizer *)sender
 {
-    CLLocationCoordinate2D location = [_map convertPoint:[tap locationInView:_map] toCoordinateFromView:_map];
+    CLLocationCoordinate2D location = [_map convertPoint:[sender locationInView:_map] toCoordinateFromView:_map];
+    CGPoint screenCoord = [sender locationInView:_map];
     
     NSDictionary *event = @{ @"target": self.reactTag,
                              @"src": @{
                                      @"latitude": @(location.latitude),
                                      @"longitude": @(location.longitude),
+                                     @"screenCoordY": @(screenCoord.y),
+                                     @"screenCoordX": @(screenCoord.x)
                                      }
                              };
     
@@ -440,11 +438,14 @@ RCT_EXPORT_MODULE();
 {
     if (sender.state == UIGestureRecognizerStateBegan) {
         CLLocationCoordinate2D location = [_map convertPoint:[sender locationInView:_map] toCoordinateFromView:_map];
+        CGPoint screenCoord = [sender locationInView:_map];
         
         NSDictionary *event = @{ @"target": self.reactTag,
                                  @"src": @{
                                          @"latitude": @(location.latitude),
                                          @"longitude": @(location.longitude),
+                                         @"screenCoordY": @(screenCoord.y),
+                                         @"screenCoordX": @(screenCoord.x)
                                          }
                                  };
         

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -38,7 +38,9 @@ RCT_EXPORT_MODULE();
       @"onRegionWillChange",
       @"onOpenAnnotation",
       @"onRightAnnotationTapped",
-      @"onUpdateUserLocation"
+      @"onUpdateUserLocation",
+      @"onTap",
+      @"onLongPress"
     ];
 }
 

--- a/ios/example.js
+++ b/ios/example.js
@@ -79,6 +79,12 @@ var MapExample = React.createClass({
   onRightAnnotationTapped(e) {
     console.log(e);
   },
+  onTap(location) {
+    console.log('tapped', location);
+  },
+  onLongPress(location) {
+    console.log('long pressed', location);
+  },
   render: function() {
     StatusBarIOS.setHidden(true);
     return (
@@ -140,7 +146,9 @@ var MapExample = React.createClass({
           annotations={this.state.annotations}
           onOpenAnnotation={this.onOpenAnnotation}
           onRightAnnotationTapped={this.onRightAnnotationTapped}
-          onUpdateUserLocation={this.onUpdateUserLocation} />
+          onUpdateUserLocation={this.onUpdateUserLocation}
+          onTap={this.onTap}
+          onLongPress={this.onLongPress} />
       </View>
     );
   }


### PR DESCRIPTION
Adds an `onTap` and `onLongPress` (1 second) event listener.

closes: https://github.com/mapbox/react-native-mapbox-gl/issues/108

/cc @1ec5 for :eyes: 
