### PR TITLE
fix: defaultProps method name for android

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -57,7 +57,7 @@ var ReactMapViewWrapper = React.createClass({
   statics: {
     Mixin: MapMixins
   },
-  defaultProps() {
+  getDefaultProps() {
     return {
       centerCoordinate: {
         latitude: 0,


### PR DESCRIPTION
ref.
https://facebook.github.io/react/docs/reusable-components.html#default-prop-values
