### PR TITLE
Remove annotations when updating props

### DIFF
--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -442,6 +442,7 @@ RCT_CUSTOM_VIEW_PROPERTY(annotations, CLLocationCoordinate2D, RCTMapboxGL) {
         NSMutableArray* annotations = [NSMutableArray array];
         id annotationObject;
         NSEnumerator *enumerator = [json objectEnumerator];
+        [view removeAllAnnotations];
 
         while (annotationObject = [enumerator nextObject]) {
             CLLocationCoordinate2D coordinate = [RCTConvert CLLocationCoordinate2D:annotationObject];


### PR DESCRIPTION
Closes: https://github.com/mapbox/react-native-mapbox-gl/issues/217

When updating the annotations `prop`, annotations remained on the map. This removes all annotations on the map, then adds the updated items in the prop. 

`addAnnotations` however will not clear out the map when annotations are added. If you'd like to clear out annotations before calling `addAnnotations`, call the method `removeAllAnnotations`.

/cc @joshblour @guofoo @christopherdro 
