### PR TITLE
add reuseIdentifier usage for custom iOS annotations to fix scroll away disappearing

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,7 @@ import { MapView } from 'react-native-mapbox-gl';
 | `contentInset` | `array` | Optional | Change the padding of the viewport of the map. Offset is in pixels. `[top, right, bottom, left]` `[0, 0, 0, 0]` |
 | `style`  | React styles | Optional | Styles the actual map view container | N/A |
 | `debugActive`  | `boolean` | Optional | Turns on debug mode. | `false` |
-| `children` | `array` | Optional |  An array of custom Annotation views (iOS only). You must import Annotation view from the component and put your custom React Native view inside | null |
+| `children` | `array` | Optional |  An array of custom Annotation views (iOS only). You must import Annotation view from the component and put your custom React Native view inside. Annotation view must have unique id prop defined as well as coordinate | null |
 
 
 ## Callback props

--- a/Annotation.js
+++ b/Annotation.js
@@ -20,7 +20,7 @@ const viewConfig = {
 
 const propTypes = {
   ...View.propTypes,
-  
+  id: PropTypes.string.isRequired,
   title: PropTypes.string,
   subtitle: PropTypes.string,
   coordinate: PropTypes.shape({
@@ -31,13 +31,15 @@ const propTypes = {
 };
 
 class MapboxAnnotation extends React.Component {
-   
+  setNativeProps(nativeProps) {
+    this.marker.setNativeProps(nativeProps);
+  }
+  
   render() {
     return (
       <RCTMapboxAnnotation
         ref={ref => { this.marker = ref; }}
         {...this.props}
-        style={[styles.marker, this.props.style]}
       />
     );
   }
@@ -45,13 +47,6 @@ class MapboxAnnotation extends React.Component {
 
 MapboxAnnotation.propTypes = propTypes;
 MapboxAnnotation.viewConfig = viewConfig;
-
-const styles = StyleSheet.create({
-  marker: {
-    position: 'absolute',
-    backgroundColor: 'transparent',
-  },
-});
 
 const RCTMapboxAnnotation = requireNativeComponent('RCTMapboxAnnotation', MapboxAnnotation);
 module.exports = MapboxAnnotation;

--- a/Annotation.js
+++ b/Annotation.js
@@ -1,0 +1,57 @@
+import React, { PropTypes } from 'react';
+import {
+  View,
+  requireNativeComponent,
+  StyleSheet,
+  Platform,
+  NativeModules,
+  Animated,
+  findNodeHandle,
+} from 'react-native';
+
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+
+const viewConfig = {
+  uiViewClassName: 'RCTMapboxAnnotation',
+  validAttributes: {
+    coordinate: true,
+  },
+};
+
+const propTypes = {
+  ...View.propTypes,
+  
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  coordinate: PropTypes.shape({
+    latitude: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
+  }).isRequired,
+  
+};
+
+class MapboxAnnotation extends React.Component {
+   
+  render() {
+    return (
+      <RCTMapboxAnnotation
+        ref={ref => { this.marker = ref; }}
+        {...this.props}
+        style={[styles.marker, this.props.style]}
+      />
+    );
+  }
+}
+
+MapboxAnnotation.propTypes = propTypes;
+MapboxAnnotation.viewConfig = viewConfig;
+
+const styles = StyleSheet.create({
+  marker: {
+    position: 'absolute',
+    backgroundColor: 'transparent',
+  },
+});
+
+const RCTMapboxAnnotation = requireNativeComponent('RCTMapboxAnnotation', MapboxAnnotation);
+module.exports = MapboxAnnotation;

--- a/ios/RCTMapboxGL/RCTMapboxAnnotation.h
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotation.h
@@ -26,6 +26,15 @@
  in your map view, you are expected to provide this property. This string is
  displayed in the callout for the associated annotation.
  */
+@property (nonatomic, copy, nullable) NSString *id;
+
+/**
+ The string containing the annotation’s title.
+ 
+ Although this property is optional, if you support the selection of annotations
+ in your map view, you are expected to provide this property. This string is
+ displayed in the callout for the associated annotation.
+ */
 @property (nonatomic, copy, nullable) NSString *title;
 
 /**

--- a/ios/RCTMapboxGL/RCTMapboxAnnotation.m
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotation.m
@@ -17,4 +17,14 @@
 @implementation RCTMapboxAnnotation {
 }
 
+-(NSString *)reuseIdentifier {
+    return self.id;
+}
+
+-(void)layoutSubviews {
+    [super layoutSubviews];
+    [self.map layoutSubviews];
+}
+
+
 @end

--- a/ios/RCTMapboxGL/RCTMapboxAnnotation.m
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotation.m
@@ -23,7 +23,7 @@
 
 -(void)layoutSubviews {
     [super layoutSubviews];
-    [self.map layoutSubviews];
+    [self.map restoreAnnotationPosition:self.id];
 }
 
 

--- a/ios/RCTMapboxGL/RCTMapboxAnnotationManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotationManager.m
@@ -33,7 +33,7 @@ RCT_EXPORT_MODULE()
     return marker;
 }
 
-
+RCT_EXPORT_VIEW_PROPERTY(id, NSString)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_EXPORT_VIEW_PROPERTY(subtitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(coordinate, CLLocationCoordinate2D)

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -66,7 +66,6 @@
 @property (nonatomic, copy) RCTDirectEventBlock onFinishLoadingMap;
 @property (nonatomic, copy) RCTDirectEventBlock onStartLoadingMap;
 @property (nonatomic, copy) RCTDirectEventBlock onLocateUserFailed;
-@property (nonatomic, copy) NSArray *custom;
 
 @end
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -45,6 +45,7 @@
 - (void)upsertAnnotation:(NSObject *)annotation;
 - (void)removeAnnotation:(NSString*)selectedIdentifier;
 - (void)removeAllAnnotations;
+- (void)restoreAnnotationPosition:(NSString *)annotationId;
 
 // Getters
 - (MGLCoordinateBounds)visibleCoordinateBounds;

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -66,6 +66,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onFinishLoadingMap;
 @property (nonatomic, copy) RCTDirectEventBlock onStartLoadingMap;
 @property (nonatomic, copy) RCTDirectEventBlock onLocateUserFailed;
+@property (nonatomic, copy) NSArray *custom;
 
 @end
 

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -43,15 +43,6 @@
     MGLAnnotationVerticalAlignment _userLocationVerticalAlignment;
     /* So we don't fire onChangeUserTracking mode when triggered by props */
     BOOL _isChangingUserTracking;
-    // Array to manually track RN subviews
-    //
-    // AIRMap implicitly creates subviews that aren't regular RN children
-    // (SMCalloutView injects an overlay subview), which otherwise confuses RN
-    // during component re-renders:
-    // https://github.com/facebook/react-native/blob/v0.16.0/React/Modules/RCTUIManager.m#L657
-    //
-    // Implementation based on RCTTextField, another component with indirect children
-    // https://github.com/facebook/react-native/blob/v0.16.0/Libraries/Text/RCTTextField.m#L20
     NSMutableDictionary<NSString *, UIView *> *_reactSubviews;
 }
 
@@ -209,6 +200,13 @@
     }
 }
 
+- (void)restoreAnnotationPosition:(NSString *)annotationId {
+    if (_reactSubviews[annotationId] && [_reactSubviews[annotationId] isKindOfClass:[RCTMapboxAnnotation class]]){
+        RCTMapboxAnnotation *annotation = (RCTMapboxAnnotation *)_reactSubviews[annotationId];
+        CGPoint point = [_map convertCoordinate:annotation.coordinate toPointToView:_map];
+        annotation.center = point;
+    }
+}
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(RCTMGLAnnotationPolyline *)shape
 {
     if ([shape isKindOfClass:[RCTMGLAnnotationPolyline class]]) {


### PR DESCRIPTION
It appears that reuseIdentifier is mandatory to use custom views (i thought it is optional, just for performance improvements). 
https://github.com/mapbox/mapbox-gl-native/issues/6458#issuecomment-249628078
