### PR TITLE
Change import to work on case-sensitive MacOS filesystems.

### DIFF
--- a/ios/RCTMapboxGL/RCTMapboxAnnotation.h
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotation.h
@@ -1,6 +1,6 @@
 #import "RCTMapboxAnnotation.h"
 
-#import <MapBox/MapBox.h>
+#import <Mapbox/Mapbox.h>
 #import <UIKit/UIKit.h>
 
 #import "RCTConvert+MapKit.h"


### PR DESCRIPTION
I had a problem setting up RN mapboxgl to work on my system because of
this.