### PR TITLE
Allow annotation images from the file system

### DIFF
--- a/API.md
+++ b/API.md
@@ -267,7 +267,7 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
   id, // required. string. Unique identifier used for adding or selecting an annotation.
   annotationImage: { // optional. Marker image for type=point
     source: {
-      uri // required. string. Either remote image URL or the name (without extension) of a bundled image
+      uri // required. string. Either remote image URL, local image file URL or the name (without extension) of a bundled image
     },
     height, // required. number. Image height
     width, // required. number. Image width
@@ -309,7 +309,7 @@ annotations: [{
   title: 'Important',
   subtitle: 'Neat, this is a custom annotation image',
   annotationImage: {
-    source: { uri: 'https://cldup.com/7NLZklp8zS.png' },
+    source: { uri: 'file:///var/mobile/Containers/Data/Application/8821CE3F-C0DA-4B86-B4F7-85DE1E158943/Documents/custom-annotation.png' },
     height: 25,
     width: 25
   },

--- a/API.md
+++ b/API.md
@@ -284,6 +284,8 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
 **For using locally bundled images, on iOS see [adding static resources to your app using Images.xcassets  docs](https://facebook.github.io/react-native/docs/image.html#adding-static-resources-to-your-app-using-images-xcassets)
 and on Android, put images in `android/app/src/main/res/drawable/yourImage.png`**.
 
+APIs from packages like `react-native-fs` or `react-native-fetch-blob` can help to construct a local image file URL.
+
 #### Example
 
 ```javascript

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.1.1@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.2@aar') {
         transitive = true
     }
 }

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
@@ -19,10 +19,15 @@ import com.mapbox.mapboxsdk.annotations.PolylineOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ClassCastException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,6 +92,17 @@ public class RNMGLAnnotationOptionsFactory {
         return ContextCompat.getDrawable(context, resID);
     }
 
+    static Drawable drawableFromFileUrl(Context context, String fileUrl) throws IOException {
+        try {
+            InputStream input = new FileInputStream(new File(new URI(fileUrl)));
+
+            Bitmap bitmap = BitmapFactory.decodeStream(input);
+            return new BitmapDrawable(context.getResources(), bitmap);
+        } catch (URISyntaxException ex) {
+            throw new MalformedURLException();
+        }
+    }
+
     static Drawable drawableFromUrl(Context context, String url) throws IOException {
         // This doesn't currently work, as it throws NetworkOnMainThreadException
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
@@ -108,6 +124,8 @@ public class RNMGLAnnotationOptionsFactory {
         Drawable drawable;
         try {
             drawable = drawableFromUrl(context, path);
+        } catch (ClassCastException ex) {
+            drawable = drawableFromFileUrl(context, path);
         } catch (MalformedURLException ex) {
             drawable = drawableFromDrawableName(context, path);
         }

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
@@ -138,7 +138,7 @@ public class ReactNativeMapboxGLModule extends ReactContextBaseJavaModule {
     // Access Token
 
     @ReactMethod
-    public void setAccessToken(String accessToken) {
+    public void setAccessToken(final String accessToken) {
         if (accessToken == null || accessToken.length() == 0 || accessToken.equals("your-mapbox.com-access-token")) {
             throw new JSApplicationIllegalArgumentException("Invalid access token. Register to mapbox.com and request an access token, then pass it to setAccessToken()");
         }
@@ -150,7 +150,12 @@ public class ReactNativeMapboxGLModule extends ReactContextBaseJavaModule {
             return;
         }
         initialized = true;
-        MapboxAccountManager.start(context.getApplicationContext(), accessToken);
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                MapboxAccountManager.start(context.getApplicationContext(), accessToken);
+            }
+        });
         initializeOfflinePacks();
     }
 

--- a/ios/RCTMapboxGL/RCTMapboxGLConversions.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLConversions.m
@@ -18,7 +18,7 @@ UIImage *imageFromSource (NSDictionary *source)
     if (!uri) { return nil; }
     
     NSURL* checkURL = [NSURL URLWithString:uri];
-    if (checkURL && checkURL.scheme && checkURL.host) {
+    if (checkURL && checkURL.scheme) { // remove checkURL.host of the checks as it's nil for file based urls
         return [UIImage imageWithData:[NSData dataWithContentsOfURL:checkURL]];
     }
     


### PR DESCRIPTION
Adds support for using images in the file system as annotation images on both iOS and Android.