### PR TITLE
Removed check for empty array of annotations

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -118,7 +118,7 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
     }
 
     public void setAnnotations(MapView view, @Nullable ReadableArray value, boolean clearMap) {
-        if (value == null || value.size() < 1) {
+        if (value == null) {
             Log.e(REACT_CLASS, "Error: No annotations");
         } else {
             if (clearMap) {


### PR DESCRIPTION
If you provide to the MapView component an empty array of annotations an error is logged. This will prevent the map view from being updated. In my current project I filter the annotations based on certain criteria and it is potential have zero annotations match the filter. In this case I expect the map view to have all annotations removed. This works in iOS.
