### PR TITLE
Imported RCTMap files which are removed from react native

### DIFF
--- a/ios/RCTMapboxGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMapboxGL.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		C5DBB3661AF2EFB500E611A9 /* RCTMapboxGLManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DBB3651AF2EFB500E611A9 /* RCTMapboxGLManager.m */; };
 		CB7CB11F1F5092CD30562E07 /* MGLPolyline+RCTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7CBE434C8597B1509C3FCA /* MGLPolyline+RCTAdditions.m */; };
 		CB7CB49F42C4A55593F71A37 /* MGLPolygon+RCTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */; };
+		EDFBF2F31EB9D4CE002C5EA0 /* RCTConvert+MapKit.m in Sources */ = {isa = PBXBuildFile; fileRef = EDFBF2F21EB9D4CE002C5EA0 /* RCTConvert+MapKit.m */; };
+		EDFBF2F61EB9D530002C5EA0 /* RCTMapAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = EDFBF2F51EB9D530002C5EA0 /* RCTMapAnnotation.m */; };
+		EDFBF2F91EB9D583002C5EA0 /* RCTMapOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = EDFBF2F81EB9D583002C5EA0 /* RCTMapOverlay.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +62,12 @@
 		CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolygon+RCTAdditions.m"; sourceTree = "<group>"; };
 		CB7CBC3A586F235841D94946 /* MGLPolyline+RCTAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolyline+RCTAdditions.h"; sourceTree = "<group>"; };
 		CB7CBE434C8597B1509C3FCA /* MGLPolyline+RCTAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolyline+RCTAdditions.m"; sourceTree = "<group>"; };
+		EDFBF2F11EB9D4CE002C5EA0 /* RCTConvert+MapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+MapKit.h"; sourceTree = "<group>"; };
+		EDFBF2F21EB9D4CE002C5EA0 /* RCTConvert+MapKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+MapKit.m"; sourceTree = "<group>"; };
+		EDFBF2F41EB9D530002C5EA0 /* RCTMapAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMapAnnotation.h; sourceTree = "<group>"; };
+		EDFBF2F51EB9D530002C5EA0 /* RCTMapAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMapAnnotation.m; sourceTree = "<group>"; };
+		EDFBF2F71EB9D583002C5EA0 /* RCTMapOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMapOverlay.h; sourceTree = "<group>"; };
+		EDFBF2F81EB9D583002C5EA0 /* RCTMapOverlay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMapOverlay.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +124,12 @@
 				CB7CBC3A586F235841D94946 /* MGLPolyline+RCTAdditions.h */,
 				CB7CBC07803C0F5C28ECB201 /* MGLPolygon+RCTAdditions.m */,
 				CB7CB655DADBFA72D7B5EB33 /* MGLPolygon+RCTAdditions.h */,
+				EDFBF2F11EB9D4CE002C5EA0 /* RCTConvert+MapKit.h */,
+				EDFBF2F21EB9D4CE002C5EA0 /* RCTConvert+MapKit.m */,
+				EDFBF2F41EB9D530002C5EA0 /* RCTMapAnnotation.h */,
+				EDFBF2F51EB9D530002C5EA0 /* RCTMapAnnotation.m */,
+				EDFBF2F71EB9D583002C5EA0 /* RCTMapOverlay.h */,
+				EDFBF2F81EB9D583002C5EA0 /* RCTMapOverlay.m */,
 			);
 			path = RCTMapboxGL;
 			sourceTree = "<group>";
@@ -224,6 +239,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5DBB3461AF2EF2B00E611A9 /* RCTMapboxGL.m in Sources */,
+				EDFBF2F91EB9D583002C5EA0 /* RCTMapOverlay.m in Sources */,
+				EDFBF2F61EB9D530002C5EA0 /* RCTMapAnnotation.m in Sources */,
+				EDFBF2F31EB9D4CE002C5EA0 /* RCTConvert+MapKit.m in Sources */,
 				C5DBB3661AF2EFB500E611A9 /* RCTMapboxGLManager.m in Sources */,
 				C167F89C1D18112B007C7A42 /* RCTMapboxGLConversions.m in Sources */,
 				874C0C451D9436D80034AF3F /* RCTMapboxAnnotationManager.m in Sources */,

--- a/ios/RCTMapboxGL/RCTConvert+MapKit.h
+++ b/ios/RCTMapboxGL/RCTConvert+MapKit.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <MapKit/MapKit.h>
+
+#import <React/RCTConvert.h>
+
+@class RCTMapAnnotation;
+@class RCTMapOverlay;
+
+@interface RCTConvert (MapKit)
+
++ (MKCoordinateSpan)MKCoordinateSpan:(id)json;
++ (MKCoordinateRegion)MKCoordinateRegion:(id)json;
++ (MKMapType)MKMapType:(id)json;
+
++ (RCTMapAnnotation *)RCTMapAnnotation:(id)json;
++ (RCTMapOverlay *)RCTMapOverlay:(id)json;
+
++ (NSArray<RCTMapAnnotation *> *)RCTMapAnnotationArray:(id)json;
++ (NSArray<RCTMapOverlay *> *)RCTMapOverlayArray:(id)json;
+
+@end

--- a/ios/RCTMapboxGL/RCTConvert+MapKit.m
+++ b/ios/RCTMapboxGL/RCTConvert+MapKit.m
@@ -8,7 +8,7 @@
  */
 
 #import "RCTConvert+MapKit.h"
-#import "RCTConvert+CoreLocation.h"
+#import <React/RCTConvert+CoreLocation.h>
 #import "RCTMapAnnotation.h"
 #import "RCTMapOverlay.h"
 

--- a/ios/RCTMapboxGL/RCTConvert+MapKit.m
+++ b/ios/RCTMapboxGL/RCTConvert+MapKit.m
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTConvert+MapKit.h"
+#import "RCTConvert+CoreLocation.h"
+#import "RCTMapAnnotation.h"
+#import "RCTMapOverlay.h"
+
+@implementation RCTConvert(MapKit)
+
++ (MKCoordinateSpan)MKCoordinateSpan:(id)json
+{
+    json = [self NSDictionary:json];
+    return (MKCoordinateSpan){
+        [self CLLocationDegrees:json[@"latitudeDelta"]],
+        [self CLLocationDegrees:json[@"longitudeDelta"]]
+    };
+}
+
++ (MKCoordinateRegion)MKCoordinateRegion:(id)json
+{
+    return (MKCoordinateRegion){
+        [self CLLocationCoordinate2D:json],
+        [self MKCoordinateSpan:json]
+    };
+}
+
+RCT_ENUM_CONVERTER(MKMapType, (@{
+                                 @"standard": @(MKMapTypeStandard),
+                                 @"satellite": @(MKMapTypeSatellite),
+                                 @"hybrid": @(MKMapTypeHybrid),
+                                 }), MKMapTypeStandard, integerValue)
+
++ (RCTMapAnnotation *)RCTMapAnnotation:(id)json
+{
+    json = [self NSDictionary:json];
+    RCTMapAnnotation *annotation = [RCTMapAnnotation new];
+    annotation.coordinate = [self CLLocationCoordinate2D:json];
+    annotation.draggable = [self BOOL:json[@"draggable"]];
+    annotation.title = [self NSString:json[@"title"]];
+    annotation.subtitle = [self NSString:json[@"subtitle"]];
+    annotation.identifier = [self NSString:json[@"id"]];
+    annotation.hasLeftCallout = [self BOOL:json[@"hasLeftCallout"]];
+    annotation.hasRightCallout = [self BOOL:json[@"hasRightCallout"]];
+    annotation.animateDrop = [self BOOL:json[@"animateDrop"]];
+    annotation.tintColor = [self UIColor:json[@"tintColor"]];
+    annotation.image = [self UIImage:json[@"image"]];
+    annotation.viewIndex =
+    [self NSInteger:json[@"viewIndex"] ?: @(NSNotFound)];
+    annotation.leftCalloutViewIndex =
+    [self NSInteger:json[@"leftCalloutViewIndex"] ?: @(NSNotFound)];
+    annotation.rightCalloutViewIndex =
+    [self NSInteger:json[@"rightCalloutViewIndex"] ?: @(NSNotFound)];
+    annotation.detailCalloutViewIndex =
+    [self NSInteger:json[@"detailCalloutViewIndex"] ?: @(NSNotFound)];
+    return annotation;
+}
+
+RCT_ARRAY_CONVERTER(RCTMapAnnotation)
+
++ (RCTMapOverlay *)RCTMapOverlay:(id)json
+{
+    json = [self NSDictionary:json];
+    NSArray<NSDictionary *> *locations = [self NSDictionaryArray:json[@"coordinates"]];
+    CLLocationCoordinate2D coordinates[locations.count];
+    NSUInteger index = 0;
+    for (NSDictionary *location in locations) {
+        coordinates[index++] = [self CLLocationCoordinate2D:location];
+    }
+
+    RCTMapOverlay *overlay = [RCTMapOverlay polylineWithCoordinates:coordinates
+                                                              count:locations.count];
+
+    overlay.strokeColor = [self UIColor:json[@"strokeColor"]];
+    overlay.identifier = [self NSString:json[@"id"]];
+    overlay.lineWidth = [self CGFloat:json[@"lineWidth"] ?: @1];
+    return overlay;
+}
+
+RCT_ARRAY_CONVERTER(RCTMapOverlay)
+
+@end

--- a/ios/RCTMapboxGL/RCTMapAnnotation.h
+++ b/ios/RCTMapboxGL/RCTMapAnnotation.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <MapKit/MapKit.h>
+
+@interface RCTMapAnnotation : MKPointAnnotation <MKAnnotation>
+
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, assign) BOOL hasLeftCallout;
+@property (nonatomic, assign) BOOL hasRightCallout;
+@property (nonatomic, assign) BOOL animateDrop;
+@property (nonatomic, strong) UIColor *tintColor;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, assign) NSUInteger viewIndex;
+@property (nonatomic, assign) NSUInteger leftCalloutViewIndex;
+@property (nonatomic, assign) NSUInteger rightCalloutViewIndex;
+@property (nonatomic, assign) NSUInteger detailCalloutViewIndex;
+@property (nonatomic, assign) BOOL draggable;
+
+@end

--- a/ios/RCTMapboxGL/RCTMapAnnotation.m
+++ b/ios/RCTMapboxGL/RCTMapAnnotation.m
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTMapAnnotation.h"
+
+@implementation RCTMapAnnotation
+
+@end

--- a/ios/RCTMapboxGL/RCTMapOverlay.h
+++ b/ios/RCTMapboxGL/RCTMapOverlay.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <MapKit/MapKit.h>
+
+@interface RCTMapOverlay : MKPolyline <MKAnnotation>
+
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, strong) UIColor *strokeColor;
+@property (nonatomic, assign) CGFloat lineWidth;
+
+@end

--- a/ios/RCTMapboxGL/RCTMapOverlay.m
+++ b/ios/RCTMapboxGL/RCTMapOverlay.m
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTMapOverlay.h"
+
+@implementation RCTMapOverlay
+
+@end

--- a/ios/RCTMapboxGL/RCTMapboxAnnotation.h
+++ b/ios/RCTMapboxGL/RCTMapboxAnnotation.h
@@ -3,8 +3,8 @@
 #import <Mapbox/Mapbox.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
+#import "RCTConvert+MapKit.h"
 #import "RCTMapboxGL.h"
 
 @class RCTBridge;

--- a/ios/RCTMapboxGL/RCTMapboxGLConversions.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLConversions.m
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTConvert+MapKit.h>
+#import "RCTConvert+MapKit.h"
 #import "RCTMapboxGL.h"
 
 UIImage *imageFromSource (NSDictionary *source)

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -10,11 +10,11 @@
 #import "RCTMapboxGL.h"
 #import <Mapbox/Mapbox.h>
 #import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
 #import <React/RCTUIManager.h>
+#import "RCTConvert+MapKit.h"
 #import "RCTMapboxGLConversions.h"
 #import "MGLPolygon+RCTAdditions.h"
 #import "MGLPolyline+RCTAdditions.h"


### PR DESCRIPTION
Hey!

react-native-mapbox-gl is currently incompatible with react-native 0.44, as some map files this library depends on are removed.

I simply copied three classes from react-native 0.43 and imported them into this library. The project compiles and runs after applying those changes.

Fixes #545. 