### PR TITLE
import PropTypes from ‘prop-types’ and ViewPropTypes instead of View.propTypes

### DIFF
--- a/Annotation.js
+++ b/Annotation.js
@@ -1,6 +1,8 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   View,
+  ViewPropTypes,
   requireNativeComponent,
   StyleSheet,
   Platform,
@@ -19,7 +21,7 @@ const viewConfig = {
 };
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   id: PropTypes.string.isRequired,
   title: PropTypes.string,
   subtitle: PropTypes.string,

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
-  View,
+  ViewPropTypes,
   NativeModules,
   NativeAppEventEmitter,
   requireNativeComponent,
@@ -283,7 +284,7 @@ class MapView extends Component {
   }
 
   static propTypes = {
-    ...View.propTypes,
+    ...ViewPropTypes,
 
     initialZoomLevel: PropTypes.number,
     initialDirection: PropTypes.number,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "peerDependencies": {
     "react": ">=15.4.0",
-    "react-native": ">=0.40"
+    "react-native": ">=0.44.3",
+    "prop-types": ">=15.5.8"
   }
 }


### PR DESCRIPTION

Fixed errors for react-native 0.44.3 and up:

`View.propTypes has been deprecated and will be removed in a future version of ReactNative. Use ViewPropTypes instead.`

`Warning: PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. Use the prop-types package on npm instead.`