### PR TITLE
Upgrade android SDK to 4.2.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.1@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.2@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
The 4.2.2 SDK fixes a bug which crashes the app on a network change that's tanking me pretty hard. Would like to now have this happen.