### PR TITLE
Upgrade to Mapbox iOS SDK 3.1.1-pre.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.1.0",
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.1.1-pre.1",
     "test": "npm run lint",
     "lint": "eslint --no-eslintrc -c .eslintrc index.ios.js index.android.js ios/example.js android/example.js",
     "start": "node_modules/react-native/packager/packager.sh"

--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -8,6 +8,9 @@ cd ios/
 if ! which curl > /dev/null; then echo "curl command not found. Please install curl"; exit 1; fi;
 if ! which unzip > /dev/null; then echo "unzip command not found. Please install unzip"; exit 1; fi;
 
+if [ -f ./ios/Mapbox.framework ]; then
+    rm -rf ./ios/Mapbox.framework
+fi
 
 curl -sS https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-$VERSION-dynamic.zip > temp.zip
 unzip -o temp.zip -d temp


### PR DESCRIPTION
Also, if the `Mapbox.framework` exists, remove it when upgrading. 
