### PR TITLE
Update SDK build and compile version to 26.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Prevents annoying error when using `yarn`.