### PR TITLE
[Android] Make remote images for annotations work

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
@@ -7,6 +7,8 @@ import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.v4.content.ContextCompat;
+import android.os.AsyncTask;
+import android.util.Log;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
@@ -88,13 +90,29 @@ public class RNMGLAnnotationOptionsFactory {
     }
 
     static Drawable drawableFromUrl(Context context, String url) throws IOException {
-        // This doesn't currently work, as it throws NetworkOnMainThreadException
-        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-        connection.connect();
-        InputStream input = connection.getInputStream();
+        try {
+            Bitmap bitmap = new RetrieveDrawableFromUrl().execute(url).get();
 
-        Bitmap bitmap = BitmapFactory.decodeStream(input);
-        return new BitmapDrawable(context.getResources(), bitmap);
+            return new BitmapDrawable(context.getResources(), bitmap);
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static class RetrieveDrawableFromUrl extends AsyncTask<String, Void, Bitmap> {
+        protected Bitmap doInBackground(String... url) {
+            try {
+                HttpURLConnection connection = (HttpURLConnection) new URL(url[0]).openConnection();
+                connection.connect();
+                InputStream input = connection.getInputStream();
+
+                return BitmapFactory.decodeStream(input);
+            }
+            catch (Exception e) {
+                return null;
+            }
+        }
     }
 
     static Map<String, Icon> iconCache = new HashMap();

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
@@ -11,6 +11,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableArray;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
@@ -195,11 +196,19 @@ public class RNMGLAnnotationOptionsFactory {
     static RNMGLAnnotationOptions polylineOptionsFromJS(ReadableMap annotation) {
         PolylineOptions polyline = new PolylineOptions();
 
-        int coordSize = annotation.getArray("coordinates").size();
-        for (int p = 0; p < coordSize; p++) {
-            double latitude = annotation.getArray("coordinates").getArray(p).getDouble(0);
-            double longitude = annotation.getArray("coordinates").getArray(p).getDouble(1);
-            polyline.add(new LatLng(latitude, longitude));
+        ReadableArray coordinates = annotation.getArray("coordinates");
+        int coordinatesSize = coordinates.size();
+        if (coordinatesSize > 0) {
+            LatLng[] points = new LatLng[coordinatesSize];
+            ReadableArray coordinate;
+            for (int p = 0; p < coordinatesSize; p++) {
+                coordinate = coordinates.getArray(p);
+                points[p] = new LatLng(
+                    coordinate.getDouble(0),
+                    coordinate.getDouble(1)
+                );
+            }
+            polyline.add(points);
         }
 
         if (annotation.hasKey("alpha")) {


### PR DESCRIPTION
I have done some testing and this appears to make remote images on annotations work for my use case at least. I am currently just returning null in the event of an exception - not sure what the preference here would be. I could catch it at the top level and try and pull it from a drawable name possibly but I don't know that makes much sense. Let me know any tweaks you guys want!

Resolves #391 
