### PR TITLE
Remove ontap

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -54,9 +54,6 @@ var MapView = React.createClass({
   _onUpdateUserLocation(event: Event) {
     if (this.props.onUpdateUserLocation) this.props.onUpdateUserLocation(event.nativeEvent.src);
   },
-  _onTap(event: Event) {
-    if (this.props.onTap) this.props.onTap(event.nativeEvent.src);
-  },
   _onLongPress(event: Event) {
     if (this.props.onLongPress) this.props.onLongPress(event.nativeEvent.src);
   },
@@ -129,7 +126,6 @@ var MapView = React.createClass({
       onOpenAnnotation={this._onOpenAnnotation}
       onRightAnnotationTapped={this._onRightAnnotationTapped}
       onUpdateUserLocation={this._onUpdateUserLocation}
-      onTap={this._onTap}
       onLongPress={this._onLongPress} />;
   }
 });

--- a/ios/API.md
+++ b/ios/API.md
@@ -27,7 +27,6 @@
 | `onOpenAnnotation` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when focusing a an annotation.
 | `onUpdateUserLocation` | `{latitude: 0, longitude: 0, headingAccuracy: 0, magneticHeading: 0, trueHeading: 0, isUpdating: false}` | Fired when the users location updates.
 | `onRightAnnotationTapped` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps `rightCalloutAccessory`
-| `onTap` | `{latitude: 0, longitude: 0, screenCoordY, screenCoordX}` | Fired when the users taps the screen.
 | `onLongPress` | `{latitude: 0, longitude: 0, screenCoordY, screenCoordX}` | Fired when the user taps and holds screen for 1 second.
 
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -91,14 +91,6 @@ RCT_EXPORT_MODULE();
     _map.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _map.delegate = self;
     
-    UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:nil];
-    doubleTap.numberOfTapsRequired = 2;
-    [_map addGestureRecognizer:doubleTap];
-    
-    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)];
-    [singleTap requireGestureRecognizerToFail:doubleTap];
-    [_map addGestureRecognizer:singleTap];
-    
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
     [longPress setMinimumPressDuration:1];
     [self addGestureRecognizer:longPress];

--- a/ios/example.js
+++ b/ios/example.js
@@ -79,9 +79,6 @@ var MapExample = React.createClass({
   onRightAnnotationTapped(e) {
     console.log(e);
   },
-  onTap(location) {
-    console.log('tapped', location);
-  },
   onLongPress(location) {
     console.log('long pressed', location);
   },
@@ -147,7 +144,6 @@ var MapExample = React.createClass({
           onOpenAnnotation={this.onOpenAnnotation}
           onRightAnnotationTapped={this.onRightAnnotationTapped}
           onUpdateUserLocation={this.onUpdateUserLocation}
-          onTap={this.onTap}
           onLongPress={this.onLongPress} />
       </View>
     );


### PR DESCRIPTION
The onTap function seems to be clobbering all tap functions on the screen. This means you can no longer tap annotations to trigger the info window opening. @1ec5 I'm inclined to remove the api all together, is there any way around this?
