### PR TITLE
Allow base64-encoded image data-URI to be used for annotationImage source URI

### DIFF
--- a/API.md
+++ b/API.md
@@ -267,7 +267,7 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
   id, // required. string. Unique identifier used for adding or selecting an annotation.
   annotationImage: { // optional. Marker image for type=point
     source: {
-      uri // required. string. Either remote image URL, a Base64-encoded data URI, or the name (without extension) of a bundled image
+      uri // required. string. Either remote image URL, a base64-encoded data URI (Android only), or the name (without extension) of a bundled image
     },
     height, // required. number. Image height
     width, // required. number. Image width

--- a/API.md
+++ b/API.md
@@ -267,7 +267,7 @@ mapbox://styles/bobbysud/cigtw1pzy0000aam2346f7ex0
   id, // required. string. Unique identifier used for adding or selecting an annotation.
   annotationImage: { // optional. Marker image for type=point
     source: {
-      uri // required. string. Either remote image URL or the name (without extension) of a bundled image
+      uri // required. string. Either remote image URL, a Base64-encoded data URI, or the name (without extension) of a bundled image
     },
     height, // required. number. Image height
     width, // required. number. Image width

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationOptionsFactory.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.v4.content.ContextCompat;
+import android.util.Base64;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
@@ -88,6 +89,12 @@ public class RNMGLAnnotationOptionsFactory {
     }
 
     static Drawable drawableFromUrl(Context context, String url) throws IOException {
+        if (url.startsWith("data:")) {
+            byte[] decoded = Base64.decode(url.substring(url.indexOf(",")), Base64.DEFAULT);
+            Bitmap bitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.length);
+            return new BitmapDrawable(context.getResources(), bitmap);
+        }
+
         // This doesn't currently work, as it throws NetworkOnMainThreadException
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.connect();


### PR DESCRIPTION
I'd like to be able to dynamically generate images locally before using them as annotation images, and this seemed like simple way to support this functionality.