### PR TITLE
Fix Android crash from SDK 4.2.0-beta.4 and up

### DIFF
--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLModule.java
@@ -138,7 +138,7 @@ public class ReactNativeMapboxGLModule extends ReactContextBaseJavaModule {
     // Access Token
 
     @ReactMethod
-    public void setAccessToken(String accessToken) {
+    public void setAccessToken(final String accessToken) {
         if (accessToken == null || accessToken.length() == 0 || accessToken.equals("your-mapbox.com-access-token")) {
             throw new JSApplicationIllegalArgumentException("Invalid access token. Register to mapbox.com and request an access token, then pass it to setAccessToken()");
         }
@@ -150,7 +150,12 @@ public class ReactNativeMapboxGLModule extends ReactContextBaseJavaModule {
             return;
         }
         initialized = true;
-        MapboxAccountManager.start(context.getApplicationContext(), accessToken);
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                MapboxAccountManager.start(context.getApplicationContext(), accessToken);
+            }
+        });
         initializeOfflinePacks();
     }
 


### PR DESCRIPTION
This PR fixes the issue first reported in mapbox/mapbox-gl-native#7587 and identified by @tobrun in #516. We ensure that the creation of the `MapboxAccountManager` class happens on the main thread, which was required starting with Android SDK 4.2.0-beta.4. If merged, this PR will make the current `master` usable on Android once again.