### PR TITLE
Use ids for selecting annotations

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -19,11 +19,14 @@ var MapMixins = {
   addAnnotations(mapRef, annotations) {
     NativeModules.MapboxGLManager.addAnnotations(React.findNodeHandle(this.refs[mapRef]), annotations);
   },
-  selectAnnotationAnimated(mapRef, annotationInArray) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
+  selectAnnotationAnimated(mapRef, selectedId) {
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), selectedId);
   },
-  removeAnnotation(mapRef, annotationInArray) {
-    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), annotationInArray);
+  removeAnnotation(mapRef, selectedId) {
+    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), selectedId);
+  },
+  removeAllAnnotations(mapRef) {
+    NativeModules.MapboxGLManager.removeAllAnnotations(React.findNodeHandle(this.refs[mapRef]));
   },
   setVisibleCoordinateBoundsAnimated(mapRef, latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft) {
     NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(React.findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);

--- a/index.ios.js
+++ b/index.ios.js
@@ -19,11 +19,11 @@ var MapMixins = {
   addAnnotations(mapRef, annotations) {
     NativeModules.MapboxGLManager.addAnnotations(React.findNodeHandle(this.refs[mapRef]), annotations);
   },
-  selectAnnotationAnimated(mapRef, selectedId) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), selectedId);
+  selectAnnotationAnimated(mapRef, selectedIdentifier) {
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
-  removeAnnotation(mapRef, selectedId) {
-    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), selectedId);
+  removeAnnotation(mapRef, selectedIdentifier) {
+    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAllAnnotations(mapRef) {
     NativeModules.MapboxGLManager.removeAllAnnotations(React.findNodeHandle(this.refs[mapRef]));

--- a/ios/API.md
+++ b/ios/API.md
@@ -48,8 +48,9 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `setCenterCoordinateAnimated` | `mapViewRef`, `latitude`, `longitude` | Moves the map to a new coordinate. Note, the zoom level stay at the current zoom level
 | `setCenterCoordinateZoomLevelAnimated` | `mapViewRef`, `latitude`, `longitude`, `zoomLevel` | Moves the map to a new coordinate and zoom level
 | `addAnnotations` | `mapViewRef`, `` (array of annotation objects, see [#annotations](https://github.com/bsudekum/react-native-mapbox-gl/blob/master/API.md#annotations)) | Adds annotation(s) to the map without redrawing the map. Note, this will remove all previous annotations from the map.
-| `selectAnnotationAnimated` | `mapViewRef`, `annotationPlaceInArray` | Open the callout of the selected annotation. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
-| `removeAnnotation`  | `mapViewRef`, `annotationPlaceInArray` | Removes the selected annotation from the map. This method works with the current annotations on the map. `annotationPlaceInArray` starts at 0 and refers to the first annotation.
+| `selectAnnotationAnimated` | `mapViewRef`, `marker id` | Open the callout of the selected annotation. This method requires that you supply an id to an annotation when creating. If 2 annotations have the same id, only the first annotation will be selected. Only works on annotation `type = 'point'``.
+| `removeAnnotation`  | `mapViewRef`, `marker id` | Removes annotation from map. This method requires that you supply an id to an annotation when creating. If 2 annotations have the same id, only the first will be removed.
+| `removeAllAnnotations`  | `mapViewRef`| Removes all annotations from the map.
 | `setVisibleCoordinateBoundsAnimated`  | `mapViewRef`, `latitude1`, `longitude1`, `latitude2`, `longitude2`, `padding top`, `padding right`, `padding bottom`, `padding left`  | Changes the viewport to fit the given coordinate bounds and some additional padding on each side.
 | `setUserTrackingMode` | `mapViewRef`, `userTrackingMode` | Modifies the tracking mode. Valid args: `this.userTrackingMode.none`, `this.userTrackingMode.follow`, `this.userTrackingMode.followWithCourse`, `this.userTrackingMode.followWithHeading`
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -34,7 +34,7 @@
 - (void)setCenterCoordinateAnimated:(CLLocationCoordinate2D)coordinates;
 - (void)setCenterCoordinateZoomLevelAnimated:(CLLocationCoordinate2D)coordinates zoomLevel:(double)zoomLevel;
 - (void)selectAnnotationAnimated:(NSString*)selectedId;
-- (void)removeAnnotation:(NSString*)selectedId;
+- (void)removeAnnotation:(NSString*)selectedIdentifier;
 - (void)removeAllAnnotations;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)setAttributionButtonVisibility:(BOOL)isVisible;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -33,8 +33,9 @@
 - (void)setDirectionAnimated:(int)heading;
 - (void)setCenterCoordinateAnimated:(CLLocationCoordinate2D)coordinates;
 - (void)setCenterCoordinateZoomLevelAnimated:(CLLocationCoordinate2D)coordinates zoomLevel:(double)zoomLevel;
-- (void)selectAnnotationAnimated:(NSUInteger)annotationInArray;
-- (void)removeAnnotation:(NSUInteger)annotationInArray;
+- (void)selectAnnotationAnimated:(NSString*)selectedId;
+- (void)removeAnnotation:(NSString*)selectedId;
+- (void)removeAllAnnotations;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)setAttributionButtonVisibility:(BOOL)isVisible;
 - (void)setLogoVisibility:(BOOL)isVisible;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -22,7 +22,6 @@
     /* Map properties */
     NSString *_accessToken;
     NSMutableArray *_annotations;
-    NSMutableArray *_newAnnotations;
     CLLocationCoordinate2D _centerCoordinate;
     BOOL _clipsToBounds;
     BOOL _debugActive;
@@ -49,7 +48,7 @@ RCT_EXPORT_MODULE();
         _eventDispatcher = eventDispatcher;
         _clipsToBounds = YES;
         _finishedLoading = NO;
-        _newAnnotations = [NSMutableArray array];
+        _annotations = [NSMutableArray array];
     }
 
     return self;
@@ -117,23 +116,13 @@ RCT_EXPORT_MODULE();
 
 - (void)setAnnotations:(NSMutableArray *)annotations
 {
-    _newAnnotations = annotations;
-    [self performSelector:@selector(updateAnnotations) withObject:nil afterDelay:0.5];
+    [self performSelector:@selector(updateAnnotations:) withObject:annotations afterDelay:0.5];
 }
 
-- (void)updateAnnotations {
-    if (_newAnnotations) {
-        if (_annotations.count) {
-            for (int i = 0; i < [_annotations count]; i++) {
-                [_map removeAnnotations: _annotations];
-            }
-            _annotations = nil;
-        }
-
-        _annotations = _newAnnotations;
-        for (int i = 0; i < [_newAnnotations count]; i++) {
-            [_map addAnnotation:_newAnnotations[i]];
-        }
+- (void)updateAnnotations:(NSMutableArray *) annotations {
+    for (int i = 0; i < [annotations count]; i++) {
+        [_annotations addObject:annotations[i]];
+        [_map addAnnotation:annotations[i]];
     }
 }
 
@@ -261,7 +250,6 @@ RCT_EXPORT_MODULE();
 - (void)setRightCalloutAccessory:(UIButton *)rightCalloutAccessory
 {
     _rightCalloutAccessory = rightCalloutAccessory;
-    [self updateAnnotations];
 }
 
 -(void)setDirectionAnimated:(int)heading

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -120,15 +120,17 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)updateAnnotations:(NSMutableArray *) annotations {
-    for (int i = 0; i < [annotations count]; i++) {
-        NSString *id = [annotations[i] id];
+    NSUInteger count = 0;
+    for (RCTMGLAnnotation *annotation in annotations) {
+        NSString *id = [annotation id];
         if ([id length] != 0) {
-            [_annotations setObject:[annotations objectAtIndex:i] forKey:id];
+            [_annotations setObject:annotation forKey:id];
         } else {
-            [_annotations setObject:[annotations objectAtIndex:i] forKey:[NSString stringWithFormat:@"id-%d", i]];
+            [_annotations setObject:annotation forKey:@(count)];
         }
+        [_map addAnnotation:annotation];
+        count++;
     }
-    [_map addAnnotations:annotations];
 }
 
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(RCTMGLAnnotationPolyline *)shape
@@ -364,9 +366,7 @@ RCT_EXPORT_MODULE();
 
 - (void)removeAllAnnotations
 {
-    for(id key in _annotations) {
-        [_map removeAnnotation:[_annotations objectForKey:key]];
-    }
+    [_map removeAnnotations:_map.annotations];
     [_annotations removeAllObjects];
 }
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -21,7 +21,7 @@
 
     /* Map properties */
     NSString *_accessToken;
-    NSMutableArray *_annotations;
+    NSMutableDictionary *_annotations;
     CLLocationCoordinate2D _centerCoordinate;
     BOOL _clipsToBounds;
     BOOL _debugActive;
@@ -119,11 +119,14 @@ RCT_EXPORT_MODULE();
     [self performSelector:@selector(updateAnnotations:) withObject:annotations afterDelay:0.5];
 }
 
-- (void)updateAnnotations:(NSMutableArray *) annotations {
+- (void)updateAnnotations:(NSArray *) annotations {
     for (int i = 0; i < [annotations count]; i++) {
-        [_annotations addObject:annotations[i]];
-        [_map addAnnotation:annotations[i]];
+        NSString *id = [(RCTMGLAnnotation *) annotations[i] id];
+        if ([id length] != 0) {
+            [_annotations setObject:[annotations objectAtIndex:i] forKey:id];
+        }
     }
+    [_map addAnnotations:annotations];
 }
 
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(RCTMGLAnnotationPolyline *)shape

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -346,21 +346,21 @@ RCT_EXPORT_MODULE();
     }
 }
 
-- (void)selectAnnotationAnimated:(NSString*)selectedId
+- (void)selectAnnotationAnimated:(NSString*)selectedIdentifier
 {
     for (int i = 0; i < [_annotations count]; i++) {
         NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
-        if (selectedId == currentId) {
+        if (selectedIdentifier == currentId) {
             [_map selectAnnotation:_annotations[i] animated:YES];
         }
     }
 }
 
-- (void)removeAnnotation:(NSString*)selectedId
+- (void)removeAnnotation:(NSString*)selectedIdentifier
 {
     for (int i = 0; i < [_annotations count]; i++) {
         NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
-        if (selectedId == currentId) {
+        if (selectedIdentifier == currentId) {
             [_map removeAnnotation:_annotations[i]];
             [_annotations removeObject:_annotations[i]];
         }

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -48,7 +48,7 @@ RCT_EXPORT_MODULE();
         _eventDispatcher = eventDispatcher;
         _clipsToBounds = YES;
         _finishedLoading = NO;
-        _annotations = [NSMutableArray array];
+        _annotations = [NSMutableDictionary dictionary];
     }
 
     return self;
@@ -119,11 +119,13 @@ RCT_EXPORT_MODULE();
     [self performSelector:@selector(updateAnnotations:) withObject:annotations afterDelay:0.5];
 }
 
-- (void)updateAnnotations:(NSArray *) annotations {
+- (void)updateAnnotations:(NSMutableArray *) annotations {
     for (int i = 0; i < [annotations count]; i++) {
-        NSString *id = [(RCTMGLAnnotation *) annotations[i] id];
+        NSString *id = [annotations[i] id];
         if ([id length] != 0) {
             [_annotations setObject:[annotations objectAtIndex:i] forKey:id];
+        } else {
+            [_annotations setObject:[annotations objectAtIndex:i] forKey:[NSString stringWithFormat:@"id-%d", i]];
         }
     }
     [_map addAnnotations:annotations];
@@ -351,29 +353,19 @@ RCT_EXPORT_MODULE();
 
 - (void)selectAnnotationAnimated:(NSString*)selectedIdentifier
 {
-    for (int i = 0; i < [_annotations count]; i++) {
-        NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
-        if (selectedIdentifier == currentId) {
-            [_map selectAnnotation:_annotations[i] animated:YES];
-        }
-    }
+    [_map selectAnnotation:[_annotations objectForKey:selectedIdentifier] animated:YES];
 }
 
 - (void)removeAnnotation:(NSString*)selectedIdentifier
 {
-    for (int i = 0; i < [_annotations count]; i++) {
-        NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
-        if (selectedIdentifier == currentId) {
-            [_map removeAnnotation:_annotations[i]];
-            [_annotations removeObject:_annotations[i]];
-        }
-    }
+    [_map removeAnnotation:[_annotations objectForKey:selectedIdentifier]];
+    [_annotations removeObjectForKey:[_annotations objectForKey:selectedIdentifier]];
 }
 
 - (void)removeAllAnnotations
 {
-    for (int i = 0; i < [_annotations count]; i++) {
-        [_map removeAnnotation:_annotations[i]];
+    for(id key in _annotations) {
+        [_map removeAnnotation:[_annotations objectForKey:key]];
     }
     [_annotations removeAllObjects];
 }

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -372,7 +372,7 @@ RCT_EXPORT_MODULE();
     for (int i = 0; i < [_annotations count]; i++) {
         [_map removeAnnotation:_annotations[i]];
     }
-    _annotations = nil;
+    [_annotations removeAllObjects];
 }
 
 - (UIButton *)mapView:(MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -346,27 +346,33 @@ RCT_EXPORT_MODULE();
     }
 }
 
-- (void)selectAnnotationAnimated:(NSUInteger)annotationInArray
+- (void)selectAnnotationAnimated:(NSString*)selectedId
 {
-    if (annotationInArray >= [_annotations count]) {
-        RCTLogError(@"Could not find annotation in array");
-        return;
-    }
-    if ([_annotations count] != 0) {
-        [_map selectAnnotation:_annotations[annotationInArray] animated:YES];
+    for (int i = 0; i < [_annotations count]; i++) {
+        NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
+        if (selectedId == currentId) {
+            [_map selectAnnotation:_annotations[i] animated:YES];
+        }
     }
 }
 
-- (void)removeAnnotation:(NSUInteger)annotationInArray
+- (void)removeAnnotation:(NSString*)selectedId
 {
-    if (annotationInArray >= [_annotations count]) {
-        RCTLogError(@"Could not find annotation in array");
-        return;
+    for (int i = 0; i < [_annotations count]; i++) {
+        NSString *currentId = [(RCTMGLAnnotation *) _annotations[i] id];
+        if (selectedId == currentId) {
+            [_map removeAnnotation:_annotations[i]];
+            [_annotations removeObject:_annotations[i]];
+        }
     }
-    if ([_annotations count] != 0) {
-        [_map removeAnnotation:_annotations[annotationInArray]];
-        [_annotations removeObjectAtIndex:annotationInArray];
+}
+
+- (void)removeAllAnnotations
+{
+    for (int i = 0; i < [_annotations count]; i++) {
+        [_map removeAnnotation:_annotations[i]];
     }
+    _annotations = nil;
 }
 
 - (UIButton *)mapView:(MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -166,23 +166,23 @@ RCT_EXPORT_METHOD(setVisibleCoordinateBoundsAnimated:(nonnull NSNumber *)reactTa
 }
 
 RCT_EXPORT_METHOD(selectAnnotationAnimated:(nonnull NSNumber *) reactTag
-                  selectedId:(NSString*)selectedId)
+                  selectedIdentifier:(NSString*)selectedIdentifier)
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
-            [mapView selectAnnotationAnimated:selectedId];
+            [mapView selectAnnotationAnimated:selectedIdentifier];
         }
     }];
 }
 
 RCT_EXPORT_METHOD(removeAnnotation:(nonnull NSNumber *) reactTag
-                  selectedId:(NSString*)selectedId)
+                  selectedIdentifier:(NSString*)selectedIdentifier)
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
-            [mapView removeAnnotation:selectedId];
+            [mapView removeAnnotation:selectedIdentifier];
         }
     }];
 }

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -166,23 +166,33 @@ RCT_EXPORT_METHOD(setVisibleCoordinateBoundsAnimated:(nonnull NSNumber *)reactTa
 }
 
 RCT_EXPORT_METHOD(selectAnnotationAnimated:(nonnull NSNumber *) reactTag
-                  annotationInArray:(NSUInteger)annotationInArray)
+                  selectedId:(NSString*)selectedId)
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
-            [mapView selectAnnotationAnimated:annotationInArray];
+            [mapView selectAnnotationAnimated:selectedId];
         }
     }];
 }
 
 RCT_EXPORT_METHOD(removeAnnotation:(nonnull NSNumber *) reactTag
-                  annotationInArray:(NSUInteger)annotationInArray)
+                  selectedId:(NSString*)selectedId)
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
-            [mapView removeAnnotation:annotationInArray];
+            [mapView removeAnnotation:selectedId];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(removeAllAnnotations:(nonnull NSNumber *) reactTag)
+{
+    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
+        RCTMapboxGL *mapView = viewRegistry[reactTag];
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            [mapView removeAllAnnotations];
         }
     }];
 }

--- a/ios/example.js
+++ b/ios/example.js
@@ -113,11 +113,14 @@ var MapExample = React.createClass({
         }])}>
           Add new marker
         </Text>
-        <Text style={styles.text} onPress={() => this.selectAnnotationAnimated(mapRef, 0)}>
-          Open first popup
+        <Text style={styles.text} onPress={() => this.selectAnnotationAnimated(mapRef, 'marker1')}>
+          Open marker1 popup
         </Text>
-        <Text style={styles.text} onPress={() => this.removeAnnotation(mapRef, 0)}>
-          Remove first annotation
+        <Text style={styles.text} onPress={() => this.removeAnnotation(mapRef, 'marker2')}>
+          Remove marker2 annotation
+        </Text>
+        <Text style={styles.text} onPress={() => this.removeAllAnnotations(mapRef)}>
+          Remove all annotations
         </Text>
         <Text style={styles.text} onPress={() => this.setVisibleCoordinateBoundsAnimated(mapRef, 40.712, -74.227, 40.774, -74.125, 100, 0, 0, 0)}>
           Set visible bounds to 40.7, -74.2, 40.7, -74.1


### PR DESCRIPTION
This changes:
- Annotations will not be wiped away when new annotations are added to map
- remove and selecting an annotation is done with an id vs a place in an array
- adds `removeAllAnnotations` function

/cc @christopherdro
