### PR TITLE
Added support for react-native 0.25 and beyond

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react');
+var { PropTypes } = React;
+
 var ReactNative = require('react-native');
 var { NativeModules, requireNativeComponent, findNodeHandle } = ReactNative;
 
@@ -111,62 +113,62 @@ var MapView = React.createClass({
     if (this.props.onOfflineDidRecieveError) this.props.onOfflineDidRecieveError(event.nativeEvent.src);
   },
   propTypes: {
-    showsUserLocation: React.PropTypes.bool,
-    rotateEnabled: React.PropTypes.bool,
-    scrollEnabled: React.PropTypes.bool,
-    zoomEnabled: React.PropTypes.bool,
-    accessToken: React.PropTypes.string.isRequired,
-    zoomLevel: React.PropTypes.number,
-    direction: React.PropTypes.number,
-    styleURL: React.PropTypes.string,
-    clipsToBounds: React.PropTypes.bool,
-    debugActive: React.PropTypes.bool,
-    userTrackingMode: React.PropTypes.number,
-    attributionButton: React.PropTypes.bool,
-    centerCoordinate: React.PropTypes.shape({
-      latitude: React.PropTypes.number.isRequired,
-      longitude: React.PropTypes.number.isRequired
+    showsUserLocation: PropTypes.bool,
+    rotateEnabled: PropTypes.bool,
+    scrollEnabled: PropTypes.bool,
+    zoomEnabled: PropTypes.bool,
+    accessToken: PropTypes.string.isRequired,
+    zoomLevel: PropTypes.number,
+    direction: PropTypes.number,
+    styleURL: PropTypes.string,
+    clipsToBounds: PropTypes.bool,
+    debugActive: PropTypes.bool,
+    userTrackingMode: PropTypes.number,
+    attributionButton: PropTypes.bool,
+    centerCoordinate: PropTypes.shape({
+      latitude: PropTypes.number.isRequired,
+      longitude: PropTypes.number.isRequired
     }),
-    annotations: React.PropTypes.arrayOf(React.PropTypes.shape({
-      coordinates: React.PropTypes.array.isRequired,
-      title: React.PropTypes.string,
-      subtitle: React.PropTypes.string,
-      fillAlpha: React.PropTypes.number,
-      fillColor: React.PropTypes.string,
-      strokeAlpha: React.PropTypes.number,
-      strokeColor: React.PropTypes.string,
-      strokeWidth: React.PropTypes.number,
-      id: React.PropTypes.string,
-      type: React.PropTypes.string.isRequired,
-      rightCalloutAccessory: React.PropTypes.object({
-        height: React.PropTypes.number,
-        width: React.PropTypes.number,
-        url: React.PropTypes.string
+    annotations: PropTypes.arrayOf(PropTypes.shape({
+      coordinates: PropTypes.array.isRequired,
+      title: PropTypes.string,
+      subtitle: PropTypes.string,
+      fillAlpha: PropTypes.number,
+      fillColor: PropTypes.string,
+      strokeAlpha: PropTypes.number,
+      strokeColor: PropTypes.string,
+      strokeWidth: PropTypes.number,
+      id: PropTypes.string,
+      type: PropTypes.string.isRequired,
+      rightCalloutAccessory: PropTypes.object({
+        height: PropTypes.number,
+        width: PropTypes.number,
+        url: PropTypes.string
       }),
-      annotationImage: React.PropTypes.object({
-        height: React.PropTypes.number,
-        width: React.PropTypes.number,
-        url: React.PropTypes.string
+      annotationImage: PropTypes.object({
+        height: PropTypes.number,
+        width: PropTypes.number,
+        url: PropTypes.string
       })
     })),
-    attributionButtonIsHidden: React.PropTypes.bool,
-    logoIsHidden: React.PropTypes.bool,
-    compassIsHidden: React.PropTypes.bool,
-    onRegionChange: React.PropTypes.func,
-    onRegionWillChange: React.PropTypes.func,
-    onOpenAnnotation: React.PropTypes.func,
-    onUpdateUserLocation: React.PropTypes.func,
-    onRightAnnotationTapped: React.PropTypes.func,
-    onFinishLoadingMap: React.PropTypes.func,
-    onStartLoadingMap: React.PropTypes.func,
-    onLocateUserFailed: React.PropTypes.func,
-    onLongPress: React.PropTypes.func,
-    onTap: React.PropTypes.func,
-    contentInset: React.PropTypes.array,
-    userLocationVerticalAlignment: React.PropTypes.number,
-    onOfflineProgressDidChange: React.PropTypes.func,
-    onOfflineMaxAllowedMapboxTiles: React.PropTypes.func,
-    onOfflineDidRecieveError: React.PropTypes.func
+    attributionButtonIsHidden: PropTypes.bool,
+    logoIsHidden: PropTypes.bool,
+    compassIsHidden: PropTypes.bool,
+    onRegionChange: PropTypes.func,
+    onRegionWillChange: PropTypes.func,
+    onOpenAnnotation: PropTypes.func,
+    onUpdateUserLocation: PropTypes.func,
+    onRightAnnotationTapped: PropTypes.func,
+    onFinishLoadingMap: PropTypes.func,
+    onStartLoadingMap: PropTypes.func,
+    onLocateUserFailed: PropTypes.func,
+    onLongPress: PropTypes.func,
+    onTap: PropTypes.func,
+    contentInset: PropTypes.array,
+    userLocationVerticalAlignment: PropTypes.number,
+    onOfflineProgressDidChange: PropTypes.func,
+    onOfflineMaxAllowedMapboxTiles: PropTypes.func,
+    onOfflineDidRecieveError: PropTypes.func
   },
   getDefaultProps() {
     return {

--- a/index.ios.js
+++ b/index.ios.js
@@ -2,62 +2,62 @@
 
 var React = require('react');
 var ReactNative = require('react-native');
-var { NativeModules, requireNativeComponent } = ReactNative;
+var { NativeModules, requireNativeComponent, findNodeHandle } = ReactNative;
 
 var MapMixins = {
   addPackForRegion(mapRef, options) {
-    NativeModules.MapboxGLManager.addPackForRegion(ReactNative.findNodeHandle(this.refs[mapRef]), options);
+    NativeModules.MapboxGLManager.addPackForRegion(findNodeHandle(this.refs[mapRef]), options);
   },
   getPacks(mapRef, callback) {
-    NativeModules.MapboxGLManager.getPacks(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getPacks(findNodeHandle(this.refs[mapRef]), callback);
   },
   removePack(mapRef, packName, callback) {
-    NativeModules.MapboxGLManager.removePack(ReactNative.findNodeHandle(this.refs[mapRef]), packName, callback);
+    NativeModules.MapboxGLManager.removePack(findNodeHandle(this.refs[mapRef]), packName, callback);
   },
   setDirectionAnimated(mapRef, heading) {
-    NativeModules.MapboxGLManager.setDirectionAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), heading);
+    NativeModules.MapboxGLManager.setDirectionAnimated(findNodeHandle(this.refs[mapRef]), heading);
   },
   setZoomLevelAnimated(mapRef, zoomLevel) {
-    NativeModules.MapboxGLManager.setZoomLevelAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), zoomLevel);
+    NativeModules.MapboxGLManager.setZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), zoomLevel);
   },
   setCenterCoordinateAnimated(mapRef, latitude, longitude) {
-    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude);
+    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude);
   },
   setCenterCoordinateZoomLevelAnimated(mapRef, latitude, longitude, zoomLevel) {
-    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
+    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
   },
   setCameraAnimated(mapRef, latitude, longitude, fromDistance, pitch, heading, duration) {
-    NativeModules.MapboxGLManager.setCameraAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
+    NativeModules.MapboxGLManager.setCameraAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
   },
   addAnnotations(mapRef, annotations) {
-    NativeModules.MapboxGLManager.addAnnotations(ReactNative.findNodeHandle(this.refs[mapRef]), annotations);
+    NativeModules.MapboxGLManager.addAnnotations(findNodeHandle(this.refs[mapRef]), annotations);
   },
   updateAnnotation(mapRef, annotation) {
-    NativeModules.MapboxGLManager.updateAnnotation(ReactNative.findNodeHandle(this.refs[mapRef]), annotation);
+    NativeModules.MapboxGLManager.updateAnnotation(findNodeHandle(this.refs[mapRef]), annotation);
   },
   selectAnnotationAnimated(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAnnotation(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.removeAnnotation(ReactNative.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    NativeModules.MapboxGLManager.removeAnnotation(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAllAnnotations(mapRef) {
-    NativeModules.MapboxGLManager.removeAllAnnotations(ReactNative.findNodeHandle(this.refs[mapRef]));
+    NativeModules.MapboxGLManager.removeAllAnnotations(findNodeHandle(this.refs[mapRef]));
   },
   setVisibleCoordinateBoundsAnimated(mapRef, latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft) {
-    NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
+    NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
   },
   setUserTrackingMode(mapRef, userTrackingMode) {
-    NativeModules.MapboxGLManager.setUserTrackingMode(ReactNative.findNodeHandle(this.refs[mapRef]), userTrackingMode);
+    NativeModules.MapboxGLManager.setUserTrackingMode(findNodeHandle(this.refs[mapRef]), userTrackingMode);
   },
   getCenterCoordinateZoomLevel(mapRef, callback) {
-    NativeModules.MapboxGLManager.getCenterCoordinateZoomLevel(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getCenterCoordinateZoomLevel(findNodeHandle(this.refs[mapRef]), callback);
   },
   getDirection(mapRef, callback) {
-    NativeModules.MapboxGLManager.getDirection(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getDirection(findNodeHandle(this.refs[mapRef]), callback);
   },
   getBounds(mapRef, callback) {
-    NativeModules.MapboxGLManager.getBounds(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getBounds(findNodeHandle(this.refs[mapRef]), callback);
   },
   mapStyles: NativeModules.MapboxGLManager.mapStyles,
   userTrackingMode: NativeModules.MapboxGLManager.userTrackingMode,

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,62 +1,63 @@
 'use strict';
 
-var React = require('react-native');
-var { NativeModules, requireNativeComponent } = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var { NativeModules, requireNativeComponent } = ReactNative;
 
 var MapMixins = {
   addPackForRegion(mapRef, options) {
-    NativeModules.MapboxGLManager.addPackForRegion(React.findNodeHandle(this.refs[mapRef]), options);
+    NativeModules.MapboxGLManager.addPackForRegion(ReactNative.findNodeHandle(this.refs[mapRef]), options);
   },
   getPacks(mapRef, callback) {
-    NativeModules.MapboxGLManager.getPacks(React.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getPacks(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
   },
   removePack(mapRef, packName, callback) {
-    NativeModules.MapboxGLManager.removePack(React.findNodeHandle(this.refs[mapRef]), packName, callback);
+    NativeModules.MapboxGLManager.removePack(ReactNative.findNodeHandle(this.refs[mapRef]), packName, callback);
   },
   setDirectionAnimated(mapRef, heading) {
-    NativeModules.MapboxGLManager.setDirectionAnimated(React.findNodeHandle(this.refs[mapRef]), heading);
+    NativeModules.MapboxGLManager.setDirectionAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), heading);
   },
   setZoomLevelAnimated(mapRef, zoomLevel) {
-    NativeModules.MapboxGLManager.setZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), zoomLevel);
+    NativeModules.MapboxGLManager.setZoomLevelAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), zoomLevel);
   },
   setCenterCoordinateAnimated(mapRef, latitude, longitude) {
-    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude);
+    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude);
   },
   setCenterCoordinateZoomLevelAnimated(mapRef, latitude, longitude, zoomLevel) {
-    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
+    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
   },
   setCameraAnimated(mapRef, latitude, longitude, fromDistance, pitch, heading, duration) {
-    NativeModules.MapboxGLManager.setCameraAnimated(React.findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
+    NativeModules.MapboxGLManager.setCameraAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
   },
   addAnnotations(mapRef, annotations) {
-    NativeModules.MapboxGLManager.addAnnotations(React.findNodeHandle(this.refs[mapRef]), annotations);
+    NativeModules.MapboxGLManager.addAnnotations(ReactNative.findNodeHandle(this.refs[mapRef]), annotations);
   },
   updateAnnotation(mapRef, annotation) {
-    NativeModules.MapboxGLManager.updateAnnotation(React.findNodeHandle(this.refs[mapRef]), annotation);
+    NativeModules.MapboxGLManager.updateAnnotation(ReactNative.findNodeHandle(this.refs[mapRef]), annotation);
   },
   selectAnnotationAnimated(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(React.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    NativeModules.MapboxGLManager.selectAnnotationAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAnnotation(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.removeAnnotation(React.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    NativeModules.MapboxGLManager.removeAnnotation(ReactNative.findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAllAnnotations(mapRef) {
-    NativeModules.MapboxGLManager.removeAllAnnotations(React.findNodeHandle(this.refs[mapRef]));
+    NativeModules.MapboxGLManager.removeAllAnnotations(ReactNative.findNodeHandle(this.refs[mapRef]));
   },
   setVisibleCoordinateBoundsAnimated(mapRef, latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft) {
-    NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(React.findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
+    NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(ReactNative.findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
   },
   setUserTrackingMode(mapRef, userTrackingMode) {
-    NativeModules.MapboxGLManager.setUserTrackingMode(React.findNodeHandle(this.refs[mapRef]), userTrackingMode);
+    NativeModules.MapboxGLManager.setUserTrackingMode(ReactNative.findNodeHandle(this.refs[mapRef]), userTrackingMode);
   },
   getCenterCoordinateZoomLevel(mapRef, callback) {
-    NativeModules.MapboxGLManager.getCenterCoordinateZoomLevel(React.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getCenterCoordinateZoomLevel(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
   },
   getDirection(mapRef, callback) {
-    NativeModules.MapboxGLManager.getDirection(React.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getDirection(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
   },
   getBounds(mapRef, callback) {
-    NativeModules.MapboxGLManager.getBounds(React.findNodeHandle(this.refs[mapRef]), callback);
+    NativeModules.MapboxGLManager.getBounds(ReactNative.findNodeHandle(this.refs[mapRef]), callback);
   },
   mapStyles: NativeModules.MapboxGLManager.mapStyles,
   userTrackingMode: NativeModules.MapboxGLManager.userTrackingMode,

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,65 +4,67 @@ var React = require('react');
 var ReactNative = require('react-native');
 var { NativeModules, requireNativeComponent, findNodeHandle } = ReactNative;
 
+var { MapboxGLManager } = NativeModules;
+
 var MapMixins = {
   addPackForRegion(mapRef, options) {
-    NativeModules.MapboxGLManager.addPackForRegion(findNodeHandle(this.refs[mapRef]), options);
+    MapboxGLManager.addPackForRegion(findNodeHandle(this.refs[mapRef]), options);
   },
   getPacks(mapRef, callback) {
-    NativeModules.MapboxGLManager.getPacks(findNodeHandle(this.refs[mapRef]), callback);
+    MapboxGLManager.getPacks(findNodeHandle(this.refs[mapRef]), callback);
   },
   removePack(mapRef, packName, callback) {
-    NativeModules.MapboxGLManager.removePack(findNodeHandle(this.refs[mapRef]), packName, callback);
+    MapboxGLManager.removePack(findNodeHandle(this.refs[mapRef]), packName, callback);
   },
   setDirectionAnimated(mapRef, heading) {
-    NativeModules.MapboxGLManager.setDirectionAnimated(findNodeHandle(this.refs[mapRef]), heading);
+    MapboxGLManager.setDirectionAnimated(findNodeHandle(this.refs[mapRef]), heading);
   },
   setZoomLevelAnimated(mapRef, zoomLevel) {
-    NativeModules.MapboxGLManager.setZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), zoomLevel);
+    MapboxGLManager.setZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), zoomLevel);
   },
   setCenterCoordinateAnimated(mapRef, latitude, longitude) {
-    NativeModules.MapboxGLManager.setCenterCoordinateAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude);
+    MapboxGLManager.setCenterCoordinateAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude);
   },
   setCenterCoordinateZoomLevelAnimated(mapRef, latitude, longitude, zoomLevel) {
-    NativeModules.MapboxGLManager.setCenterCoordinateZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
+    MapboxGLManager.setCenterCoordinateZoomLevelAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, zoomLevel);
   },
   setCameraAnimated(mapRef, latitude, longitude, fromDistance, pitch, heading, duration) {
-    NativeModules.MapboxGLManager.setCameraAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
+    MapboxGLManager.setCameraAnimated(findNodeHandle(this.refs[mapRef]), latitude, longitude, fromDistance, pitch, heading, duration);
   },
   addAnnotations(mapRef, annotations) {
-    NativeModules.MapboxGLManager.addAnnotations(findNodeHandle(this.refs[mapRef]), annotations);
+    MapboxGLManager.addAnnotations(findNodeHandle(this.refs[mapRef]), annotations);
   },
   updateAnnotation(mapRef, annotation) {
-    NativeModules.MapboxGLManager.updateAnnotation(findNodeHandle(this.refs[mapRef]), annotation);
+    MapboxGLManager.updateAnnotation(findNodeHandle(this.refs[mapRef]), annotation);
   },
   selectAnnotationAnimated(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.selectAnnotationAnimated(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    MapboxGLManager.selectAnnotationAnimated(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAnnotation(mapRef, selectedIdentifier) {
-    NativeModules.MapboxGLManager.removeAnnotation(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
+    MapboxGLManager.removeAnnotation(findNodeHandle(this.refs[mapRef]), selectedIdentifier);
   },
   removeAllAnnotations(mapRef) {
-    NativeModules.MapboxGLManager.removeAllAnnotations(findNodeHandle(this.refs[mapRef]));
+    MapboxGLManager.removeAllAnnotations(findNodeHandle(this.refs[mapRef]));
   },
   setVisibleCoordinateBoundsAnimated(mapRef, latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft) {
-    NativeModules.MapboxGLManager.setVisibleCoordinateBoundsAnimated(findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
+    MapboxGLManager.setVisibleCoordinateBoundsAnimated(findNodeHandle(this.refs[mapRef]), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft);
   },
   setUserTrackingMode(mapRef, userTrackingMode) {
-    NativeModules.MapboxGLManager.setUserTrackingMode(findNodeHandle(this.refs[mapRef]), userTrackingMode);
+    MapboxGLManager.setUserTrackingMode(findNodeHandle(this.refs[mapRef]), userTrackingMode);
   },
   getCenterCoordinateZoomLevel(mapRef, callback) {
-    NativeModules.MapboxGLManager.getCenterCoordinateZoomLevel(findNodeHandle(this.refs[mapRef]), callback);
+    MapboxGLManager.getCenterCoordinateZoomLevel(findNodeHandle(this.refs[mapRef]), callback);
   },
   getDirection(mapRef, callback) {
-    NativeModules.MapboxGLManager.getDirection(findNodeHandle(this.refs[mapRef]), callback);
+    MapboxGLManager.getDirection(findNodeHandle(this.refs[mapRef]), callback);
   },
   getBounds(mapRef, callback) {
-    NativeModules.MapboxGLManager.getBounds(findNodeHandle(this.refs[mapRef]), callback);
+    MapboxGLManager.getBounds(findNodeHandle(this.refs[mapRef]), callback);
   },
-  mapStyles: NativeModules.MapboxGLManager.mapStyles,
-  userTrackingMode: NativeModules.MapboxGLManager.userTrackingMode,
-  userLocationVerticalAlignment: NativeModules.MapboxGLManager.userLocationVerticalAlignment,
-  unknownResourceCount: NativeModules.MapboxGLManager.unknownResourceCount
+  mapStyles: MapboxGLManager.mapStyles,
+  userTrackingMode: MapboxGLManager.userTrackingMode,
+  userLocationVerticalAlignment: MapboxGLManager.userLocationVerticalAlignment,
+  unknownResourceCount: MapboxGLManager.unknownResourceCount
 };
 
 var MapView = React.createClass({


### PR DESCRIPTION
Hey I opened this issue #344 yesterday about adding support for react-native 0.25 and up. I updated only the iOS part so you can take a look at what I did and tell me if you like the changes. I would of course update the android part too before the PR would be merged in.

I also did some refactoring of the code. Extract PropTypes, findNodeHandle (I did everything in separate commits so you can easily take a look at what I changed)
