### PR TITLE
add required empty metadata object to addPackForRegion.

### DIFF
--- a/ios/example.js
+++ b/ios/example.js
@@ -169,6 +169,7 @@ var MapExample = React.createClass({
             bounds: [0, 0, 0, 0],
             minZoomLevel: 0,
             maxZoomLevel: 0,
+            metadata: {},
             styleURL: this.mapStyles.emerald
           })}>
           Create offline pack


### PR DESCRIPTION
Without the empty metadata object, clicking "Create offline pack" results in an red box error that "metadata is required".
