### PR TITLE
Feature: Get bounds for positions

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,6 +204,9 @@ class MapView extends Component {
   getBounds(callback) {
     MapboxGLManager.getBounds(findNodeHandle(this), callback);
   }
+  getBoundsForPositions(positions, callback) {
+    MapboxGLManager.getBoundsForPositions(findNodeHandle(this), positions, callback);
+  }
   getPitch(callback) {
     MapboxGLManager.getPitch(findNodeHandle(this), callback);
   }


### PR DESCRIPTION
# Get bounds for positions

I've added a method which gets the bounding rectangle in GPS coordinates for an array of positions.
## Why?

I have a use case where I have a set of markers on the map and I want to adjust the camera position and zoom level to display all the markers + the user's current location on the map. 

At first, I created a high-level method which determined the bounding box using `LatLngBounds` but also used the `view.setCameraUpdate` method. I eventually decided to implement a more low-level method which focuses just on calculating and returning the bounds. This can be combined with the already available method `setVisibleCoordinateBounds`. 
## Feedback

I'd like to get feedback on the implemented method first before I add it to the documentation. I'd also require some help with the iOS implementation since I'm not familiar with Objective-C.
