### PR TITLE
Add attribution, logo and compass toggle props

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -96,6 +96,9 @@ var MapView = React.createClass({
         url: React.PropTypes.string
       })
     })),
+    attributionButtonIsHidden: React.PropTypes.bool,
+    logoIsHidden: React.PropTypes.bool,
+    compassIsHidden: React.PropTypes.bool,
     onRegionChange: React.PropTypes.func,
     onRegionWillChange: React.PropTypes.func,
     onOpenAnnotation: React.PropTypes.func,
@@ -115,7 +118,10 @@ var MapView = React.createClass({
       showsUserLocation: false,
       styleUrl: this.Mixin.mapStyles.streets,
       zoomEnabled: true,
-      zoomLevel: 0
+      zoomLevel: 0,
+      attributionButtonIsHidden: false,
+      logoIsHidden: false,
+      compassIsHidden: false
     };
   },
   render() {

--- a/ios/API.md
+++ b/ios/API.md
@@ -17,6 +17,9 @@
 | `debugActive`  | `bool` | Optional | `false` | Turns on debug mode. |
 | `style`  | flexbox `view` | Optional | NA | Styles the actual map view container |
 | `userTrackingMode` | `int` | Optional | `this.userTrackingMode.none` | Must add `mixins` to use. Valid values are `this.userTrackingMode.none`, `this.userTrackingMode.follow`, `this.userTrackingMode.followWithCourse`, `this.userTrackingMode.followWithHeading` |
+| `attributionButtonIsHidden`  | `bool` | Optional | `false` | Whether attribution button is visible in lower right corner. *If true you must still attribute OpenStreetMap in your app. [Ref](https://www.mapbox.com/about/maps/)* |
+| `logoIsHidden`  | `bool` | Optional | `false` | Whether logo is visible in lower left corner. |
+| `compassIsHidden`  | `bool` | Optional | `false` | Whether compass is visible when map is rotated. |
 
 ## Events
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -36,6 +36,9 @@
 - (void)selectAnnotationAnimated:(NSUInteger)annotationInArray;
 - (void)removeAnnotation:(NSUInteger)annotationInArray;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
+- (void)setAttributionButtonVisibility:(BOOL)isVisible;
+- (void)setLogoVisibility:(BOOL)isVisible;
+- (void)setCompassVisibility:(BOOL)isVisible;
 
 @end
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -36,6 +36,9 @@
     double _zoomLevel;
     UIButton *_rightCalloutAccessory;
     int _userTrackingMode;
+    BOOL _attributionButton;
+    BOOL _logo;
+    BOOL _compass;
 }
 
 RCT_EXPORT_MODULE();
@@ -76,6 +79,9 @@ RCT_EXPORT_MODULE();
         _map.styleURL = _styleURL;
         _map.zoomLevel = _zoomLevel;
         _map.userTrackingMode = _userTrackingMode;
+        [_map.attributionButton setHidden:_attributionButton];
+        [_map.logoView setHidden:_logo];
+        [_map.compassView setHidden:_compass];
     } else {
         /* We need to have a height/width specified in order to render */
         if (_accessToken && _styleURL && self.bounds.size.height > 0 && self.bounds.size.width > 0) {
@@ -221,6 +227,24 @@ RCT_EXPORT_MODULE();
 - (void)setStyleURL:(NSURL *)styleURL
 {
     _styleURL = styleURL;
+    [self updateMap];
+}
+
+- (void)setAttributionButtonVisibility:(BOOL)isVisible
+{
+    _attributionButton = isVisible;
+    [self updateMap];
+}
+
+- (void)setLogoVisibility:(BOOL)isVisible
+{
+    _logo = isVisible;
+    [self updateMap];
+}
+
+- (void)setCompassVisibility:(BOOL)isVisible
+{
+    _compass = isVisible;
     [self updateMap];
 }
 

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -78,6 +78,25 @@ RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(styleURL, NSURL);
 RCT_EXPORT_VIEW_PROPERTY(userTrackingMode, int);
 RCT_EXPORT_VIEW_PROPERTY(zoomLevel, double);
+
+RCT_CUSTOM_VIEW_PROPERTY(attributionButtonIsHidden, BOOL, RCTMapboxGL)
+{
+    BOOL value = [json boolValue];
+    [view setAttributionButtonVisibility:value ? true : false];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(logoIsHidden, BOOL, RCTMapboxGL)
+{
+    BOOL value = [json boolValue];
+    [view setLogoVisibility:value ? true : false];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(compassIsHidden, BOOL, RCTMapboxGL)
+{
+    BOOL value = [json boolValue];
+    [view setCompassVisibility:value ? true : false];
+}
+
 RCT_EXPORT_METHOD(setZoomLevelAnimated:(nonnull NSNumber *)reactTag
                   zoomLevel:(double)zoomLevel)
 {


### PR DESCRIPTION
Allows users to toggle on and off the attribution button, logo and compass.

/cc @1ec5 
