### PR TITLE
Add MarkerView annotation

### DIFF
--- a/API.md
+++ b/API.md
@@ -256,7 +256,7 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
 ```javascript
 [{
   coordinates, // required. For type polyline and polygon must be an array of arrays. For type point, single array with 2 coordinates
-  type, // required. One of 'point', 'polyline' or 'polygon'
+  type, // required. One of 'point', 'view', 'polyline' or 'polygon'
   title, // optional. Title string. Appears when marker pressed
   subtitle, // optional. Subtitle string. Appears when marker pressed
   fillAlpha, // optional. number. Only for type=polygon. Controls the opacity of the polygon
@@ -264,6 +264,10 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
   strokeAlpha, // optional. number. Only for type=polygon or type=polyline. Controls the opacity of the line
   strokeColor, // optional. string. Only for type=polygon or type=polyline. CSS color (#rrggbb). Controls line color.
   strokeWidth, // optional. number. Only for type=polygon or type=polyline. Controls line width.
+  alpha, // optional. number. Only for type=view. Sets the marker icon opacity. Defaults 1.0.
+  rotation, // optional. number. Only for type=view. Sets the orientation of the marker clockwise starting from the bottom.
+  visible, // optional. boolean. Only for type=view. Passing false will cause the marker to be invisible
+  flat, // optional. boolean. Only for type=view. When set to true, the marker will always have the same tilt as the map camera. Default is false.
   id, // required. string. Unique identifier used for adding or selecting an annotation.
   annotationImage: { // optional. Marker image for type=point
     source: {

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -381,6 +381,8 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<ReactNativeMap
             String name = annotation.getString("id");
             view.setAnnotation(name, annotationOptions);
         }
+
+        view.forceRelayoutOnMapView();
     }
 
     public void selectAnnotation(ReactNativeMapboxGLView view, String annotationId, boolean animated) {

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
@@ -185,6 +185,8 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
             _annotationIdsToName.put(annotation.getId(), entry.getKey());
         }
         _annotationOptions.clear();
+
+        forceRelayoutOnMapView();
     }
 
     private void destroyMapView() {
@@ -200,6 +202,18 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
             _map = null;
         }
         _mapView.onDestroy();
+    }
+
+    public void forceRelayoutOnMapView() {
+        _handler.post(new Runnable() {
+            @Override
+            public void run() {
+                _mapView.measure(
+                        View.MeasureSpec.makeMeasureSpec(_mapView.getMeasuredWidth(), MeasureSpec.EXACTLY),
+                        View.MeasureSpec.makeMeasureSpec(_mapView.getMeasuredHeight(), MeasureSpec.EXACTLY));
+                _mapView.layout(_mapView.getLeft(), _mapView.getTop(), _mapView.getRight(), _mapView.getBottom());
+            }
+        });
     }
 
     // Props
@@ -562,15 +576,7 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
 
         if (_annotationsPopUpEnabled == false) { return true; }
         // Due to a bug, we need to force a relayout on the _mapView
-        _handler.post(new Runnable() {
-            @Override
-            public void run() {
-                _mapView.measure(
-                        View.MeasureSpec.makeMeasureSpec(_mapView.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
-                        View.MeasureSpec.makeMeasureSpec(_mapView.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
-                _mapView.layout(_mapView.getLeft(), _mapView.getTop(), _mapView.getRight(), _mapView.getBottom());
-            }
-        });
+        forceRelayoutOnMapView();
 
         return false;
     }


### PR DESCRIPTION
# MarkerView annotation support

I've added support for rendering marker views. I added all extra properties available in the MapBox API like  `rotation`, `alpha`, `visible` and `flat`.
## Improvements

I struggled quite a while with actually getting the Marker views to actually render properly. I eventually found out that by clicking on a normal point marker it did suddenly make the marker views appear on the map. I eventually was able to replicate the workaround used in the `onMarkerClick` method by forcing the map to relayout. I had to add the force in 2 different places to get my use case working:
1. Rendering a MarkerView on the initial load when the map is still `null`
2. Repositioning the MarkerView by changing the annotation `coordinates`

What would really help is if someone was able to explain what the actual bug is that requires the relayout. If I can fix that we can skip the force relayout in several places like I have in this PR now.
