### PR TITLE
Fix rn 0.24.1 compatibility

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -2,7 +2,7 @@
 
 var React = require('react-native');
 var { NativeModules, requireNativeComponent, DeviceEventEmitter } = React;
-var Subscribable = require('Subscribable');
+var Subscribable = require('../react-native/Libraries/Components/Subscribable');
 
 var MapMixins = {
   setDirectionAnimated(mapRef, heading) {


### PR DESCRIPTION
Not sure if this breaks older versions, can anybody test this?

``` shell
npm install git+https://github.com/vespakoen/react-native-mapbox-gl.git#fix-rn-compat
```

**EDIT** CicleCI is testing =)
