### PR TITLE
Respect height and width settings on annotationImage property

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -135,7 +135,7 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                             SpriteFactory spriteFactory = view.getSpriteFactory();
                             Sprite icon;
 
-                            if (annotationImage.hasKey("height")) {
+                            if (annotationImage.hasKey("height") && annotationImage.hasKey("width")) {
                                 int height = annotationImage.getInt("height");
                                 int width = annotationImage.getInt("width");
                                 icon = spriteFactory.fromDrawable(image, width, height);

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -133,7 +133,16 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                         try {
                             Drawable image = drawableFromUrl(mapView, annotationURL);
                             SpriteFactory spriteFactory = view.getSpriteFactory();
-                            Sprite icon = spriteFactory.fromDrawable(image);
+                            Sprite icon;
+
+                            if (annotationImage.hasKey("height")) {
+                                int height = annotationImage.getInt("height");
+                                int width = annotationImage.getInt("width");
+                                icon = spriteFactory.fromDrawable(image, width, height);
+                            } else {
+                                icon = spriteFactory.fromDrawable(image);
+                            }
+
                             marker.icon(icon);
                         } catch (Exception e) {
                             e.printStackTrace();


### PR DESCRIPTION
Currently images custom annotation images are not resized when being added to the map on Android.
This change uses the spriteFactory method that resizes the images before setting them on the annotation.
