### PR TITLE
Android custom annotation bugfixes.

### DIFF
--- a/API.md
+++ b/API.md
@@ -364,9 +364,6 @@ The `Annotation` view has the following required props:
 2. React Native views do not work with the regular `onAnnotationTapped` on need to
    add their own tap handling (e.g. by using a `TouchableHighlight`).
 
-3. (*Android only*) Adding a view with style `flex: 1` and no `width` or `height` set can cause
-   views to behave a little strangely. It is recommended to add them.
-
 ###### Example
 
 ```

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationView.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationView.java
@@ -1,30 +1,27 @@
 package com.mapbox.reactnativemapboxgl;
 
 import android.content.Context;
-import android.util.Log;
 
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class RNMGLAnnotationView extends ReactViewGroup {
 
-    private final RNMGLAnnotationViewManager _manager;
+    private Set<PropertyListener> propertyListeners;
     private String annotationId;
     private LatLng coordinate;
+    private float layoutWidth;
+    private float layoutHeight;
 
-    public RNMGLAnnotationView(Context context, RNMGLAnnotationViewManager manager) {
+    public RNMGLAnnotationView(Context context) {
         super(context);
-        this._manager = manager;
+        this.propertyListeners = new HashSet<>();
     }
 
-    public LayoutParams getShadowNodeMeasurements() {
-        LayoutShadowNode shadowNode = _manager.getShadowNode();
-        return new LayoutParams(
-                (int)shadowNode.getLayoutWidth(),
-                (int)shadowNode.getLayoutHeight()
-        );
-    }
+    // Properties
 
     public String getAnnotationId() {
         return annotationId;
@@ -40,5 +37,41 @@ public class RNMGLAnnotationView extends ReactViewGroup {
 
     public void setCoordinate(LatLng coordinate) {
         this.coordinate = coordinate;
+        fireUpdateEvent();
+    }
+
+    // React layout
+
+    public void setLayoutDimensions(float layoutWidth, float layoutHeight) {
+        this.layoutWidth = layoutWidth;
+        this.layoutHeight = layoutHeight;
+    }
+
+    public float getLayoutWidth() {
+        return layoutWidth;
+    }
+
+    public float getLayoutHeight() {
+        return layoutHeight;
+    }
+
+    // Listeners
+
+    public void addPropertyListener(PropertyListener propertyListener) {
+        propertyListeners.add(propertyListener);
+    }
+
+    public void removePropertyListener(PropertyListener propertyListener) {
+        propertyListeners.remove(propertyListener);
+    }
+
+    private void fireUpdateEvent() {
+        for (PropertyListener listener : propertyListeners) {
+            listener.propertiesUpdated(this);
+        }
+    }
+
+    public interface PropertyListener {
+        void propertiesUpdated(RNMGLAnnotationView view);
     }
 }

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationViewManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/RNMGLAnnotationViewManager.java
@@ -7,8 +7,9 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
+import java.util.HashMap;
+
 public class RNMGLAnnotationViewManager extends ViewGroupManager<RNMGLAnnotationView> {
-    private LayoutShadowNode _shadowNode;
 
     private static final String NAME = "RCTMapboxAnnotation";
 
@@ -19,17 +20,17 @@ public class RNMGLAnnotationViewManager extends ViewGroupManager<RNMGLAnnotation
 
     @Override
     protected RNMGLAnnotationView createViewInstance(ThemedReactContext reactContext) {
-        return new RNMGLAnnotationView(reactContext, this);
+        return new RNMGLAnnotationView(reactContext);
+    }
+
+    @Override
+    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
+        return SizeReportingShadowNode.class;
     }
 
     @Override
     public LayoutShadowNode createShadowNodeInstance() {
-        _shadowNode = super.createShadowNodeInstance();
-        return _shadowNode;
-    }
-
-    public LayoutShadowNode getShadowNode() {
-        return _shadowNode;
+        return new SizeReportingShadowNode();
     }
 
     // Props
@@ -45,5 +46,16 @@ public class RNMGLAnnotationViewManager extends ViewGroupManager<RNMGLAnnotation
         coordinate.setLatitude(map.getDouble("latitude"));
         coordinate.setLongitude(map.getDouble("longitude"));
         view.setCoordinate(coordinate);
+    }
+
+    @Override
+    public void updateExtraData(RNMGLAnnotationView view, Object extraData) {
+        // This is called from the {@link SizeReportingShadowNode}. We cache
+        // the width and height so that we can set the correct size on the marker
+        // view annotations in ReactNativeMapboxGLView RNMGLCustomMarkerViewAdapter.
+        HashMap<String, Float> data = (HashMap<String, Float>) extraData;
+        float width = data.get("width");
+        float height = data.get("height");
+        view.setLayoutDimensions(width, height);
     }
 }

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLEventTypes.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLEventTypes.java
@@ -1,0 +1,23 @@
+package com.mapbox.reactnativemapboxgl;
+
+
+/**
+ * Prefix all the internal event names with mapbox so that they don't clobber or get clobbered
+ * by events with the same name in other libraries. None of this will be visible to the user.
+ * The callback names will remain normal.
+ */
+public class ReactNativeMapboxGLEventTypes {
+    public static String ON_REGION_DID_CHANGE = "mapbox.onRegionDidChange";
+    public static String ON_REGION_WILL_CHANGE = "mapbox.onRegionWillChange";
+    public static String ON_OPEN_ANNOTATION = "mapbox.onOpenAnnotation";
+    public static String ON_RIGHT_ANNOTATION_TAPPED = "mapbox.onRightAnnotationTapped";
+    public static String ON_CHANGE_USER_TRACKING_MODE = "mapbox.onChangeUserTrackingMode";
+    public static String ON_UPDATE_USER_LOCATION = "mapbox.onUpdateUserLocation";
+    public static String ON_LONG_PRESS = "mapbox.onLongPress";
+    public static String ON_TAP = "mapbox.onTap";
+    public static String ON_FINISH_LOADING_MAP = "mapbox.onFinishLoadingMap";
+    public static String ON_START_LOADING_MAP = "mapbox.onStartLoadingMap";
+    public static String ON_LOCATE_USER_FAILED = "mapbox.onLocateUserFailed";
+
+    private ReactNativeMapboxGLEventTypes() {}
+}

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/SizeReportingShadowNode.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/SizeReportingShadowNode.java
@@ -1,0 +1,21 @@
+package com.mapbox.reactnativemapboxgl;
+
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.UIViewOperationQueue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SizeReportingShadowNode extends LayoutShadowNode {
+
+    @Override
+    public void onCollectExtraUpdates(UIViewOperationQueue uiViewOperationQueue) {
+        super.onCollectExtraUpdates(uiViewOperationQueue);
+
+        Map<String, Float> data = new HashMap<>();
+        data.put("width", getLayoutWidth());
+        data.put("height", getLayoutHeight());
+
+        uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), data);
+    }
+}


### PR DESCRIPTION
- Custom annotations would sometimes not get rendered on the screen.
  Haven't nailed down the exact problem, but it was some sort of
  interleaving of operations from adding children and computing custom
  marker views. Moving the marker view addition to when the map finishes
  loading resolves this.
- The adapter for the react native marker views now handles the caching
  behaviour correctly and re-uses views when they are available.
- Make sure each layout actually gets the height and width of the react
  native views from the correct shadow nodes so that they don't all have
  the same measurements by accident.
- Use custom shadow node to cache view widths and heights correctly so that they don't all have the same dimensions by accident.
- Update locations of annotations when they are changed.
- Split annotation views into a map. The manager is a singleton and all
  the existing map views go through it so the children need to be kep
  separately.
- Safeguard against relayout being called after onDrop(), resulting in a
  null pointer exception.