### PR TITLE
Removing iOS in the title

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-# iOS API Docs
+# API Docs
 
 ## Access token
 


### PR DESCRIPTION
API Docs should now be merged between the two platforms. Removing the iOS designation from the title. Could make new users confused.
