### PR TITLE
Use class methods instead of static properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,22 @@ function addOfflineErrorListener(handler) {
 }
 
 class MapView extends Component {
+  constructor(props) {
+    super(props);
+
+    this._onRegionDidChange = this._onRegionDidChange.bind(this);
+    this._onRegionWillChange = this._onRegionWillChange.bind(this);
+    this._onOpenAnnotation = this._onOpenAnnotation.bind(this);
+    this._onRightAnnotationTapped = this._onRightAnnotationTapped.bind(this);
+    this._onChangeUserTrackingMode = this._onChangeUserTrackingMode.bind(this);
+    this._onUpdateUserLocation = this._onUpdateUserLocation.bind(this);
+    this._onLongPress = this._onLongPress.bind(this);
+    this._onTap = this._onTap.bind(this);
+    this._onFinishLoadingMap = this._onFinishLoadingMap.bind(this);
+    this._onStartLoadingMap = this._onStartLoadingMap.bind(this);
+    this._onLocateUserFailed = this._onLocateUserFailed.bind(this);
+    this._onNativeComponentMount = this._onNativeComponentMount.bind(this);
+  }
 
   // Viewport setters
   setDirection(direction, animated = true, callback) {
@@ -214,39 +230,39 @@ class MapView extends Component {
   }
 
   // Events
-  _onRegionDidChange = (event: Event) => {
+  _onRegionDidChange(event: Event) {
     if (this.props.onRegionDidChange) this.props.onRegionDidChange(event.nativeEvent.src);
-  };
-  _onRegionWillChange = (event: Event) => {
+  }
+  _onRegionWillChange(event: Event) {
     if (this.props.onRegionWillChange) this.props.onRegionWillChange(event.nativeEvent.src);
-  };
-  _onOpenAnnotation = (event: Event) => {
+  }
+  _onOpenAnnotation(event: Event) {
     if (this.props.onOpenAnnotation) this.props.onOpenAnnotation(event.nativeEvent.src);
-  };
-  _onRightAnnotationTapped = (event: Event) => {
+  }
+  _onRightAnnotationTapped(event: Event) {
     if (this.props.onRightAnnotationTapped) this.props.onRightAnnotationTapped(event.nativeEvent.src);
-  };
-  _onChangeUserTrackingMode = (event: Event) => {
+  }
+  _onChangeUserTrackingMode(event: Event) {
     if (this.props.onChangeUserTrackingMode) this.props.onChangeUserTrackingMode(event.nativeEvent.src);
-  };
-  _onUpdateUserLocation = (event: Event) => {
+  }
+  _onUpdateUserLocation(event: Event) {
     if (this.props.onUpdateUserLocation) this.props.onUpdateUserLocation(event.nativeEvent.src);
-  };
-  _onLongPress = (event: Event) => {
+  }
+  _onLongPress(event: Event) {
     if (this.props.onLongPress) this.props.onLongPress(event.nativeEvent.src);
-  };
-  _onTap = (event: Event) => {
+  }
+  _onTap(event: Event) {
     if (this.props.onTap) this.props.onTap(event.nativeEvent.src);
-  };
-  _onFinishLoadingMap = (event: Event) => {
+  }
+  _onFinishLoadingMap(event: Event) {
     if (this.props.onFinishLoadingMap) this.props.onFinishLoadingMap(event.nativeEvent.src);
-  };
-  _onStartLoadingMap = (event: Event) => {
+  }
+  _onStartLoadingMap(event: Event) {
     if (this.props.onStartLoadingMap) this.props.onStartLoadingMap(event.nativeEvent.src);
-  };
-  _onLocateUserFailed = (event: Event) => {
+  }
+  _onLocateUserFailed(event: Event) {
     if (this.props.onLocateUserFailed) this.props.onLocateUserFailed(event.nativeEvent.src);
-  };
+  }
 
   static propTypes = {
     ...View.propTypes,
@@ -363,7 +379,7 @@ class MapView extends Component {
 
   _native = null;
 
-  _onNativeComponentMount = (ref) => {
+  _onNativeComponentMount(ref) {
     if (this._native === ref) { return; }
     this._native = ref;
 
@@ -375,7 +391,7 @@ class MapView extends Component {
       acc[annotation.id] = isImmutable ? annotation : cloneDeep(annotation);
       return acc;
     }, {});
-  };
+  }
 
   setNativeProps(nativeProps) {
     this._native && this._native.setNativeProps(nativeProps);


### PR DESCRIPTION
The `this` reference used in the static properties like `_onNativeComponentMount` and `_onRegionDidChange` is undefined when using it in combination with the react-relay and babel-relay-plugin (both version 0.9.2). Before adding react-relay to our project everything was working fine but as soon as we switched to Relay with the use of the babel-relay-plugin the errors started occurring as soon as the MapView is loaded.

The `babel-preset-react-native` plugin that we use (version 1.9.0) does support the babel transformer `transform-class-properties` which should take care of `this` bindings in static properties but it does not work for files residing in the node_modules folder. 

The solution was to change all the static properties to methods and add a constructor to do the `this` binding manually. Another solution would be to distribute a "babelified" version of the index.js when publishing to npm as is described [here](http://blog.xebia.com/publishing-es6-code-to-npm/). I'm willing to create a PR to support this.
