### PR TITLE
Fixing set annotations to remove all prior annotations before adding …

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -106,6 +106,7 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
 
     @ReactProp(name = PROP_ANNOTATIONS)
     public void setAnnotations(MapView view, @Nullable ReadableArray value) {
+        view.removieAllAnnotations();
         if (value == null || value.size() < 1) {
             Log.e(REACT_CLASS, "Error: No annotations");
         } else {

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -115,6 +115,7 @@ RCT_EXPORT_MODULE();
 
 - (void)setAnnotations:(NSMutableArray *)annotations
 {
+		[self removeAllAnnotations];
     [self performSelector:@selector(updateAnnotations:) withObject:annotations afterDelay:0.5];
 }
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -115,7 +115,6 @@ RCT_EXPORT_MODULE();
 
 - (void)setAnnotations:(NSMutableArray *)annotations
 {
-		[self removeAllAnnotations];
     [self performSelector:@selector(updateAnnotations:) withObject:annotations afterDelay:0.5];
 }
 


### PR DESCRIPTION
Fixing set annotations to remove all prior annotations before adding new annotations. According the the documentation 'Note, this will remove all previous annotations from the map' which was not the observed behavior
