### PR TITLE
android install docs: change MainActivity.java to MainApplication.java

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -37,7 +37,7 @@ dependencies {
 ```
 
 ```java
-// file: android/app/src/main/java/com/yourcompany/yourapp/MainActivity.java
+// file: android/app/src/main/java/com/yourcompany/yourapp/MainApplication.java
 import com.mapbox.reactnativemapboxgl.ReactNativeMapboxGLPackage; // <-- import
 ...
 /**


### PR DESCRIPTION
In recent versions the `getPackages` method is implemented in MainApplication.java