### PR TITLE
Adding queryRenderedFeatures on iOS

### DIFF
--- a/API.md
+++ b/API.md
@@ -183,6 +183,32 @@ Selects the annotation tagged with `id`, as if it would be tapped by the user.
 
 The transition is animated unless you pass `animated` as `false`.
 
+---
+
+```javascript
+this._map.queryRenderedFeatures({
+  point: { // required if rect not defined. Point on screen
+    screenCoordX: 287,
+    screenCoordY: 493
+  },
+  rect: { // required if point not defined. Dimensions of rectangle on screen
+    left: 267,
+    top: 473,
+    right: 307,
+    bottom: 513
+  },
+  layers: ['building'] // optional. Array of layer names
+},
+callback // optional. Alternative to returned promise
+);
+```
+
+Queries the features in the vector tiles at given `point` or `rect`. (iOS only - Android SDK's `queryRenderedFeatures` is in beta)
+
+All layers are queried unless you pass an array of layer names into `layers`.
+
+This method returns a promise that resolves with an array of GeoJSON features. It also optionally takes a `callback` as a second parameter with the signature `(err, features) => {}`.
+
 ## Styles
 
 #### Default styles

--- a/index.js
+++ b/index.js
@@ -212,6 +212,9 @@ class MapView extends Component {
   selectAnnotation(annotationId, animated = true) {
     MapboxGLManager.selectAnnotation(findNodeHandle(this), annotationId, animated);
   }
+  queryRenderedFeatures(options, callback) {
+    MapboxGLManager.queryRenderedFeatures(findNodeHandle(this), options, callback);
+  }
 
   // Events
   _onRegionDidChange = (event: Event) => {

--- a/index.js
+++ b/index.js
@@ -212,8 +212,15 @@ class MapView extends Component {
   selectAnnotation(annotationId, animated = true) {
     MapboxGLManager.selectAnnotation(findNodeHandle(this), annotationId, animated);
   }
-  queryRenderedFeatures(options) {
-    return MapboxGLManager.queryRenderedFeatures(findNodeHandle(this), options);
+  queryRenderedFeatures(options, callback) {
+    let promise;
+    if (Platform.OS === 'android') {
+      promise = Promise.reject('queryRenderedFeatures() is not yet implemented on Android');
+    } else {
+      promise = MapboxGLManager.queryRenderedFeatures(findNodeHandle(this), options);
+    }
+    bindCallbackToPromise(callback, promise);
+    return promise;
   }
 
   // Events

--- a/index.js
+++ b/index.js
@@ -212,8 +212,8 @@ class MapView extends Component {
   selectAnnotation(annotationId, animated = true) {
     MapboxGLManager.selectAnnotation(findNodeHandle(this), annotationId, animated);
   }
-  queryRenderedFeatures(options, callback) {
-    MapboxGLManager.queryRenderedFeatures(findNodeHandle(this), options, callback);
+  queryRenderedFeatures(options) {
+    return MapboxGLManager.queryRenderedFeatures(findNodeHandle(this), options);
   }
 
   // Events

--- a/ios/RCTMapboxGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMapboxGL.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		C5DBB3461AF2EF2B00E611A9 /* RCTMapboxGL.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DBB3451AF2EF2B00E611A9 /* RCTMapboxGL.m */; };
 		C5DBB34C1AF2EF2B00E611A9 /* libRCTMapboxGL.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DBB3401AF2EF2B00E611A9 /* libRCTMapboxGL.a */; };
 		C5DBB3661AF2EFB500E611A9 /* RCTMapboxGLManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DBB3651AF2EFB500E611A9 /* RCTMapboxGLManager.m */; };
+		CB7CB11F1F5092CD30562E07 /* MGLPolyline+RCTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7CBE434C8597B1509C3FCA /* MGLPolyline+RCTAdditions.m */; };
+		CB7CB49F42C4A55593F71A37 /* MGLPolygon+RCTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +49,10 @@
 		C5DBB3511AF2EF2B00E611A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C5DBB3641AF2EFB500E611A9 /* RCTMapboxGLManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMapboxGLManager.h; sourceTree = "<group>"; };
 		C5DBB3651AF2EFB500E611A9 /* RCTMapboxGLManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMapboxGLManager.m; sourceTree = "<group>"; };
+		CB7CB655DADBFA72D7B5EB33 /* MGLPolygon+RCTAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolygon+RCTAdditions.h"; sourceTree = "<group>"; };
+		CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolygon+RCTAdditions.m"; sourceTree = "<group>"; };
+		CB7CBC3A586F235841D94946 /* MGLPolyline+RCTAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolyline+RCTAdditions.h"; sourceTree = "<group>"; };
+		CB7CBE434C8597B1509C3FCA /* MGLPolyline+RCTAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolyline+RCTAdditions.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +101,10 @@
 				C5DBB3651AF2EFB500E611A9 /* RCTMapboxGLManager.m */,
 				C167F89A1D18111F007C7A42 /* RCTMapboxGLConversions.h */,
 				C167F89B1D18112B007C7A42 /* RCTMapboxGLConversions.m */,
+				CB7CBE434C8597B1509C3FCA /* MGLPolyline+RCTAdditions.m */,
+				CB7CBC3A586F235841D94946 /* MGLPolyline+RCTAdditions.h */,
+				CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */,
+				CB7CB655DADBFA72D7B5EB33 /* MGLPolygon+RCTAdditions.h */,
 			);
 			path = RCTMapboxGL;
 			sourceTree = "<group>";
@@ -206,6 +216,8 @@
 				C5DBB3461AF2EF2B00E611A9 /* RCTMapboxGL.m in Sources */,
 				C5DBB3661AF2EFB500E611A9 /* RCTMapboxGLManager.m in Sources */,
 				C167F89C1D18112B007C7A42 /* RCTMapboxGLConversions.m in Sources */,
+				CB7CB11F1F5092CD30562E07 /* MGLPolyline+RCTAdditions.m in Sources */,
+				CB7CB49F42C4A55593F71A37 /* MGLPolygon+RCTAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RCTMapboxGL/MGLPolygon+RCTAdditions.h
+++ b/ios/RCTMapboxGL/MGLPolygon+RCTAdditions.h
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2016 Mapbox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Mapbox/Mapbox.h>
+
+@interface MGLPolygon (RCTAdditions)
+- (NSMutableArray *)coordinateArray;
+@end

--- a/ios/RCTMapboxGL/MGLPolygon+RCTAdditions.m
+++ b/ios/RCTMapboxGL/MGLPolygon+RCTAdditions.m
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Mapbox. All rights reserved.
+//
+
+#import "MGLPolygon+RCTAdditions.h"
+
+
+@implementation MGLPolygon (RCTAdditions)
+
+- (NSMutableArray *)coordinateArray
+{
+    NSMutableArray *coordinates = [[NSMutableArray alloc] init];
+
+    NSMutableArray *outerRingCoordinates = [[NSMutableArray alloc] init];
+    for (int index = 0; index < self.pointCount; index++) {
+        CLLocationCoordinate2D coord = self.coordinates[index];
+        [outerRingCoordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
+    }
+    [coordinates addObject:outerRingCoordinates];
+
+    for (MGLPolygon *interiorRing in self.interiorPolygons) {
+        NSMutableArray *interiorRingCoordinates = [[NSMutableArray alloc] init];
+        for (int index = 0; index < interiorRing.pointCount; index++) {
+            CLLocationCoordinate2D coord = interiorRing.coordinates[index];
+            [interiorRingCoordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
+        }
+        [coordinates addObject:interiorRingCoordinates];
+    }
+    return coordinates;
+}
+@end

--- a/ios/RCTMapboxGL/MGLPolyline+RCTAdditions.h
+++ b/ios/RCTMapboxGL/MGLPolyline+RCTAdditions.h
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2016 Mapbox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Mapbox/Mapbox.h>
+
+@interface MGLPolyline (RCTAdditions)
+- (NSMutableArray *)coordinateArray;
+@end

--- a/ios/RCTMapboxGL/MGLPolyline+RCTAdditions.m
+++ b/ios/RCTMapboxGL/MGLPolyline+RCTAdditions.m
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2016 Mapbox. All rights reserved.
+//
+
+#import "MGLPolyline+RCTAdditions.h"
+
+
+@implementation MGLPolyline (RCTAdditions)
+
+- (NSMutableArray *)coordinateArray
+{
+    NSMutableArray *coordinates = [[NSMutableArray alloc] init];
+    for (int index = 0; index < self.pointCount; index++) {
+        CLLocationCoordinate2D coord = self.coordinates[index];
+        [coordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
+    }
+    return coordinates;
+}
+
+@end

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -38,8 +38,8 @@
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))handler;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)selectAnnotation:(NSString*)selectedId animated:(BOOL)animated;
-- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point;
 - (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point inStyleLayersWithIdentifiers:(nullable NSSet<NSString *> *)styleLayerIdentifiers;
+- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesInRect:(CGRect)rect inStyleLayersWithIdentifiers:(nullable NSSet<NSString *> *)identifiers;
 
 // Annotation management
 - (void)upsertAnnotation:(NSObject *)annotation;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -38,7 +38,8 @@
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))handler;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)selectAnnotation:(NSString*)selectedId animated:(BOOL)animated;
-- (NSArray *)visibleFeaturesAtPoint:(CGPoint)point;
+- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point;
+- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point inStyleLayersWithIdentifiers:(nullable NSSet<NSString *> *)styleLayerIdentifiers;
 
 // Annotation management
 - (void)upsertAnnotation:(NSObject *)annotation;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -38,6 +38,7 @@
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))handler;
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)padding animated:(BOOL)animated;
 - (void)selectAnnotation:(NSString*)selectedId animated:(BOOL)animated;
+- (NSArray *)visibleFeaturesAtPoint:(CGPoint)point;
 
 // Annotation management
 - (void)upsertAnnotation:(NSObject *)annotation;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -539,15 +539,15 @@
                                @"screenCoordX": @(screenCoord.x) } });
 }
 
- - (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point
- {
-     return [_map visibleFeaturesAtPoint:point];
- }
-
 - (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point
                                inStyleLayersWithIdentifiers:(nullable NSSet<NSString *> *)styleLayerIdentifiers
 {
     return [_map visibleFeaturesAtPoint:point inStyleLayersWithIdentifiers:styleLayerIdentifiers];
+}
+
+- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesInRect:(CGRect)rect inStyleLayersWithIdentifiers:(NSSet<NSString *> *)identifiers
+{
+    return [_map visibleFeaturesInRect:rect inStyleLayersWithIdentifiers:identifiers];
 }
 
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -539,13 +539,16 @@
                                @"screenCoordX": @(screenCoord.x) } });
 }
 
- - (NSArray *)visibleFeaturesAtPoint:(CGPoint)point
+ - (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point
  {
-     // This is failing with:
-     // Exception thrown while executing UI block: -[MGLMapView visibleFeaturesAtPoint:]:
-     // unrecognized selector sent to instance
      return [_map visibleFeaturesAtPoint:point];
  }
+
+- (nonnull NSArray<id<MGLFeature>> *)visibleFeaturesAtPoint:(CGPoint)point
+                               inStyleLayersWithIdentifiers:(nullable NSSet<NSString *> *)styleLayerIdentifiers
+{
+    return [_map visibleFeaturesAtPoint:point inStyleLayersWithIdentifiers:styleLayerIdentifiers];
+}
 
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView
 {

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -539,6 +539,14 @@
                                @"screenCoordX": @(screenCoord.x) } });
 }
 
+ - (NSArray *)visibleFeaturesAtPoint:(CGPoint)point
+ {
+     // This is failing with:
+     // Exception thrown while executing UI block: -[MGLMapView visibleFeaturesAtPoint:]:
+     // unrecognized selector sent to instance
+     return [_map visibleFeaturesAtPoint:point];
+ }
+
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView
 {
     if (!_onFinishLoadingMap) { return; }

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -605,4 +605,31 @@ RCT_EXPORT_METHOD(selectAnnotation:(nonnull NSNumber *) reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
+                  options:(NSDictionary *)options
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
+        RCTMapboxGL *mapView = viewRegistry[reactTag];
+        if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
+            NSNumber *screenCoordX = options[@"screenCoordX"];
+            NSNumber *screenCoordY = options[@"screenCoordY"];
+            if (!screenCoordX || !screenCoordY) {
+                // TODO: figure out best way to error this. Should we be using RCTPromise rather than a callback?
+//                reject(@"invalid_arguments", @"queryRenderedFeatures(): screenCoordX and screenCoordY are required.", nil);
+                return;
+            }
+            CGPoint point = CGPointMake(screenCoordX.floatValue, screenCoordY.floatValue);
+
+            NSArray * features = [mapView visibleFeaturesAtPoint:point];
+
+            // TODO: also accept Rect to use [mapView visibleFeaturesInRect:]
+
+            // TODO: convert features to JS friendly objects
+
+            callback(features);
+        }
+    }];
+}
+
 @end

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -650,7 +650,7 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
                     coordinates = (NSMutableArray *) @[@(feature.coordinate.longitude), @(feature.coordinate.latitude)];
                 } else if ([feature isKindOfClass:[MGLPolylineFeature class]]) {
                     geometryType = @"LineString";
-                    MGLPolyline *polyline = (MGLPolyline *)feature;
+                    MGLPolylineFeature *polyline = (MGLPolylineFeature *)feature;
                     for (int index = 0; index < polyline.pointCount; index++) {
                         CLLocationCoordinate2D coord = polyline.coordinates[index];
                         [coordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
@@ -675,6 +675,12 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
                             [interiorRingCoordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
                         }
                         [coordinates addObject:interiorRingCoordinates];
+                    }
+                } else if ([feature isKindOfClass:[MGLMultiPointFeature class]]) {
+                    MGLMultiPointFeature *multiPoint = (MGLMultiPointFeature *)feature;
+                    for (int index = 0; index < multiPoint.pointCount; index++) {
+                        CLLocationCoordinate2D coord = multiPoint.coordinates[index];
+                        [coordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
                     }
                 }
                 // TODO: checks for MGLMultiPolyline and MGLMultiPolygon

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -648,20 +648,34 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
                 if ([feature isKindOfClass:[MGLPointFeature class]]) {
                     geometryType = @"Point";
                     coordinates = (NSMutableArray *) @[@(feature.coordinate.longitude), @(feature.coordinate.latitude)];
-                } else if ([feature isKindOfClass:[MGLPolyline class]]) {
-                    MGLMultiPoint *multiPoint = (MGLMultiPoint *)feature;
-                    for (int index = 0; index < multiPoint.pointCount; index++) {
-                        CLLocationCoordinate2D coord = multiPoint.coordinates[index];
-                        [coordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
-                    }
+                } else if ([feature isKindOfClass:[MGLPolylineFeature class]]) {
                     geometryType = @"LineString";
-                } else if ([feature isKindOfClass:[MGLPolygon class]]) {
-                    MGLMultiPoint *multiPoint = (MGLMultiPoint *)feature;
-                    for (int index = 0; index < multiPoint.pointCount; index++) {
-                        CLLocationCoordinate2D coord = multiPoint.coordinates[index];
+                    MGLPolyline *polyline = (MGLPolyline *)feature;
+                    for (int index = 0; index < polyline.pointCount; index++) {
+                        CLLocationCoordinate2D coord = polyline.coordinates[index];
                         [coordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
                     }
+                } else if ([feature isKindOfClass:[MGLPolygonFeature class]]) {
                     geometryType = @"Polygon";
+                    MGLPolygonFeature *polygon = (MGLPolygonFeature *)feature;
+
+                    // first add outer polygon ring coordinate array
+                    NSMutableArray *outerRingCoordinates = [[NSMutableArray alloc] init];
+                    for (int index = 0; index < polygon.pointCount; index++) {
+                        CLLocationCoordinate2D coord = polygon.coordinates[index];
+                        [outerRingCoordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
+                    }
+                    [coordinates addObject:outerRingCoordinates];
+
+                    // then add any interior rings
+                    for (MGLPolygon *interiorRing in polygon.interiorPolygons) {
+                        NSMutableArray *interiorRingCoordinates = [[NSMutableArray alloc] init];
+                        for (int index = 0; index < interiorRing.pointCount; index++) {
+                            CLLocationCoordinate2D coord = interiorRing.coordinates[index];
+                            [interiorRingCoordinates addObject:@[@(coord.longitude), @(coord.latitude)]];
+                        }
+                        [coordinates addObject:interiorRingCoordinates];
+                    }
                 }
                 // TODO: checks for MGLMultiPolyline and MGLMultiPolygon
 

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -645,6 +645,7 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
 
                 NSDictionary *geoJSON = @{
                         @"type": @"Feature",
+                        @"id": feature.identifier ? feature.identifier : [NSNull null],
                         @"properties": feature.attributes,
                         @"geometry": geoJSONGeometry
                 };

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -621,20 +621,15 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
             }
             NSNumber *screenCoordX = pointDict[@"screenCoordX"];
             NSNumber *screenCoordY = pointDict[@"screenCoordY"];
-            NSSet<NSString *> *styleLayerIdentifiers = options[@"layers"];
-
-            CLLocationCoordinate2D location = [_map convertPoint:[sender locationInView:_map] toCoordinateFromView:_map];
-            CGPoint screenCoord = [sender locationInView:_map];
-
+            NSArray<NSString *> *styleLayerIdentifiersArray = options[@"layers"];
+            NSSet<NSString *> *styleLayerIdentifiers;
+            if (styleLayerIdentifiersArray) {
+                styleLayerIdentifiers = [NSSet setWithArray:styleLayerIdentifiersArray];
+            }
 
             CGPoint point = CGPointMake(screenCoordX.floatValue, screenCoordY.floatValue);
 
-            NSArray *features;
-            if (!styleLayerIdentifiers) {
-                features = [mapView visibleFeaturesAtPoint:point];
-            } else {
-                features = [mapView visibleFeaturesAtPoint:point inStyleLayersWithIdentifiers:styleLayerIdentifiers];
-            }
+            NSArray *features = [mapView visibleFeaturesAtPoint:point inStyleLayersWithIdentifiers:styleLayerIdentifiers];
 
             NSDictionary *geoJSONTypesByMGLClassName = @{
                     @"MGLPointFeature": @"Point",


### PR DESCRIPTION
I'm trying to make a PR adding `queryRenderedFeatures` support (or `visibleFeaturesAtPoint` and `visibleFeaturesInRect` on iOS), and I need some feedback.

I have the bridge set up to properly send the screen coordinate from JS to Obj C. However, it's failing on line 547 of RCTMapboxGL.m with `Exception thrown while executing UI block: -[MGLMapView visibleFeaturesAtPoint:]: unrecognized selector sent to instance`. I can't figure out why it's giving me this issue. I apologize if this is a simple issue I've overlooked - this is my first time writing React Native bridge code.

I also want feedback on the name and signature on the method. On iOS, it's called `visibleFeaturesAtPoint` and `visibleFeaturesInRect`, and on Android it's called `queryRenderedFeatures`. I'm planning on calling it `queryRenderedFeatures`, and allow passing in either a point or a rect.
