### PR TITLE
Add support for paths with spaces

### DIFF
--- a/scripts/download-mapbox-gl-native-ios-if-on-mac.js
+++ b/scripts/download-mapbox-gl-native-ios-if-on-mac.js
@@ -6,7 +6,7 @@ var path = require('path');
 // only download iOS SDK if on Mac OS
 if (process.platform === 'darwin') {
   var exec = require('child_process').exec;
-  var cmd = path.join(__dirname, 'download-mapbox-gl-native-ios.sh') + ' ' + version;
+  var cmd = `"${path.join(__dirname, 'download-mapbox-gl-native-ios.sh')}" ${version}`;
   exec(cmd, function(error, stdout, stderr) {
     if (error) {
       console.error(error);


### PR DESCRIPTION
If script is being run from a path having spaces it will fail. This patch will ensure to support spaces by encapsulating concatenated script path with double-quotes.