### PR TITLE
Add height and width support to annotationImage (android)

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -153,7 +153,14 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                                 image = drawableFromUrl(mapView, annotationURL);
                             }
                             IconFactory iconFactory = view.getIconFactory();
-                            Icon icon = iconFactory.fromDrawable(image);
+                            Icon icon;
+                            if (annotationImage.hasKey("height") && annotationImage.hasKey("width")) {
+                                int height = Math.round((float)annotationImage.getInt("height") * view.getResources().getDisplayMetrics().density);
+                                int width = Math.round((float)annotationImage.getInt("width") * view.getResources().getDisplayMetrics().density);
+                                icon = iconFactory.fromDrawable(image, width, height);
+                            } else {
+                                icon = iconFactory.fromDrawable(image);
+                            }
                             marker.icon(icon);
                         } catch (Exception e) {
                             e.printStackTrace();

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -155,8 +155,9 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                             IconFactory iconFactory = view.getIconFactory();
                             Icon icon;
                             if (annotationImage.hasKey("height") && annotationImage.hasKey("width")) {
-                                int height = Math.round((float)annotationImage.getInt("height") * view.getResources().getDisplayMetrics().density);
-                                int width = Math.round((float)annotationImage.getInt("width") * view.getResources().getDisplayMetrics().density);
+                                float scale = view.getResources().getDisplayMetrics().density;
+                                int height = Math.round((float)annotationImage.getInt("height") * scale);
+                                int width = Math.round((float)annotationImage.getInt("width") * scale);
                                 icon = iconFactory.fromDrawable(image, width, height);
                             } else {
                                 icon = iconFactory.fromDrawable(image);


### PR DESCRIPTION
The current android implementation does not support height and width like on ios.
