### PR TITLE
PropTypes.object() is not a function. Use shape() instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -316,12 +316,12 @@ class MapView extends Component {
       strokeWidth: PropTypes.number,
       id: PropTypes.string,
       type: PropTypes.string.isRequired,
-      rightCalloutAccessory: PropTypes.object({
+      rightCalloutAccessory: PropTypes.shape({
         height: PropTypes.number,
         width: PropTypes.number,
         url: PropTypes.string
       }),
-      annotationImage: PropTypes.object({
+      annotationImage: PropTypes.shape({
         height: PropTypes.number,
         width: PropTypes.number,
         url: PropTypes.string


### PR DESCRIPTION
This should remove the following error message from the console:

```
<Warning>: Warning: You are manually calling a React.PropTypes validation function for the `undefined` prop on `<<anonymous>>`. This is deprecated and will not work in the next major version. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.
```
