### PR TITLE
Exposing min/max zoom level properties to react native

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -89,6 +89,16 @@ public class ReactNativeMapboxGLManager extends SimpleViewManager<ReactNativeMap
         view.setInitialZoomLevel(value);
     }
 
+    @ReactProp(name = "minimumZoomLevel")
+    public void setMinumumZoomLevel(ReactNativeMapboxGLView view, double value) {
+        view.setMinimumZoomLevel(value);
+    }
+
+    @ReactProp(name = "maximumZoomLevel")
+    public void setMaxumumZoomLevel(ReactNativeMapboxGLView view, double value) {
+        view.setMaximumZoomLevel(value);
+    }
+
     @ReactProp(name = "initialDirection")
     public void setInitialDirection(ReactNativeMapboxGLView view, double value) {
         view.setInitialDirection(value);

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
@@ -57,6 +57,8 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
     private boolean _showsUserLocation;
     private boolean _annotationsPopUpEnabled = true;
     private boolean _zoomEnabled = true;
+    private double _minimumZoomLevel = 0;
+    private double _maximumZoomLevel = 20;
     private boolean _pitchEnabled = true;
     private boolean _scrollEnabled = true;
     private boolean _rotateEnabled = true;
@@ -145,6 +147,9 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
         _map.getTrackingSettings().setMyLocationTrackingMode(_locationTrackingMode);
         _map.getTrackingSettings().setMyBearingTrackingMode(_bearingTrackingMode);
         _map.setPadding(_paddingLeft, _paddingTop, _paddingRight, _paddingBottom);
+        _map.setMinZoom(_minimumZoomLevel);
+        _map.setMaxZoom(_maximumZoomLevel);
+
         UiSettings uiSettings = _map.getUiSettings();
         uiSettings.setZoomGesturesEnabled(_zoomEnabled);
         uiSettings.setScrollGesturesEnabled(_scrollEnabled);
@@ -251,6 +256,22 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
         _zoomEnabled = value;
         if (_map != null) {
             _map.getUiSettings().setZoomGesturesEnabled(value);
+        }
+    }
+
+    public void setMinimumZoomLevel(double value) {
+        if (_minimumZoomLevel == value) { return; }
+        _minimumZoomLevel = value;
+        if (_map != null) {
+            _map.setMinZoom(value);
+        }
+    }
+
+    public void setMaximumZoomLevel(double value) {
+        if (_maximumZoomLevel == value) { return; }
+        _maximumZoomLevel = value;
+        if (_map != null) {
+            _map.setMaxZoom(value);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -292,6 +292,8 @@ class MapView extends Component {
     rotateEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     zoomEnabled: PropTypes.bool,
+    minimumZoomLevel: PropTypes.number,
+    maximumZoomLevel: PropTypes.number,
     pitchEnabled: PropTypes.bool,
     annotationsPopUpEnabled: PropTypes.bool,
     showsUserLocation: PropTypes.bool,
@@ -347,6 +349,8 @@ class MapView extends Component {
     },
     initialDirection: 0,
     initialZoomLevel: 0,
+    minimumZoomLevel: 0,
+    maximumZoomLevel: 20, // default in native map view
     debugActive: false,
     rotateEnabled: true,
     scrollEnabled: true,

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -27,6 +27,8 @@
     double _initialDirection;
     double _initialZoomLevel;
     BOOL _zoomEnabled;
+    double _minimumZoomLevel;
+    double _maximumZoomLevel;
     BOOL _clipsToBounds;
     BOOL _debugActive;
     BOOL _finishedLoading;
@@ -95,6 +97,8 @@
     _map.scrollEnabled = _scrollEnabled;
     _map.zoomEnabled = _zoomEnabled;
     _map.pitchEnabled = _pitchEnabled;
+    _map.minimumZoomLevel = _minimumZoomLevel;
+    _map.maximumZoomLevel = _maximumZoomLevel;
     _map.showsUserLocation = _showsUserLocation;
     _map.styleURL = _styleURL;
     _map.zoomLevel = _initialZoomLevel;
@@ -356,6 +360,20 @@
     if (_zoomEnabled == zoomEnabled) { return; }
     _zoomEnabled = zoomEnabled;
     if (_map) { _map.zoomEnabled = zoomEnabled; }
+}
+
+- (void)setMinimumZoomLevel:(double)minimumZoomLevel
+{
+    if (_minimumZoomLevel == minimumZoomLevel) { return; }
+    _minimumZoomLevel = minimumZoomLevel;
+    if (_map) { _map.minimumZoomLevel = minimumZoomLevel; }
+}
+
+- (void)setMaximumZoomLevel:(double)maximumZoomLevel
+{
+    if (_maximumZoomLevel == maximumZoomLevel) { return; }
+    _maximumZoomLevel = maximumZoomLevel;
+    if (_map) { _map.maximumZoomLevel = maximumZoomLevel; }
 }
 
 - (void)setPitchEnabled:(BOOL)pitchEnabled

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -45,6 +45,8 @@ RCT_EXPORT_VIEW_PROPERTY(debugActive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(rotateEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(scrollEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(zoomEnabled, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(minimumZoomLevel, double);
+RCT_EXPORT_VIEW_PROPERTY(maximumZoomLevel, double);
 RCT_EXPORT_VIEW_PROPERTY(pitchEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(styleURL, NSURL);
@@ -726,5 +728,4 @@ RCT_EXPORT_METHOD(queryRenderedFeatures:(nonnull NSNumber *)reactTag
               @"coordinates": coordinates };
 }
 
->>>>>>> alseageo/queryRenderedFeatures
 @end


### PR DESCRIPTION
# Summary

This pull request exposes the min/max zoom limit properties to javascript. The defaults are set to the same as in the native code (unfortunately, I didn't see a clear way to get the defaults from the native code, and had to hard code the default values).
# Test Plan

In an app with a Mapbox MapView component
Add the properties `minimumZoomLevel` and `maximumZoomLevel` with the values 15 and 18.

> Zooming should then be limited to those values.
