### PR TITLE
Improve CocoaPods documentation

### DIFF
--- a/ios/install-cocoapods.md
+++ b/ios/install-cocoapods.md
@@ -1,0 +1,54 @@
+# Installation Process with CocoaPods
+
+If you use already [CocoaPods](https://cocoapods.org/) in your react-native
+project, you can also add the react-native-mapbox-gl project to your Podfile.
+
+1. Run `npm install --save react-native-mapbox-gl`
+2. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'`
+   to your `Podfile` file.  
+   (The path dependence on your Podfile location.)
+3. Open your Xcode project and ensure that the "Build Settings" parameter
+   "Other linker flags" (`OTHER_LDFLAGS`) contains the CocoaPods generated
+   linker options!
+   * If you have used `react-natve init` to setup your project you can just
+     remove this parameter. Just select the line and press the backspace key.
+   * Alternative, if you setup your Xcode project yourself, ensure that the
+     parent configuration was included with a `$(inherited)` variable.
+4. Install the new CocoaPods dependency with `pod install`.  
+   This command must not have output any warning. ;)
+
+## Troubleshooting CocoaPods install
+
+### RCTView.h file not found
+
+Because react-native is only available as npm module (and not as "regular"
+CocoaPods dependency, see [v0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
+for more informations).
+
+So it is required that you import react-native also from a local path.
+Ensure that you include `React` before you include `react-native-mapbox-gl` in
+your `Podfile`. Here is a complete working example if you want add your Podfile
+in the project root while your generated Xcode project is still in the `ios`
+folder:
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+
+xcodeproj 'ios/YourProject'
+workspace 'ios/YourProject'
+
+pod 'React', :path => 'node_modules/react-native'
+pod 'React/RCTGeolocation', :path => 'node_modules/react-native'
+pod 'React/RCTImage', :path => 'node_modules/react-native'
+pod 'React/RCTNetwork', :path => 'node_modules/react-native'
+pod 'React/RCTText', :path => 'node_modules/react-native'
+pod 'React/RCTWebSocket', :path => 'node_modules/react-native'
+
+pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'
+```
+
+### NativeModules.MapboxGLManager.* not defined
+
+Verify that your "Build Settings" parameter "Other linker flags" (`OTHER_LDFLAGS`)
+is defined correctly. This is NOT the case in a `react-native init` project which doesn't
+use CocoaPods. See Step 3 above!

--- a/ios/install-cocoapods.md
+++ b/ios/install-cocoapods.md
@@ -1,4 +1,4 @@
-# Installation Process with CocoaPods
+# Installation process with CocoaPods
 
 If you use already [CocoaPods](https://cocoapods.org/) in your react-native
 project, you can also add the react-native-mapbox-gl project to your Podfile.
@@ -17,7 +17,7 @@ project, you can also add the react-native-mapbox-gl project to your Podfile.
 4. Install the new CocoaPods dependency with `pod install`.  
    This command must not have output any warning. ;)
 
-## Troubleshooting CocoaPods install
+## Troubleshooting with CocoaPods
 
 ### RCTView.h file not found
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -2,13 +2,47 @@
 
 ## Use CocoaPods
 
-If you already use [CocoaPods](https://cocoapods.org/) in your react-native project you add the native
-part of Mapbox GL with just one line of code:
+If you use already [CocoaPods](https://cocoapods.org/)
+in your react-native project, you can also add the react-native-mapbox-gl project
+to your Podfile.
 
-1. `npm install react-native-mapbox-gl --save`
-1. Add `pod 'RCTMapboxGL', :path => '../node_modules/react-native-mapbox-gl/ios'` to your `Podfile` file and re-run `pod install`.
+1. Run `npm install --save react-native-mapbox-gl`
+2. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'` to your `Podfile` file.  
+   (The path dependence on your Podfile location.)
+3. Open your Xcode project and ensure that the "Build Settings" parameter "Other linker flags" (`OTHER_LDFLAGS`) contains the CocoaPods generated linker options!
+   * If you have used `react-natve init` to setup your project you can just remove this paramter. Just select the line and press the delete (backspace) key.
+   * Alternative, if you setup your Xcode project yourself, ensure that the parent configuration was included with a `$(inherited)` variable.
+4. Install the new CocoaPods dependency with `pod install`.  
+   This command must not have output any warning. ;)
 
-See also the react-native [0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
+### Troubleshooting
+
+#### RCTView.h file not found
+
+Because react-native is only available as npm module (and not as "regular" CocoaPods
+dependency, see RN [v0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0) for more informations), it is required that you import react-native also from a local path. Ensure that you include at least this RN dependencies before you include `react-native-mapbox-gl` in your `Podfile`. Here is a complete working example if you want add your Podfile in the project root while your generated Xcode project is still in the `ios` folder:
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+
+xcodeproj 'ios/YourProject'
+workspace 'ios/YourProject'
+
+pod 'React', :path => 'node_modules/react-native'
+pod 'React/RCTGeolocation', :path => 'node_modules/react-native'
+pod 'React/RCTImage', :path => 'node_modules/react-native'
+pod 'React/RCTNetwork', :path => 'node_modules/react-native'
+pod 'React/RCTText', :path => 'node_modules/react-native'
+pod 'React/RCTWebSocket', :path => 'node_modules/react-native'
+
+pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'
+```
+
+#### NativeModules.MapboxGLManager.* not defined
+
+Verify that your "Build Settings" parameter "Other linker flags" (`OTHER_LDFLAGS`)
+is defined correctly. This is NOT the case in a `react-native init` project which doesn't
+use CocoaPods. See Step 3 above!
 
 ## Manually
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -2,16 +2,20 @@
 
 ## Use CocoaPods
 
-If you use already [CocoaPods](https://cocoapods.org/)
-in your react-native project, you can also add the react-native-mapbox-gl project
-to your Podfile.
+If you use already [CocoaPods](https://cocoapods.org/) in your react-native
+project, you can also add the react-native-mapbox-gl project to your Podfile.
 
 1. Run `npm install --save react-native-mapbox-gl`
-2. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'` to your `Podfile` file.  
-   (The path dependence on your Podfile location.)
-3. Open your Xcode project and ensure that the "Build Settings" parameter "Other linker flags" (`OTHER_LDFLAGS`) contains the CocoaPods generated linker options!
-   * If you have used `react-natve init` to setup your project you can just remove this paramter. Just select the line and press the delete (backspace) key.
-   * Alternative, if you setup your Xcode project yourself, ensure that the parent configuration was included with a `$(inherited)` variable.
+2. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'`
+   to your `Podfile` file.  
+(The path dependence on your Podfile location.)
+3. Open your Xcode project and ensure that the "Build Settings" parameter
+   "Other linker flags" (`OTHER_LDFLAGS`) contains the CocoaPods generated
+   linker options!
+   * If you have used `react-natve init` to setup your project you can just
+     remove this parameter. Just select the line and press the backspace key.
+   * Alternative, if you setup your Xcode project yourself, ensure that the
+     parent configuration was included with a `$(inherited)` variable.
 4. Install the new CocoaPods dependency with `pod install`.  
    This command must not have output any warning. ;)
 
@@ -19,8 +23,15 @@ to your Podfile.
 
 #### RCTView.h file not found
 
-Because react-native is only available as npm module (and not as "regular" CocoaPods
-dependency, see RN [v0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0) for more informations), it is required that you import react-native also from a local path. Ensure that you include at least this RN dependencies before you include `react-native-mapbox-gl` in your `Podfile`. Here is a complete working example if you want add your Podfile in the project root while your generated Xcode project is still in the `ios` folder:
+Because react-native is only available as npm module (and not as "regular"
+CocoaPods dependency, see [v0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
+for more informations).
+
+So it is required that you import react-native also from a local path.
+Ensure that you include `React` before you include `react-native-mapbox-gl` in
+your `Podfile`. Here is a complete working example if you want add your Podfile
+in the project root while your generated Xcode project is still in the `ios`
+folder:
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'

--- a/ios/install.md
+++ b/ios/install.md
@@ -1,4 +1,4 @@
-# Manual Installation Process
+# Manual installation process
 
 1. `npm install react-native-mapbox-gl --save`
 2. In the XCode's `Project navigator`, right click on project's name ➜ `Add Files to <...>` ![](https://cldup.com/k0oJwOUKPN.png)

--- a/ios/install.md
+++ b/ios/install.md
@@ -1,69 +1,12 @@
-# Installation Process
-
-## Use CocoaPods
-
-If you use already [CocoaPods](https://cocoapods.org/) in your react-native
-project, you can also add the react-native-mapbox-gl project to your Podfile.
-
-1. Run `npm install --save react-native-mapbox-gl`
-2. Add `pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'`
-   to your `Podfile` file.  
-(The path dependence on your Podfile location.)
-3. Open your Xcode project and ensure that the "Build Settings" parameter
-   "Other linker flags" (`OTHER_LDFLAGS`) contains the CocoaPods generated
-   linker options!
-   * If you have used `react-natve init` to setup your project you can just
-     remove this parameter. Just select the line and press the backspace key.
-   * Alternative, if you setup your Xcode project yourself, ensure that the
-     parent configuration was included with a `$(inherited)` variable.
-4. Install the new CocoaPods dependency with `pod install`.  
-   This command must not have output any warning. ;)
-
-### Troubleshooting CocoaPods install
-
-#### RCTView.h file not found
-
-Because react-native is only available as npm module (and not as "regular"
-CocoaPods dependency, see [v0.13 release notes](https://github.com/facebook/react-native/releases/tag/v0.13.0)
-for more informations).
-
-So it is required that you import react-native also from a local path.
-Ensure that you include `React` before you include `react-native-mapbox-gl` in
-your `Podfile`. Here is a complete working example if you want add your Podfile
-in the project root while your generated Xcode project is still in the `ios`
-folder:
-
-```ruby
-source 'https://github.com/CocoaPods/Specs.git'
-
-xcodeproj 'ios/YourProject'
-workspace 'ios/YourProject'
-
-pod 'React', :path => 'node_modules/react-native'
-pod 'React/RCTGeolocation', :path => 'node_modules/react-native'
-pod 'React/RCTImage', :path => 'node_modules/react-native'
-pod 'React/RCTNetwork', :path => 'node_modules/react-native'
-pod 'React/RCTText', :path => 'node_modules/react-native'
-pod 'React/RCTWebSocket', :path => 'node_modules/react-native'
-
-pod 'RCTMapboxGL', :path => 'node_modules/react-native-mapbox-gl/ios'
-```
-
-#### NativeModules.MapboxGLManager.* not defined
-
-Verify that your "Build Settings" parameter "Other linker flags" (`OTHER_LDFLAGS`)
-is defined correctly. This is NOT the case in a `react-native init` project which doesn't
-use CocoaPods. See Step 3 above!
-
-## Manually
+# Manual Installation Process
 
 1. `npm install react-native-mapbox-gl --save`
-1. In the XCode's `Project navigator`, right click on project's name ➜ `Add Files to <...>` ![](https://cldup.com/k0oJwOUKPN.png)
-1. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL.xcodeproj` ![](https://cldup.com/bnJWwtaACM.png)
-1. Select your project in the `Project navigator`. Click `Build Phases` then `Link Binary With Libraries`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/libRCTMapboxGL.a` ![](https://cldup.com/QWhL_SjobN.png)
-1. Select your project in the `Project navigator`. Click `Build Phases` then `Copy Bundle Resources`. Click the `+` button. When the modal appears, click `Add other`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/Mapbox.bundle`. ![](https://cldup.com/Oi7uHxc1Fd.png)
-1. Just like in the last step, select your project in the `Project navigator`. Click `Build Phases` then `Copy Bundle Resources`. Click the `+` button. When the modal appears, click `Add other`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/Settings.bundle`. [More information on location metrics can be found here](https://www.mapbox.com/mapbox-gl-ios/#metrics_opt_out).
-1. Add the following Cocoa framework dependencies to your target's Link Binary With Libraries build phase:
+2. In the XCode's `Project navigator`, right click on project's name ➜ `Add Files to <...>` ![](https://cldup.com/k0oJwOUKPN.png)
+3. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL.xcodeproj` ![](https://cldup.com/bnJWwtaACM.png)
+4. Select your project in the `Project navigator`. Click `Build Phases` then `Link Binary With Libraries`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/libRCTMapboxGL.a` ![](https://cldup.com/QWhL_SjobN.png)
+5. Select your project in the `Project navigator`. Click `Build Phases` then `Copy Bundle Resources`. Click the `+` button. When the modal appears, click `Add other`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/Mapbox.bundle`. ![](https://cldup.com/Oi7uHxc1Fd.png)
+6. Just like in the last step, select your project in the `Project navigator`. Click `Build Phases` then `Copy Bundle Resources`. Click the `+` button. When the modal appears, click `Add other`. Add `node_modules/react-native-mapbox-gl/ios/RCTMapboxGL/Settings.bundle`. [More information on location metrics can be found here](https://www.mapbox.com/mapbox-gl-ios/#metrics_opt_out).
+7. Add the following Cocoa framework dependencies to your target's Link Binary With Libraries build phase:
   * `CoreTelephony.framework`
   * `GLKit.framework`
   * `ImageIO.framework`
@@ -74,5 +17,5 @@ use CocoaPods. See Step 3 above!
   * `libsqlite3.tbd`
   * `libz.tbd`
   * ![](https://cldup.com/KuSEgMQQSy.gif)
-1. Click on the `RCTMapboxGL` project. Under the `Build Settings` tab, search for `header_search_path`. Make sure `$(SRCROOT)/../../../React` and `$(SRCROOT)/../../react-native/React` are added and set to `recursive`. ![](https://cldup.com/81zUEHaKoX.png)
-1. You can now `require('react-native-mapbox-gl')` and build.
+8. Click on the `RCTMapboxGL` project. Under the `Build Settings` tab, search for `header_search_path`. Make sure `$(SRCROOT)/../../../React` and `$(SRCROOT)/../../react-native/React` are added and set to `recursive`. ![](https://cldup.com/81zUEHaKoX.png)
+9. You can now `require('react-native-mapbox-gl')` and build.

--- a/ios/install.md
+++ b/ios/install.md
@@ -19,7 +19,7 @@ project, you can also add the react-native-mapbox-gl project to your Podfile.
 4. Install the new CocoaPods dependency with `pod install`.  
    This command must not have output any warning. ;)
 
-### Troubleshooting
+### Troubleshooting CocoaPods install
 
 #### RCTView.h file not found
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@ npm install react-native-mapbox-gl --save
 
 # Installation
 * [Android](/android/install.md)
-* iOS: [manually](/ios/install.md), or with [CocoaPods](/ios/install-cocoapods.md)
+* [iOS](/ios/install.md) (manually),
+  or with [CocoaPods](/ios/install-cocoapods.md)
 
 # API
 * [Android](/android/API.md)

--- a/readme.md
+++ b/readme.md
@@ -11,18 +11,18 @@ npm install react-native-mapbox-gl --save
 ```
 
 # Installation
-* [iOS manually](/ios/install.md), or with [CocoaPods](/ios/install-cocoapods.md)
 * [Android](/android/install.md)
+* iOS: [manually](/ios/install.md), or with [CocoaPods](/ios/install-cocoapods.md)
 
 # API
-* [iOS](/ios/API.md)
 * [Android](/android/API.md)
+* [iOS](/ios/API.md)
 
 # Example
-* [iOS](/ios//example.js)
 * [Android](/android/example.js)
+* [iOS](/ios//example.js)
 
-![](https://cldup.com/A8S_7rLg1L.png)
 ![](http://i.imgur.com/I8XkXcS.jpg)
+![](https://cldup.com/A8S_7rLg1L.png)
 
 *Need help? [Join the Discord channel](https://discord.gg/0iAWSG9X4zDK8ptn)*

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install react-native-mapbox-gl --save
 ```
 
 # Installation
-* [iOS](/ios/install.md)
+* [iOS manually](/ios/install.md), or with [CocoaPods](/ios/install-cocoapods.md)
 * [Android](/android/install.md)
 
 # API


### PR DESCRIPTION
To solve common issues with the CocoaPods integration I extend the CocoaPods documentations with a "troubleshooting" section for these both issues:
- Add pod 'React' dependency hint for mapbox/react-native-mapbox-gl#165
- Add OTHER_LDFLAGS hint for mapbox/react-native-mapbox-gl#212
