### PR TITLE
Add ios offline support

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -55,6 +55,9 @@ var MapMixins = {
   getDirection(mapRef, callback) {
     NativeModules.MapboxGLManager.getDirection(React.findNodeHandle(this.refs[mapRef]), callback);
   },
+  getBounds(mapRef, callback) {
+    NativeModules.MapboxGLManager.getBounds(React.findNodeHandle(this.refs[mapRef]), callback);
+  },
   mapStyles: NativeModules.MapboxGLManager.mapStyles,
   userTrackingMode: NativeModules.MapboxGLManager.userTrackingMode,
   userLocationVerticalAlignment: NativeModules.MapboxGLManager.userLocationVerticalAlignment,

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,6 +4,12 @@ var React = require('react-native');
 var { NativeModules, requireNativeComponent } = React;
 
 var MapMixins = {
+  addPackForRegion(mapRef, options) {
+    NativeModules.MapboxGLManager.addPackForRegion(React.findNodeHandle(this.refs[mapRef]), options);
+  },
+  getPacksWithCompletionHandler(mapRef, callback) {
+    NativeModules.MapboxGLManager.getPacksWithCompletionHandler(React.findNodeHandle(this.refs[mapRef]), callback);
+  },
   setDirectionAnimated(mapRef, heading) {
     NativeModules.MapboxGLManager.setDirectionAnimated(React.findNodeHandle(this.refs[mapRef]), heading);
   },
@@ -48,7 +54,8 @@ var MapMixins = {
   },
   mapStyles: NativeModules.MapboxGLManager.mapStyles,
   userTrackingMode: NativeModules.MapboxGLManager.userTrackingMode,
-  userLocationVerticalAlignment: NativeModules.MapboxGLManager.userLocationVerticalAlignment
+  userLocationVerticalAlignment: NativeModules.MapboxGLManager.userLocationVerticalAlignment,
+  unknownResourceCount: NativeModules.MapboxGLManager.unknownResourceCount
 };
 
 var MapView = React.createClass({
@@ -81,6 +88,15 @@ var MapView = React.createClass({
   },
   _onLocateUserFailed(event: Event) {
     if (this.props.onLocateUserFailed) this.props.onLocateUserFailed(event.nativeEvent.src);
+  },
+  _onOfflineProgressDidChange(event: Event) {
+    if (this.props.onOfflineProgressDidChange) this.props.onOfflineProgressDidChange(event.nativeEvent.src);
+  },
+  _onOfflineMaxAllowedMapboxTiles(event: Event) {
+    if (this.props.onOfflineMaxAllowedMapboxTiles) this.props.onOfflineMaxAllowedMapboxTiles(event.nativeEvent.src);
+  },
+  _onOfflineDidRecieveError(event: Event) {
+    if (this.props.onOfflineDidRecieveError) this.props.onOfflineDidRecieveError(event.nativeEvent.src);
   },
   propTypes: {
     showsUserLocation: React.PropTypes.bool,
@@ -134,7 +150,10 @@ var MapView = React.createClass({
     onLocateUserFailed: React.PropTypes.func,
     onLongPress: React.PropTypes.func,
     contentInset: React.PropTypes.array,
-    userLocationVerticalAlignment: React.PropTypes.number
+    userLocationVerticalAlignment: React.PropTypes.number,
+    onOfflineProgressDidChange: React.PropTypes.func,
+    onOfflineMaxAllowedMapboxTiles: React.PropTypes.func,
+    onOfflineDidRecieveError: React.PropTypes.func
   },
   getDefaultProps() {
     return {
@@ -167,7 +186,10 @@ var MapView = React.createClass({
         onLongPress={this._onLongPress}
         onFinishLoadingMap={this._onFinishLoadingMap}
         onStartLoadingMap={this._onStartLoadingMap}
-        onLocateUserFailed={this._onLocateUserFailed} />
+        onLocateUserFailed={this._onLocateUserFailed}
+        onOfflineProgressDidChange={this._onOfflineProgressDidChange}
+        onOfflineMaxAllowedMapboxTiles={this._onOfflineMaxAllowedMapboxTiles}
+        onOfflineDidRecieveError={this._onOfflineDidRecieveError} />
     );
   }
 });

--- a/index.ios.js
+++ b/index.ios.js
@@ -7,8 +7,8 @@ var MapMixins = {
   addPackForRegion(mapRef, options) {
     NativeModules.MapboxGLManager.addPackForRegion(React.findNodeHandle(this.refs[mapRef]), options);
   },
-  getPacksWithCompletionHandler(mapRef, callback) {
-    NativeModules.MapboxGLManager.getPacksWithCompletionHandler(React.findNodeHandle(this.refs[mapRef]), callback);
+  getPacks(mapRef, callback) {
+    NativeModules.MapboxGLManager.getPacks(React.findNodeHandle(this.refs[mapRef]), callback);
   },
   removePack(mapRef, packName, callback) {
     NativeModules.MapboxGLManager.removePack(React.findNodeHandle(this.refs[mapRef]), packName, callback);

--- a/index.ios.js
+++ b/index.ios.js
@@ -10,6 +10,9 @@ var MapMixins = {
   getPacksWithCompletionHandler(mapRef, callback) {
     NativeModules.MapboxGLManager.getPacksWithCompletionHandler(React.findNodeHandle(this.refs[mapRef]), callback);
   },
+  removePack(mapRef, packName, callback) {
+    NativeModules.MapboxGLManager.removePack(React.findNodeHandle(this.refs[mapRef]), packName, callback);
+  },
   setDirectionAnimated(mapRef, heading) {
     NativeModules.MapboxGLManager.setDirectionAnimated(React.findNodeHandle(this.refs[mapRef]), heading);
   },

--- a/ios/API.md
+++ b/ios/API.md
@@ -42,7 +42,6 @@
 | `onOfflineProgressDidChange` | `{countOfResourcesCompleted: 7, countOfResourcesExpected: 1284, name: "test", countOfBytesCompleted: 306543, maximumResourcesExpected: 1284}` | Event fired when the progress of an offline pack changes while downloading. |
 | `onOfflineMaxAllowedMapboxTiles` | `{maximumCount: number}` | Event fired when the maximum number of tiles has been hit. |
 | `onOfflineDidRecieveError` | `{error: error}` | Event fired when there is an error while downloading a pack. |
-| `getPacksWithCompletionHandler` | `array of packs` | Returns packs which have started and/or completed |
 
 ## Methods for Modifying the Map State
 
@@ -62,7 +61,9 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `removeAllAnnotations`  | `mapViewRef`| Removes all annotations from the map.
 | `setVisibleCoordinateBoundsAnimated`  | `mapViewRef`, `latitude1`, `longitude1`, `latitude2`, `longitude2`, `padding top`, `padding right`, `padding bottom`, `padding left`  | Changes the viewport to fit the given coordinate bounds and some additional padding on each side.
 | `setUserTrackingMode` | `mapViewRef`, `userTrackingMode` | Modifies the tracking mode. Valid args: `this.userTrackingMode.none`, `this.userTrackingMode.follow`, `this.userTrackingMode.followWithCourse`, `this.userTrackingMode.followWithHeading`
-| `addPackForRegion` | `mapRef` `name` `type` `bounds` `minZoomLevel` `maxZoomLevel` `style` | Adds an offline region for a given bounding box. `name` is a string to represent an offline pack. `type` must be of type `bbox`. `bounds` is an array. `minZoomLevel` is an number representing the minimum zoom level of the offline pack. `maxZoomLevel` is an number representing the maximum zoom level of the offline pack. `style` is a style url to download.
+| `addPackForRegion` | `mapRef` `{name, type, bounds, minZoomLevel, maxZoomLevel, style}` | Adds an offline region for a given bounding box. `name` is a string to represent an offline pack. `type` must be of type `bbox`. `bounds` is an array. `minZoomLevel` is an number representing the minimum zoom level of the offline pack. `maxZoomLevel` is an number representing the maximum zoom level of the offline pack. `style` is a style url to download.
+| `getPacks` | `mapRef` `callback` | Returns a callback with an array of all offline packs on device. If the downloaded pack was not downloaded during the current session, the size will be 0.
+| `removePack` | `mapRef` `name-of-pack` `callback` | Removes a pack from the device. The name corresponds to the `name` of the pack used when calling `addPackForRegion`
 
 ## Styles
 

--- a/ios/API.md
+++ b/ios/API.md
@@ -39,6 +39,7 @@
 | `onLocateUserFailed` | `{message: message}` | Fired when there is an error getting the users location. Do not rely on the string that is returned for determining what kind of error it is. |
 | `getCenterCoordinateZoomLevel` | `mapViewRef`, `callback` | Gets the current center location and zoom level. Returns a single callback object. |
 | `getDirection` | `mapViewRef`, `callback` | Gets the current direction. Returns a single callback object. |
+| `getBounds` | `mapViewRef`, `callback` | Gets the bounds of the current view. Returns array [latitudeSW, longitudeSW, latitudeNE, longitudeNE]. |
 | `onOfflineProgressDidChange` | `{countOfResourcesCompleted: 7, countOfResourcesExpected: 1284, name: "test", countOfBytesCompleted: 306543, maximumResourcesExpected: 1284}` | Event fired when the progress of an offline pack changes while downloading. |
 | `onOfflineMaxAllowedMapboxTiles` | `{maximumCount: number}` | Event fired when the maximum number of tiles has been hit. |
 | `onOfflineDidRecieveError` | `{error: error}` | Event fired when there is an error while downloading a pack. |
@@ -61,7 +62,7 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `removeAllAnnotations`  | `mapViewRef`| Removes all annotations from the map.
 | `setVisibleCoordinateBoundsAnimated`  | `mapViewRef`, `latitude1`, `longitude1`, `latitude2`, `longitude2`, `padding top`, `padding right`, `padding bottom`, `padding left`  | Changes the viewport to fit the given coordinate bounds and some additional padding on each side.
 | `setUserTrackingMode` | `mapViewRef`, `userTrackingMode` | Modifies the tracking mode. Valid args: `this.userTrackingMode.none`, `this.userTrackingMode.follow`, `this.userTrackingMode.followWithCourse`, `this.userTrackingMode.followWithHeading`
-| `addPackForRegion` | `mapRef` `{name, type, bounds, minZoomLevel, maxZoomLevel, style}` | Adds an offline region for a given bounding box. `name` is a string to represent an offline pack. `type` must be of type `bbox`. `bounds` is an array. `minZoomLevel` is an number representing the minimum zoom level of the offline pack. `maxZoomLevel` is an number representing the maximum zoom level of the offline pack. `style` is a style url to download.
+| `addPackForRegion` | `mapRef` `{name, type, bounds, minZoomLevel, maxZoomLevel, style}` | Adds an offline region for a given bounding box. `name` is a string to represent an offline pack. `type` must be of type `bbox`. `bounds` is an array.  `minZoomLevel` is an number representing the minimum zoom level of the offline pack. `maxZoomLevel` is an number representing the maximum zoom level of the offline pack. `style` is a style url to download. `metadata` is an object you can use metadata about the pack.
 | `getPacks` | `mapRef` `callback` | Returns a callback with an array of all offline packs on device. If the downloaded pack was not downloaded during the current session, the size will be 0.
 | `removePack` | `mapRef` `name-of-pack` `callback` | Removes a pack from the device. The name corresponds to the `name` of the pack used when calling `addPackForRegion`
 

--- a/ios/API.md
+++ b/ios/API.md
@@ -38,9 +38,10 @@
 | `onLocateUserFailed` | `{message: message}` | Fired when there is an error getting the users location. Do not rely on the string that is returned for determining what kind of error it is. |
 | `getCenterCoordinateZoomLevel` | `mapViewRef`, `callback` | Gets the current center location and zoom level. Returns a single callback object. |
 | `getDirection` | `mapViewRef`, `callback` | Gets the current direction. Returns a single callback object. |
-
-
-
+| `onOfflineProgressDidChange` | `{countOfResourcesCompleted: 7, countOfResourcesExpected: 1284, name: "test", countOfBytesCompleted: 306543, maximumResourcesExpected: 1284}` | Event fired when the progress of an offline pack changes while downloading. |
+| `onOfflineMaxAllowedMapboxTiles` | `{maximumCount: number}` | Event fired when the maximum number of tiles has been hit. |
+| `onOfflineDidRecieveError` | `{error: error}` | Event fired when there is an error while downloading a pack. |
+| `getPacksWithCompletionHandler` | `array of packs` | Returns packs which have started and/or completed |
 
 ## Methods for Modifying the Map State
 
@@ -60,6 +61,7 @@ These methods require you to use `MapboxGLMap.Mixin` to access the methods. Each
 | `removeAllAnnotations`  | `mapViewRef`| Removes all annotations from the map.
 | `setVisibleCoordinateBoundsAnimated`  | `mapViewRef`, `latitude1`, `longitude1`, `latitude2`, `longitude2`, `padding top`, `padding right`, `padding bottom`, `padding left`  | Changes the viewport to fit the given coordinate bounds and some additional padding on each side.
 | `setUserTrackingMode` | `mapViewRef`, `userTrackingMode` | Modifies the tracking mode. Valid args: `this.userTrackingMode.none`, `this.userTrackingMode.follow`, `this.userTrackingMode.followWithCourse`, `this.userTrackingMode.followWithHeading`
+| `addPackForRegion` | `mapRef` `name` `type` `bounds` `minZoomLevel` `maxZoomLevel` `style` | Adds an offline region for a given bounding box. `name` is a string to represent an offline pack. `type` must be of type `bbox`. `bounds` is an array. `minZoomLevel` is an number representing the minimum zoom level of the offline pack. `maxZoomLevel` is an number representing the maximum zoom level of the offline pack. `style` is a style url to download.
 
 ## Styles
 

--- a/ios/RCTMapboxGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMapboxGL.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C5AF3B8C1C5A8C3D0003BF64 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5AF3B8B1C5A8C3D0003BF64 /* Mapbox.framework */; };
 		C5DBB3441AF2EF2B00E611A9 /* RCTMapboxGL.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = C5DBB3431AF2EF2B00E611A9 /* RCTMapboxGL.h */; };
 		C5DBB3461AF2EF2B00E611A9 /* RCTMapboxGL.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DBB3451AF2EF2B00E611A9 /* RCTMapboxGL.m */; };
 		C5DBB34C1AF2EF2B00E611A9 /* libRCTMapboxGL.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DBB3401AF2EF2B00E611A9 /* libRCTMapboxGL.a */; };
@@ -38,7 +37,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C5AF3B8B1C5A8C3D0003BF64 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = "<group>"; };
 		C5DBB3401AF2EF2B00E611A9 /* libRCTMapboxGL.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTMapboxGL.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5DBB3431AF2EF2B00E611A9 /* RCTMapboxGL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTMapboxGL.h; sourceTree = "<group>"; };
 		C5DBB3451AF2EF2B00E611A9 /* RCTMapboxGL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMapboxGL.m; sourceTree = "<group>"; };
@@ -53,7 +51,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C5AF3B8C1C5A8C3D0003BF64 /* Mapbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,7 +68,6 @@
 		C5DBB3371AF2EF2B00E611A9 = {
 			isa = PBXGroup;
 			children = (
-				C5AF3B8B1C5A8C3D0003BF64 /* Mapbox.framework */,
 				C5DBB3421AF2EF2B00E611A9 /* RCTMapboxGL */,
 				C5DBB34F1AF2EF2B00E611A9 /* RCTMapboxGLTests */,
 				C5DBB3411AF2EF2B00E611A9 /* Products */,

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -11,7 +11,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTBridgeModule.h"
 
-@interface RCTMapboxGL : RCTView <MGLMapViewDelegate, RCTBridgeModule>
+@interface RCTMapboxGL : RCTView <MGLMapViewDelegate, MGLOfflinePackDelegate, RCTBridgeModule>
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
@@ -43,6 +43,7 @@
 - (void)setCompassVisibility:(BOOL)isVisible;
 - (double)zoomLevel;
 - (double)direction;
+- (void) createOfflinePack:(MGLCoordinateBounds)bounds style:(NSURL*)style fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type;
 - (CLLocationCoordinate2D)centerCoordinate;
 @property (nonatomic) MGLAnnotationVerticalAlignment userLocationVerticalAlignment;
 @property (nonatomic) UIEdgeInsets contentInset;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -37,6 +37,7 @@
 - (void)addAnnotation:(NSObject *)annotation;
 - (void)removeAnnotation:(NSString*)selectedIdentifier;
 - (void)removeAllAnnotations;
+- (MGLCoordinateBounds)visibleCoordinateBounds;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)setAttributionButtonVisibility:(BOOL)isVisible;
 - (void)setLogoVisibility:(BOOL)isVisible;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -11,7 +11,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTBridgeModule.h"
 
-@interface RCTMapboxGL : RCTView <MGLMapViewDelegate, MGLOfflinePackDelegate, RCTBridgeModule>
+@interface RCTMapboxGL : RCTView <MGLMapViewDelegate, RCTBridgeModule>
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -43,7 +43,7 @@
 - (void)setCompassVisibility:(BOOL)isVisible;
 - (double)zoomLevel;
 - (double)direction;
-- (void) createOfflinePack:(MGLCoordinateBounds)bounds style:(NSURL*)style fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type;
+- (void) createOfflinePack:(MGLCoordinateBounds)bounds styleURL:(NSURL*)styleURL fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type metadata:(NSDictionary*)metadata;
 - (CLLocationCoordinate2D)centerCoordinate;
 @property (nonatomic) MGLAnnotationVerticalAlignment userLocationVerticalAlignment;
 @property (nonatomic) UIEdgeInsets contentInset;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -284,6 +284,11 @@ RCT_EXPORT_MODULE();
     [self updateMap];
 }
 
+- (MGLCoordinateBounds) visibleCoordinateBounds
+{
+    return [_map visibleCoordinateBounds];
+}
+
 - (void)setUserTrackingMode:(int)userTrackingMode
 {
     if (userTrackingMode > 3 || userTrackingMode < 0) {

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -12,6 +12,10 @@
 #import "UIView+React.h"
 #import "RCTLog.h"
 
+@interface RCTMapboxGL ()
+@property (nonatomic) MGLOfflinePack *pack;
+@end
+
 @implementation RCTMapboxGL {
     /* Required to publish events */
     RCTEventDispatcher *_eventDispatcher;
@@ -91,6 +95,7 @@ RCT_EXPORT_MODULE();
     }
 }
 
+
 - (void)createMap
 {
     [MGLAccountManager setAccessToken:_accessToken];
@@ -106,6 +111,26 @@ RCT_EXPORT_MODULE();
     [self layoutSubviews];
 }
 
+-(void)createOfflinePack:(MGLCoordinateBounds)bounds style:(NSURL*)style fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type
+{
+    
+    id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:style bounds:bounds fromZoomLevel:fromZoomLevel toZoomLevel:toZoomLevel];
+    
+    NSDictionary *userInfo = @{ @"name": name };
+    NSData *context = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
+    
+    __weak RCTMapboxGL *weakSelf = self;
+    [[MGLOfflineStorage sharedOfflineStorage] addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack *pack, NSError *error) {
+        RCTMapboxGL *strongSelf = weakSelf;
+        if (error) {
+            RCTLogError(@"Error creating pack.");
+        } else {
+            strongSelf.pack = pack;
+            pack.delegate = strongSelf;
+            [pack resume];
+        }
+    }];
+}
 
 - (void)layoutSubviews
 {
@@ -503,6 +528,40 @@ RCT_EXPORT_MODULE();
 
     [_eventDispatcher sendInputEventWithName:@"onStartLoadingMap" body:event];
 }
+
+- (void)offlinePack:(MGLOfflinePack *)pack progressDidChange:(MGLOfflinePackProgress)progress {
+    NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
+    NSDictionary *event = @{ @"target": self.reactTag,
+                             @"src": @{
+                                     @"name": userInfo[@"name"],
+                                     @"countOfResourcesCompleted": @(progress.countOfResourcesCompleted),
+                                     @"countOfResourcesExpected": @(progress.countOfResourcesExpected),
+                                     @"countOfBytesCompleted": @(progress.countOfBytesCompleted),
+                                     @"maximumResourcesExpected": @(progress.maximumResourcesExpected)
+                                     }
+                             };
+    
+    [_eventDispatcher sendInputEventWithName:@"onOfflineProgressDidChange" body:event];
+}
+
+- (void)offlinePack:(MGLOfflinePack *)pack didReceiveMaximumAllowedMapboxTiles:(uint64_t)maximumCount {
+    NSDictionary *event = @{ @"target": self.reactTag,
+                             @"src": @{
+                                     @"maximumCount": @(maximumCount)
+                                     }
+                             };
+    [_eventDispatcher sendInputEventWithName:@"onOfflineMaxAllowedMapboxTiles" body:event];
+}
+
+- (void)offlinePack:(MGLOfflinePack *)pack didReceiveError:(nonnull NSError *)error {
+    NSDictionary *event = @{ @"target": self.reactTag,
+                             @"src": @{
+                                     @"error": [error localizedDescription]
+                                     }
+                             };
+    [_eventDispatcher sendInputEventWithName:@"onOfflineDidRecieveError" body:event];
+}
+
 
 - (void)mapView:(MGLMapView *)mapView didFailToLocateUserWithError:(NSError *)error
 {

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -120,12 +120,13 @@ RCT_EXPORT_MODULE();
     [self layoutSubviews];
 }
 
--(void)createOfflinePack:(MGLCoordinateBounds)bounds style:(NSURL*)style fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type
+-(void)createOfflinePack:(MGLCoordinateBounds)bounds styleURL:(NSURL*)styleURL fromZoomLevel:(double)fromZoomLevel toZoomLevel:(double)toZoomLevel name:(NSString*)name type:(NSString*)type metadata:(NSDictionary *)metadata
 {
     
-    id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:style bounds:bounds fromZoomLevel:fromZoomLevel toZoomLevel:toZoomLevel];
+    id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:styleURL bounds:bounds fromZoomLevel:fromZoomLevel toZoomLevel:toZoomLevel];
     
-    NSDictionary *userInfo = @{ @"name": name };
+    NSMutableDictionary *userInfo = [metadata mutableCopy];
+    userInfo[@"name"] = name;
     NSData *context = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
     
     [[MGLOfflineStorage sharedOfflineStorage] addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack *pack, NSError *error) {
@@ -556,7 +557,7 @@ RCT_EXPORT_MODULE();
     NSDictionary *event = @{ @"target": self.reactTag,
                              @"src": @{
                                      @"name": userInfo[@"name"],
-                                     @"maximumCount": @(maximumCount)
+                                     @"maxTiles": @(maximumCount)
                                      }
                              };
     [_eventDispatcher sendInputEventWithName:@"onOfflineMaxAllowedMapboxTiles" body:event];

--- a/ios/example.js
+++ b/ios/example.js
@@ -173,6 +173,12 @@ var MapExample = React.createClass({
           })}>
           Get offline packs
         </Text>
+        <Text onPress={() => this.removePack(mapRef, 'test', (err, info)=> {
+            if (err) console.log(err);
+            console.log('Deleted', info.deleted);
+          })}>
+          Remove pack with name 'test'
+        </Text>
         <Mapbox
           style={styles.container}
           direction={0}

--- a/ios/example.js
+++ b/ios/example.js
@@ -154,6 +154,22 @@ var MapExample = React.createClass({
           })}>
           Get direction
         </Text>
+        <Text onPress={() => this.addPackForRegion(mapRef, {
+            name: 'test',
+            type: 'bbox',
+            bounds: [0, 0, 0, 0],
+            minZoomLevel: 0,
+            maxZoomLevel: 0,
+            style: this.mapStyles.emerald
+          })}>
+          Create offline pack
+        </Text>
+        <Text onPress={() => this.getPacksWithCompletionHandler(mapRef, (err, packs)=> {
+            if (err) console.log(err);
+            console.log(packs);
+          })}>
+          Get offline packs
+        </Text>
         <Mapbox
           style={styles.container}
           direction={0}

--- a/ios/example.js
+++ b/ios/example.js
@@ -7,7 +7,7 @@ var {
   AppRegistry,
   StyleSheet,
   Text,
-  StatusBarIOS,
+  StatusBar,
   View
 } = React;
 
@@ -85,8 +85,11 @@ var MapExample = React.createClass({
   onTap(location) {
     console.log('tapped', location);
   },
-  render: function() {
-    StatusBarIOS.setHidden(true);
+  onOfflineProgressDidChange(progress) {
+    console.log(progress);
+  },
+  render() {
+    StatusBar.setHidden(true);
     return (
       <View style={styles.container}>
         <Text onPress={() => this.setDirectionAnimated(mapRef, 0)}>
@@ -145,17 +148,20 @@ var MapExample = React.createClass({
         <Text onPress={() => this.setUserTrackingMode(mapRef, this.userTrackingMode.follow)}>
           Set userTrackingMode to follow
         </Text>
-        <Text onPress={() => this.getCenterCoordinateZoomLevel(mapRef, (err, location)=> {
-            if (err) console.log(err);
+        <Text onPress={() => this.getCenterCoordinateZoomLevel(mapRef, (location)=> {
             console.log(location);
           })}>
           Get location
         </Text>
-        <Text onPress={() => this.getDirection(mapRef, (err, direction)=> {
-            if (err) console.log(err);
+        <Text onPress={() => this.getDirection(mapRef, (direction)=> {
             console.log(direction);
           })}>
           Get direction
+        </Text>
+        <Text onPress={() => this.getBounds(mapRef, (bounds)=> {
+            console.log(bounds);
+          })}>
+          Get bounds
         </Text>
         <Text onPress={() => this.addPackForRegion(mapRef, {
             name: 'test',
@@ -163,11 +169,11 @@ var MapExample = React.createClass({
             bounds: [0, 0, 0, 0],
             minZoomLevel: 0,
             maxZoomLevel: 0,
-            style: this.mapStyles.emerald
+            styleURL: this.mapStyles.emerald
           })}>
           Create offline pack
         </Text>
-        <Text onPress={() => this.getPacksWithCompletionHandler(mapRef, (err, packs)=> {
+        <Text onPress={() => this.getPacks(mapRef, (err, packs)=> {
             if (err) console.log(err);
             console.log(packs);
           })}>
@@ -175,7 +181,11 @@ var MapExample = React.createClass({
         </Text>
         <Text onPress={() => this.removePack(mapRef, 'test', (err, info)=> {
             if (err) console.log(err);
-            console.log('Deleted', info.deleted);
+            if (info) {
+              console.log('Deleted', info.deleted);
+            } else {
+              console.log('No packs to delete');
+            }
           })}>
           Remove pack with name 'test'
         </Text>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.2.0-pre.2",
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.2.0",
     "test": "npm run lint",
     "lint": "eslint --no-eslintrc -c .eslintrc index.ios.js index.android.js ios/example.js android/example.js"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.1.1",
+    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.2.0-pre.2",
     "test": "npm run lint",
     "lint": "eslint --no-eslintrc -c .eslintrc index.ios.js index.android.js ios/example.js android/example.js",
     "start": "node_modules/react-native/packager/packager.sh"


### PR DESCRIPTION
Adds support for ios offline.

Currently the api looks like: 

``` js
 this.addPackForRegion(mapRef, {
  name: 'test',
  bounds: [0, 0, 0, 0],
  minZoomLevel: 0,
  maxZoomLevel: 0,
  style: this.mapStyles.emerald
});
```

`bounds` is a tricky one to make future-proof-able because new `regions` will come out down the line ie offline along a line. I might add a `type` to this.

still todo:
- [x] fixup `getPacksWithCompletionHandler` 

/cc @1ec5 for :eyes: 
