### PR TITLE
fix #170: preinstall downloads iOS SDK only on Mac. Adds Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "preinstall": "./scripts/download-mapbox-gl-native-ios.sh 3.2.0",
+    "preinstall": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.2.0",
     "test": "npm run lint",
     "lint": "eslint --no-eslintrc -c .eslintrc index.ios.js index.android.js ios/example.js android/example.js"
   },

--- a/scripts/download-mapbox-gl-native-ios-if-on-mac.js
+++ b/scripts/download-mapbox-gl-native-ios-if-on-mac.js
@@ -1,0 +1,15 @@
+var version = process.argv[2];
+
+// only download iOS SDK if on Mac OS
+if (process.platform === 'darwin') {
+  var exec = require('child_process').exec;
+  var cmd = './scripts/download-mapbox-gl-native-ios.sh ' + version;
+  exec(cmd, function(error, stdout, stderr) {
+    if (error) {
+      console.error(error);
+      return;
+    }
+    console.log(stdout);
+    console.log(stderr);
+  });
+}


### PR DESCRIPTION
This change allows the package to be installed on Windows, since Windows would choke up on using the `.sh` download script. Also, since it now only downloads the iOS SDK when on Mac, it doesn't unnecessarily install the SDK when on Linux.
