### PR TITLE
Adding onCloseAnnotation to iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ class MapView extends Component {
     this._onRegionDidChange = this._onRegionDidChange.bind(this);
     this._onRegionWillChange = this._onRegionWillChange.bind(this);
     this._onOpenAnnotation = this._onOpenAnnotation.bind(this);
+    this._onCloseAnnotation = this._onCloseAnnotation.bind(this);
     this._onRightAnnotationTapped = this._onRightAnnotationTapped.bind(this);
     this._onChangeUserTrackingMode = this._onChangeUserTrackingMode.bind(this);
     this._onUpdateUserLocation = this._onUpdateUserLocation.bind(this);
@@ -253,6 +254,9 @@ class MapView extends Component {
   _onOpenAnnotation(event: Event) {
     if (this.props.onOpenAnnotation) this.props.onOpenAnnotation(event.nativeEvent.src);
   }
+  _onCloseAnnotation(event: Event) {
+    if (this.props.onCloseAnnotation) this.props.onCloseAnnotation(event.nativeEvent.src);
+  }
   _onRightAnnotationTapped(event: Event) {
     if (this.props.onRightAnnotationTapped) this.props.onRightAnnotationTapped(event.nativeEvent.src);
   }
@@ -332,6 +336,7 @@ class MapView extends Component {
     onRegionDidChange: PropTypes.func,
     onRegionWillChange: PropTypes.func,
     onOpenAnnotation: PropTypes.func,
+    onCloseAnnotation: PropTypes.func,
     onUpdateUserLocation: PropTypes.func,
     onRightAnnotationTapped: PropTypes.func,
     onFinishLoadingMap: PropTypes.func,
@@ -431,6 +436,7 @@ class MapView extends Component {
         enableOnRegionDidChange={!!this.props.onRegionDidChange}
         enableOnRegionWillChange={!!this.props.onRegionWillChange}
         onOpenAnnotation={this._onOpenAnnotation}
+        onCloseAnnotation={this._onCloseAnnotation}
         onRightAnnotationTapped={this._onRightAnnotationTapped}
         onUpdateUserLocation={this._onUpdateUserLocation}
         onLongPress={this._onLongPress}

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -62,6 +62,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onRegionWillChange;
 @property (nonatomic, copy) RCTDirectEventBlock onChangeUserTrackingMode;
 @property (nonatomic, copy) RCTDirectEventBlock onOpenAnnotation;
+@property (nonatomic, copy) RCTDirectEventBlock onCloseAnnotation;
 @property (nonatomic, copy) RCTDirectEventBlock onRightAnnotationTapped;
 @property (nonatomic, copy) RCTDirectEventBlock onUpdateUserLocation;
 @property (nonatomic, copy) RCTDirectEventBlock onTap;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -562,6 +562,17 @@
                                        @"longitude": @(annotation.coordinate.longitude)} });
 }
 
+-(void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(nonnull id<MGLAnnotation>)annotation
+{
+    if (!annotation.title || !annotation.subtitle) { return; }
+    if (!_onCloseAnnotation) { return; }
+    _onCloseAnnotation(@{ @"target": self.reactTag,
+                            @"src": @{ @"title": annotation.title,
+                                       @"subtitle": annotation.subtitle,
+                                       @"id": [(RCTMGLAnnotation *) annotation id],
+                                       @"latitude": @(annotation.coordinate.latitude),
+                                       @"longitude": @(annotation.coordinate.longitude)} });
+}
 
 - (void)mapView:(RCTMapboxGL *)mapView regionDidChangeAnimated:(BOOL)animated
 {

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -61,6 +61,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionDidChange, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRegionWillChange, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onChangeUserTrackingMode, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onOpenAnnotation, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onCloseAnnotation, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRightAnnotationTapped, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onUpdateUserLocation, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTap, RCTDirectEventBlock);


### PR DESCRIPTION
Exposing `didDeselectAnnotation` for iOS. A couple open questions:
1. Is there an equivalent Android event? All I could find was a `MarkerClickListener` but no corresponding un-click listener.
2. I assume there's no way to get an event "user selected _another_ annotation" when one is already selected? Right now, the only way to figure that out is to watch for a deselect and select (of another annotation) back to back but I'd obviously prefer not to have to do weird timing in the code like that.
