### PR TITLE
fix(event): fix #356 onRegionChange is not getting called

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -1,6 +1,8 @@
 
 package com.mapbox.reactnativemapboxgl;
 
+import java.util.Map;
+
 import android.graphics.Color;
 import android.util.Log;
 import android.os.StrictMode;
@@ -11,6 +13,8 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.mapbox.mapboxsdk.annotations.Marker;
@@ -68,6 +72,16 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
     @Override
     public String getName() {
         return REACT_CLASS;
+    }
+
+    @Override
+    public @Nullable Map getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.of(
+            PROP_ONREGIONCHANGE, MapBuilder.of("registrationName", PROP_ONREGIONCHANGE),
+            PROP_ONUSER_LOCATION_CHANGE, MapBuilder.of("registrationName", PROP_ONUSER_LOCATION_CHANGE),
+            PROP_ONLONGPRESS, MapBuilder.of("registrationName", PROP_ONLONGPRESS),
+            PROP_ONOPENANNOTATION, MapBuilder.of("registrationName", PROP_ONOPENANNOTATION)
+        );
     }
 
     @Override
@@ -239,8 +253,8 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                     event.putMap("src", location);
                     ReactContext reactContext = (ReactContext) view.getContext();
                     reactContext
-                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit("onRegionChange", event);
+                            .getJSModule(RCTEventEmitter.class)
+                            .receiveEvent(view.getId(), PROP_ONREGIONCHANGE, event);
                 }
             }
         });
@@ -263,8 +277,8 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                 event.putMap("src", locationMap);
                 ReactContext reactContext = (ReactContext) view.getContext();
                 reactContext
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit("onUserLocationChange", event);
+                        .getJSModule(RCTEventEmitter.class)
+                        .receiveEvent(view.getId(), PROP_ONUSER_LOCATION_CHANGE, event);
             }
         });
     }
@@ -283,8 +297,8 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                 event.putMap("src", markerObject);
                 ReactContext reactContext = (ReactContext) view.getContext();
                 reactContext
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit("onOpenAnnotation", event);
+                        .getJSModule(RCTEventEmitter.class)
+                        .receiveEvent(view.getId(), PROP_ONOPENANNOTATION, event);
                 return false;
             }
         });
@@ -302,8 +316,8 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<MapView> {
                 event.putMap("src", loc);
                 ReactContext reactContext = (ReactContext) view.getContext();
                 reactContext
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit("onLongPress", event);
+                        .getJSModule(RCTEventEmitter.class)
+                        .receiveEvent(view.getId(), PROP_ONLONGPRESS, event);
             }
         });
     }

--- a/index.android.js
+++ b/index.android.js
@@ -3,7 +3,7 @@
 var React = require('react');
 var { PropTypes } = React;
 var ReactNative = require('react-native');
-var { NativeModules, requireNativeComponent, findNodeHandle } = ReactNative;
+var { NativeModules, requireNativeComponent, findNodeHandle, View } = ReactNative;
 var { MapboxGLManager } = NativeModules;
 
 var MapMixins = {
@@ -53,7 +53,7 @@ var MapMixins = {
   userTrackingMode: MapboxGLManager.userTrackingMode
 };
 
-var ReactMapViewWrapper = React.createClass({
+var MapView = React.createClass({
   statics: {
     Mixin: MapMixins
   },
@@ -108,32 +108,34 @@ var ReactMapViewWrapper = React.createClass({
     onRegionChange: PropTypes.func,
     onOpenAnnotation: PropTypes.func,
     onLongPress: PropTypes.func,
-    onUserLocationChange: PropTypes.func
+    onUserLocationChange: PropTypes.func,
+    ...View.propTypes,
   },
-  handleOnChange(event) {
-    if (this.props.onRegionChange) this.props.onRegionChange(event);
+  _onRegionChange(event: Event) {
+    if (this.props.onRegionChange) this.props.onRegionChange(event.nativeEvent.src);
   },
-  handleUserLocation(event) {
-    if (this.props.onUserLocationChange) this.props.onUserLocationChange(event);
+  _onUserLocationChange(event: Event) {
+    if (this.props.onUserLocationChange) this.props.onUserLocationChange(event.nativeEvent.src);
   },
-  handleOnOpenAnnotation(event) {
-    if (this.props.onOpenAnnotation) this.props.onOpenAnnotation(event);
+  _onOpenAnnotation(event: Event) {
+    if (this.props.onOpenAnnotation) this.props.onOpenAnnotation(event.nativeEvent.src);
   },
-  handleOnLongPress(event) {
-    if (this.props.onLongPress) this.props.onLongPress(event);
+  _onLongPress(event: Event) {
+    if (this.props.onLongPress) this.props.onLongPress(event.nativeEvent.src);
   },
   render() {
     return (
-      <ReactMapView
-        onRegionChange={this.handleOnChange}
-        onUserLocationChange={this.handleUserLocation}
-        onOpenAnnotation={this.handleOnOpenAnnotation}
-        onLongPress={this.handleOnLongPress}
-        {...this.props} />
+      <MapboxGLView
+        {...this.props}
+        onRegionChange={this._onRegionChange}
+        onUserLocationChange={this._onUserLocationChange}
+        onOpenAnnotation={this._onOpenAnnotation}
+        onLongPress={this._onLongPress}
+      />
     );
   }
 });
 
-var ReactMapView = requireNativeComponent('RCTMapbox');
+var MapboxGLView = requireNativeComponent('RCTMapbox', MapView);
 
-module.exports = ReactMapViewWrapper;
+module.exports = MapView;


### PR DESCRIPTION
http://facebook.github.io/react-native/docs/native-components-android.html#events

but for "custom events" (events that are not pre-defined likes onLoad, onScroll, etc..) you will also need to override getExportedCustomDirectEventTypeConstants.

as this line.
https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPagerManager.java#L58
