### PR TITLE
Bring back onTap

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -73,6 +73,9 @@ var MapView = React.createClass({
   _onLongPress(event: Event) {
     if (this.props.onLongPress) this.props.onLongPress(event.nativeEvent.src);
   },
+  _onTap(event: Event) {
+    if (this.props.onTap) this.props.onTap(event.nativeEvent.src);
+  },
   _onFinishLoadingMap(event: Event) {
     if (this.props.onFinishLoadingMap) this.props.onFinishLoadingMap(event.nativeEvent.src);
   },
@@ -133,6 +136,7 @@ var MapView = React.createClass({
     onStartLoadingMap: React.PropTypes.func,
     onLocateUserFailed: React.PropTypes.func,
     onLongPress: React.PropTypes.func,
+    onTap: React.PropTypes.func,
     contentInset: React.PropTypes.array,
     userLocationVerticalAlignment: React.PropTypes.number
   },
@@ -165,6 +169,7 @@ var MapView = React.createClass({
         onRightAnnotationTapped={this._onRightAnnotationTapped}
         onUpdateUserLocation={this._onUpdateUserLocation}
         onLongPress={this._onLongPress}
+        onTap={this._onTap}
         onFinishLoadingMap={this._onFinishLoadingMap}
         onStartLoadingMap={this._onStartLoadingMap}
         onLocateUserFailed={this._onLocateUserFailed} />

--- a/ios/API.md
+++ b/ios/API.md
@@ -32,6 +32,7 @@
 | `onOpenAnnotation` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when focusing a an annotation.
 | `onUpdateUserLocation` | `{latitude: 0, longitude: 0, headingAccuracy: 0, magneticHeading: 0, trueHeading: 0, isUpdating: false}` | Fired when the users location updates.
 | `onRightAnnotationTapped` | `{title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps `rightCalloutAccessory`
+| `onTap` | `{latitude: 0, longitude: 0}` | Fired when the users taps the screen.
 | `onLongPress` | `{latitude: 0, longitude: 0, screenCoordY, screenCoordX}` | Fired when the user taps and holds screen for 1 second.
 | `onFinishLoadingMap` | does not return an object | Fired once the map has loaded the style |
 | `onStartLoadingMap` | does not return an object | Fired once the map begins loading the style |

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -101,11 +101,19 @@ RCT_EXPORT_MODULE();
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
     [self addGestureRecognizer:longPress];
 
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)];
+    singleTap.delegate = self;
+    [_map addGestureRecognizer:singleTap];
+
     [self updateMap];
     [self addSubview:_map];
     [self layoutSubviews];
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return YES;
+}
 
 - (void)layoutSubviews
 {

--- a/ios/example.js
+++ b/ios/example.js
@@ -82,6 +82,9 @@ var MapExample = React.createClass({
   onLongPress(location) {
     console.log('long pressed', location);
   },
+  onTap(location) {
+    console.log('tapped', location);
+  },
   render: function() {
     StatusBarIOS.setHidden(true);
     return (
@@ -173,7 +176,8 @@ var MapExample = React.createClass({
           onOpenAnnotation={this.onOpenAnnotation}
           onRightAnnotationTapped={this.onRightAnnotationTapped}
           onUpdateUserLocation={this.onUpdateUserLocation}
-          onLongPress={this.onLongPress} />
+          onLongPress={this.onLongPress}
+          onTap={this.onTap} />
       </View>
     );
   }


### PR DESCRIPTION
Noticed this was removed, probably because it didn't originally work well with annotations and swallowed the tap event? The plumbing here should fix that and safely trigger both.

It's great for tracking the users last touch. I'm going to use it to draw custom callouts with React native views where the user last touched (including over annotations).
