### PR TITLE
Do not require access token for iOS

### DIFF
--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -73,11 +73,6 @@
         return;
     }
 
-    if (![MGLAccountManager accessToken]) {
-        RCTLogError(@"You need an access token to use Mapbox. Register to mapbox.com to obtain one, then run Mapbox.setAccessToken(yourToken) before mounting this component");
-        return;
-    }
-
     _map = [[MGLMapView alloc] initWithFrame:self.bounds];
     _map.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _map.delegate = self;


### PR DESCRIPTION
Remove the iOS-side accessToken check. The Android one described in #400 is already gone. Fixes #400