### PR TITLE
Clarify project's support status in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,21 @@
 # React Native Mapbox GL
 
-_A React Native component for building maps with the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) and [Mapbox Android SDK](https://www.mapbox.com/android-sdk/)_
+_An experimental React Native component for building maps with the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) and [Mapbox Android SDK](https://www.mapbox.com/android-sdk/)_
 
 [![npm version](https://badge.fury.io/js/react-native-mapbox-gl.svg)](https://badge.fury.io/js/react-native-mapbox-gl) [![Circle CI](https://circleci.com/gh/mapbox/react-native-mapbox-gl/tree/master.svg?style=svg)](https://circleci.com/gh/mapbox/react-native-mapbox-gl/tree/master)
+
+# Support
+
+This project is **experimental**. Mapbox does not officially support React Native Mapbox GL to the same extent as the [iOS](https://www.mapbox.com/ios-sdk/) or [Android](https://www.mapbox.com/android-sdk/) SDKs it depends on; however, bug reports and pull requests are certainly welcome.
+
+If you need help, try [the Discord channel](https://discord.gg/0iAWSG9X4zDK8ptn).
+
+# Installation
 
 ```
 npm install react-native-mapbox-gl --save
 ```
 
-# Installation
 * [Android](/android/install.md)
 * [iOS](/ios/install.md) (manually),
   or with [CocoaPods](/ios/install-cocoapods.md)
@@ -23,5 +30,3 @@ npm install react-native-mapbox-gl --save
 
 ![](http://i.imgur.com/I8XkXcS.jpg)
 ![](https://cldup.com/A8S_7rLg1L.png)
-
-*Need help? [Join the Discord channel](https://discord.gg/0iAWSG9X4zDK8ptn)*


### PR DESCRIPTION
Jams a fresh new "Support" section at the top of the readme that tries to kindly outline this project's support status.

Fixes #191.

/cc @bsudekum @tmcw
