### PR TITLE
Allow empty array of annotations

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:3.2.0@aar') {
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.0.0-beta.2@aar'){
         transitive = true
     }
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,4 +4,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+
+    <service android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService" />
 </manifest>

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -140,7 +140,7 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
     }
 
     public void setAnnotations(MapView view, @Nullable ReadableArray value, boolean clearMap) {
-        if (value == null || value.size() < 1) {
+        if (value == null) {
             Log.e(REACT_CLASS, "Error: No annotations");
         } else {
             if (clearMap) {

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
@@ -3,21 +3,19 @@ package com.mapbox.reactnativemapboxgl;
 
 import android.content.Context;
 import android.util.Log;
-import java.util.HashMap;
-import java.util.Map;
 
-import com.mapbox.mapboxsdk.constants.Style;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.WritableMap;
 import com.mapbox.mapboxsdk.constants.MyLocationTracking;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.views.MapView;
+import com.mapbox.mapboxsdk.constants.Style;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
If you provide to the MapView component an empty array of annotations an error is logged. This will prevent the map view from being updated. In my current project I filter the annotations based on certain criteria and it is potential have zero annotations match the filter. In this case I expect the map view to have all annotations removed. This works in iOS.
