### PR TITLE
Fix install process

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -30,18 +30,6 @@ node_modules/
 npm-debug.log
 
 # project specific
-libMapboxGL.a
-MapboxGL.bundle/
-MapboxGL.h
-MGLAnnotation.h
-MGLMapboxEvents.h
-MGLMapView+IBAdditions.h
-MGLMapView.h
-MGLMetricsLocationManager.h
-MGLTypes.h
-MGLUserLocation.h
-MGLAccountManager.h
-MGLMapView_Private.h
 android/.gradle/
 android/.idea/
 android/android.iml

--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -8,8 +8,9 @@ cd ios/
 if ! which curl > /dev/null; then echo "curl command not found. Please install curl"; exit 1; fi;
 if ! which unzip > /dev/null; then echo "unzip command not found. Please install unzip"; exit 1; fi;
 
-if [ -f ./ios/Mapbox.framework ]; then
-    rm -rf ./ios/Mapbox.framework
+if [ -d ./Mapbox.framework ]; then
+    echo "Old Mapbox.framework found. Removing it and installing a $VERSION"
+    rm -rf ./Mapbox.framework
 fi
 
 curl -sS https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-$VERSION-dynamic.zip > temp.zip


### PR DESCRIPTION
Fixes: https://github.com/mapbox/react-native-mapbox-gl/issues/270

Two issues were solved here:

``` bash
if [ -f ./Mapbox.framework ]; then
  echo "Old Mapbox.framework found. Removing it and installing a $VERSION"
  rm -rf ./Mapbox.framework
 fi
```

A `.framework` is a directory, not a file. This should have been `-d`. This resulted in nested `Mapbox.framework`.

The second issue this solves is around `MGLAccountManager.h`. `MGLAccountManager.h` was in the `.npmignore` file and somehow was being omitted from the `Mapbox Module`.
