### PR TITLE
Allow user to tap on annotation callout windows

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,7 +59,8 @@ import { MapView } from 'react-native-mapbox-gl';
 | `onRegionWillChange` | `{latitude: 0, longitude: 0, zoomLevel: 0, direction: 0, pitch: 0, animated: false}` | Fired when the map begins panning or zooming. `animated` indicates whether the action is user-driven or animation-driven.
 | `onRegionDidChange` | `{latitude: 0, longitude: 0, zoomLevel: 0, direction: 0, pitch: 0, animated: false}` | Fired when the map ends panning or zooming.
 | `onOpenAnnotation` | `{id: 'marker_id', title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when tapping an annotation.
-| `onRightAnnotationTapped` | `{id: 'marker_id', title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps the `rightCalloutAccessory` of an annotation.
+| `onRightAnnotationTapped` | `{id: 'marker_id', title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps the `rightCalloutAccessory` of an annotation.  iOS only.  Android does not support the right callout accessory.
+| `onAnnotationTapped` | `{id: 'marker_id', title: null, subtitle: null, latitude: 0, longitude: 0}` | Fired when user taps the annotation.
 | `onChangeUserTrackingMode` | `Mapbox.userTrackingMode.none` | Fired when the user tracking mode gets changed by an user pan or rotate.
 | `onUpdateUserLocation` | `{latitude: 0, longitude: 0, verticalAccuracy: 0, horizontalAccuracy: 0, headingAccuracy: 0, magneticHeading: 0, trueHeading: 0, isUpdating: false}` | Fired when the user's location updates. `headingAccuracy` and `isUpdating` are only supported on iOS. `verticalAccuracy` and `horizontalAccuracy` will be the same on Android, or might not exist in some circumstances.
 | `onLocateUserFailed` | `{message: 'Error message'}` | Fired when there is an error getting the user's location. Do not rely on the string that is returned for determining what kind of error it is.

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLEventTypes.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLEventTypes.java
@@ -10,7 +10,7 @@ public class ReactNativeMapboxGLEventTypes {
     public static String ON_REGION_DID_CHANGE = "mapbox.onRegionDidChange";
     public static String ON_REGION_WILL_CHANGE = "mapbox.onRegionWillChange";
     public static String ON_OPEN_ANNOTATION = "mapbox.onOpenAnnotation";
-    public static String ON_RIGHT_ANNOTATION_TAPPED = "mapbox.onRightAnnotationTapped";
+    public static String ON_ANNOTATION_TAPPED = "mapbox.onAnnotationTapped";
     public static String ON_CHANGE_USER_TRACKING_MODE = "mapbox.onChangeUserTrackingMode";
     public static String ON_UPDATE_USER_LOCATION = "mapbox.onUpdateUserLocation";
     public static String ON_LONG_PRESS = "mapbox.onLongPress";

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLManager.java
@@ -93,7 +93,7 @@ public class ReactNativeMapboxGLManager extends ViewGroupManager<ReactNativeMapb
                 .put(ReactNativeMapboxGLEventTypes.ON_REGION_DID_CHANGE, MapBuilder.of("registrationName", "onRegionDidChange"))
                 .put(ReactNativeMapboxGLEventTypes.ON_REGION_WILL_CHANGE, MapBuilder.of("registrationName", "onRegionWillChange"))
                 .put(ReactNativeMapboxGLEventTypes.ON_OPEN_ANNOTATION, MapBuilder.of("registrationName", "onOpenAnnotation"))
-                .put(ReactNativeMapboxGLEventTypes.ON_RIGHT_ANNOTATION_TAPPED, MapBuilder.of("registrationName", "onRightAnnotationTapped"))
+                .put(ReactNativeMapboxGLEventTypes.ON_ANNOTATION_TAPPED, MapBuilder.of("registrationName", "onAnnotationTapped"))
                 .put(ReactNativeMapboxGLEventTypes.ON_CHANGE_USER_TRACKING_MODE, MapBuilder.of("registrationName", "onChangeUserTrackingMode"))
                 .put(ReactNativeMapboxGLEventTypes.ON_UPDATE_USER_LOCATION, MapBuilder.of("registrationName", "onUpdateUserLocation"))
                 .put(ReactNativeMapboxGLEventTypes.ON_LONG_PRESS, MapBuilder.of("registrationName", "onLongPress"))

--- a/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
+++ b/android/src/main/java/com/mapbox/reactnativemapboxgl/ReactNativeMapboxGLView.java
@@ -659,7 +659,7 @@ public class ReactNativeMapboxGLView extends RelativeLayout implements
 
     @Override
     public boolean onInfoWindowClick(@NonNull Marker marker) {
-        emitEvent(ReactNativeMapboxGLEventTypes.ON_RIGHT_ANNOTATION_TAPPED, serializeMarker(marker));
+        emitEvent(ReactNativeMapboxGLEventTypes.ON_ANNOTATION_TAPPED, serializeMarker(marker));
         return false;
     }
 

--- a/example.js
+++ b/example.js
@@ -83,6 +83,9 @@ class MapExample extends Component {
   onRightAnnotationTapped = (e) => {
     console.log('onRightAnnotationTapped', e);
   };
+  onAnnotationTapped = (e) => {
+    console.log('onAnnotationTapped', e);
+  };
   onLongPress = (location) => {
     console.log('onLongPress', location);
   };
@@ -181,6 +184,7 @@ class MapExample extends Component {
           onRegionWillChange={this.onRegionWillChange}
           onOpenAnnotation={this.onOpenAnnotation}
           onRightAnnotationTapped={this.onRightAnnotationTapped}
+          onAnnotationTapped={this.onAnnotationTapped}
           onUpdateUserLocation={this.onUpdateUserLocation}
           onLongPress={this.onLongPress}
           onTap={this.onTap}

--- a/index.js
+++ b/index.js
@@ -169,6 +169,7 @@ class MapView extends Component {
     this._onOpenAnnotation = this._onOpenAnnotation.bind(this);
     this._onCloseAnnotation = this._onCloseAnnotation.bind(this);
     this._onRightAnnotationTapped = this._onRightAnnotationTapped.bind(this);
+    this._onAnnotationTapped = this._onAnnotationTapped.bind(this);
     this._onChangeUserTrackingMode = this._onChangeUserTrackingMode.bind(this);
     this._onUpdateUserLocation = this._onUpdateUserLocation.bind(this);
     this._onLongPress = this._onLongPress.bind(this);
@@ -260,6 +261,9 @@ class MapView extends Component {
   _onRightAnnotationTapped(event: Event) {
     if (this.props.onRightAnnotationTapped) this.props.onRightAnnotationTapped(event.nativeEvent.src);
   }
+  _onAnnotationTapped(event: Event) {
+    if (this.props.onAnnotationTapped) this.props.onAnnotationTapped(event.nativeEvent.src);
+  }
   _onChangeUserTrackingMode(event: Event) {
     if (this.props.onChangeUserTrackingMode) this.props.onChangeUserTrackingMode(event.nativeEvent.src);
   }
@@ -339,6 +343,7 @@ class MapView extends Component {
     onCloseAnnotation: PropTypes.func,
     onUpdateUserLocation: PropTypes.func,
     onRightAnnotationTapped: PropTypes.func,
+    onAnnotationTapped: PropTypes.func,
     onFinishLoadingMap: PropTypes.func,
     onStartLoadingMap: PropTypes.func,
     onLocateUserFailed: PropTypes.func,
@@ -438,6 +443,7 @@ class MapView extends Component {
         onOpenAnnotation={this._onOpenAnnotation}
         onCloseAnnotation={this._onCloseAnnotation}
         onRightAnnotationTapped={this._onRightAnnotationTapped}
+        onAnnotationTapped={this._onAnnotationTapped}
         onUpdateUserLocation={this._onUpdateUserLocation}
         onLongPress={this._onLongPress}
         onTap={this._onTap}

--- a/ios/RCTMapboxGL/RCTMapboxGL.h
+++ b/ios/RCTMapboxGL/RCTMapboxGL.h
@@ -64,6 +64,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onOpenAnnotation;
 @property (nonatomic, copy) RCTDirectEventBlock onCloseAnnotation;
 @property (nonatomic, copy) RCTDirectEventBlock onRightAnnotationTapped;
+@property (nonatomic, copy) RCTDirectEventBlock onAnnotationTapped;
 @property (nonatomic, copy) RCTDirectEventBlock onUpdateUserLocation;
 @property (nonatomic, copy) RCTDirectEventBlock onTap;
 @property (nonatomic, copy) RCTDirectEventBlock onLongPress;

--- a/ios/RCTMapboxGL/RCTMapboxGL.m
+++ b/ios/RCTMapboxGL/RCTMapboxGL.m
@@ -113,7 +113,7 @@
     for (NSString *key in [_reactSubviews allKeys]) {
         [_map addAnnotation:_reactSubviews[key]];
     }
-    
+
     [self layoutSubviews];
 }
 
@@ -280,6 +280,23 @@
                                             @"longitude": @(annotation.coordinate.longitude)} };
 
         [_eventDispatcher sendInputEventWithName:@"onRightAnnotationTapped" body:event];
+    }
+}
+
+- (void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation
+{
+    if (annotation.title && annotation.subtitle) {
+
+        NSString *id = [(RCTMGLAnnotation *) annotation id];
+
+        NSDictionary *event = @{ @"target": self.reactTag,
+                                 @"src": @{ @"title": annotation.title,
+                                            @"subtitle": annotation.subtitle,
+                                            @"id": id,
+                                            @"latitude": @(annotation.coordinate.latitude),
+                                            @"longitude": @(annotation.coordinate.longitude)} };
+
+        [_eventDispatcher sendInputEventWithName:@"onAnnotationTapped" body:event];
     }
 }
 

--- a/ios/RCTMapboxGL/RCTMapboxGLManager.m
+++ b/ios/RCTMapboxGL/RCTMapboxGLManager.m
@@ -63,6 +63,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChangeUserTrackingMode, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onOpenAnnotation, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onCloseAnnotation, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRightAnnotationTapped, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onAnnotationTapped, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onUpdateUserLocation, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onTap, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLongPress, RCTDirectEventBlock);
@@ -143,24 +144,24 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
 - (id)init
 {
     if (!(self = [super init])) { return nil; }
-    
+
     _recentPacks = [NSMutableSet new];
     _throttledPacks = [NSMutableSet new];
     _removedPacks = [NSMutableSet new];
     _throttleInterval = 300;
-    
+
     _loadingPacks = [NSMutableSet new];
     _loadedPacks = NO;
-    
+
     // Setup pack array loading notifications
     [[MGLOfflineStorage sharedOfflineStorage] addObserver:self forKeyPath:@"packs" options:NSKeyValueObservingOptionInitial context:NULL];
     _packRequests = [NSMutableArray new];
-    
+
     // Setup offline pack notification handlers.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(offlinePackProgressDidChange:) name:MGLOfflinePackProgressChangedNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(offlinePackDidReceiveError:) name:MGLOfflinePackErrorNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(offlinePackDidReceiveMaximumAllowedMapboxTiles:) name:MGLOfflinePackMaximumMapboxTilesReachedNotification object:nil];
-    
+
     return self;
 }
 
@@ -173,9 +174,9 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
 - (void)offlinePacksDidFinishLoading
 {
     _loadedPacks = YES;
-    
+
     NSArray * packs = [MGLOfflineStorage sharedOfflineStorage].packs;
-    
+
     if ([_packRequests count]) {
         NSArray * callbackArray = [self serializePacksArray:packs];
         for (RCTPromiseResolveBlock callback in _packRequests) {
@@ -183,7 +184,7 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
         }
         [_packRequests removeAllObjects];
     }
-    
+
     for (MGLOfflinePack * pack in packs) {
         [pack resume];
     }
@@ -197,18 +198,18 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
     NSNumber * changeKind = change[NSKeyValueChangeKindKey];
     if (changeKind == [NSNull null]) { return; }
     if ([changeKind integerValue] != NSKeyValueChangeSetting) { return; }
-    
+
     NSArray * packs = [[MGLOfflineStorage sharedOfflineStorage] packs];
-    
+
     if (!packs) { return; }
     if (_loadedPacks) { return; }
-    
+
     [_loadingPacks addObjectsFromArray:packs];
-    
+
     for (MGLOfflinePack * pack in packs) {
         [pack requestProgress];
     }
-    
+
     if (!packs.count) {
         [self offlinePacksDidFinishLoading];
     }
@@ -217,18 +218,18 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
 - (void)firePackProgress:(MGLOfflinePack*)pack {
     NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
     MGLOfflinePackProgress progress = pack.progress;
-    
+
     NSDictionary *event = @{ @"name": userInfo[@"name"],
                              @"metadata": userInfo[@"metadata"],
                              @"countOfResourcesCompleted": @(progress.countOfResourcesCompleted),
                              @"countOfResourcesExpected": @(progress.countOfResourcesExpected),
                              @"countOfBytesCompleted": @(progress.countOfBytesCompleted),
                              @"maximumResourcesExpected": @(progress.maximumResourcesExpected) };
-    
+
     [_bridge.eventDispatcher sendAppEventWithName:@"MapboxOfflineProgressDidChange" body:event];
-    
+
     [_recentPacks addObject:pack];
-    
+
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _throttleInterval * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
         [_recentPacks removeObject:pack];
         if ([_throttledPacks containsObject:pack]) {
@@ -253,23 +254,23 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
 
 - (void)offlinePackProgressDidChange:(NSNotification *)notification {
     MGLOfflinePack *pack = notification.object;
-    
+
     if (!_loadedPacks && [_loadingPacks containsObject:pack]) {
         [_loadingPacks removeObject:pack];
         if ([_loadingPacks count] == 0) {
             [self offlinePacksDidFinishLoading];
         }
     }
-    
+
     if ([_removedPacks containsObject:pack]) {
         return;
     }
-    
+
     if ([_recentPacks containsObject:pack]) {
         [_throttledPacks addObject:pack];
         return;
     }
-    
+
     [self firePackProgress:pack];
 }
 
@@ -278,10 +279,10 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
     [self flushThrottleForPack:pack];
     NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
     uint64_t maximumCount = [notification.userInfo[MGLOfflinePackMaximumCountUserInfoKey] unsignedLongLongValue];
-    
+
     NSDictionary *event = @{ @"name": userInfo[@"name"],
                              @"maxTiles": @(maximumCount) };
-    
+
     [_bridge.eventDispatcher sendAppEventWithName:@"MapboxOfflineMaxAllowedTiles" body:event];
 }
 
@@ -290,10 +291,10 @@ RCT_EXPORT_METHOD(setAccessToken:(nonnull NSString *)accessToken)
     [self flushThrottleForPack:pack];
     NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
     NSError *error = notification.userInfo[MGLOfflinePackErrorUserInfoKey];
-    
+
     NSDictionary *event = @{ @"name": userInfo[@"name"],
                              @"error": [error localizedDescription] };
-    
+
     [_bridge.eventDispatcher sendAppEventWithName:@"MapboxOfflineError" body:event];
 }
 
@@ -328,24 +329,24 @@ RCT_REMAP_METHOD(addOfflinePack,
                , nil);
         return;
     }
-    
+
     NSArray *b = [options valueForKey:@"bounds"];
     MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(CLLocationCoordinate2DMake([b[0] floatValue], [b[1] floatValue]), CLLocationCoordinate2DMake([b[2] floatValue], [b[3] floatValue]));
-    
+
     NSURL * styleURL = [NSURL URLWithString:[options valueForKey:@"styleURL"]];
     float fromZoomLevel = [[options valueForKey:@"minZoomLevel"] floatValue];
     float toZoomLevel = [[options valueForKey:@"maxZoomLevel"] floatValue];
     NSString * name = [options valueForKey:@"name"];
     NSString * type = [options valueForKey:@"type"];
     NSDictionary * metadata = [options valueForKey:@"metadata"];
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:styleURL bounds:bounds fromZoomLevel:fromZoomLevel toZoomLevel:toZoomLevel];
-        
+
         NSMutableDictionary *userInfo = @{ @"name": name,
                                            @"metadata": metadata ? metadata : [NSNull null] };
         NSData *context = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
-        
+
         [[MGLOfflineStorage sharedOfflineStorage] addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack *pack, NSError *error) {
             if (error != nil) {
                 reject(@"add_pack_failed", error.localizedFailureReason, error);
@@ -360,7 +361,7 @@ RCT_REMAP_METHOD(addOfflinePack,
 - (NSArray*)serializePacksArray:(NSArray<MGLOfflinePack*>*)packs
 {
     NSMutableArray* callbackArray = [NSMutableArray new];
-    
+
     for (MGLOfflinePack *pack in packs) {
         NSMutableDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
         [callbackArray addObject:@{ @"name": userInfo[@"name"],
@@ -370,7 +371,7 @@ RCT_REMAP_METHOD(addOfflinePack,
                                     @"countOfResourcesExpected": @(pack.progress.countOfResourcesExpected),
                                     @"maximumResourcesExpected": @(pack.progress.maximumResourcesExpected) }];
     }
-    
+
     return callbackArray;
 }
 
@@ -380,7 +381,7 @@ RCT_REMAP_METHOD(getOfflinePacks,
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSMutableArray* callbackArray = [NSMutableArray new];
-        
+
         if (!_loadedPacks) {
             [_packRequests addObject:resolve];
         } else {
@@ -398,7 +399,7 @@ RCT_REMAP_METHOD(removeOfflinePack,
     dispatch_async(dispatch_get_main_queue(), ^{
         MGLOfflinePack *packs = [MGLOfflineStorage sharedOfflineStorage].packs;
         MGLOfflinePack *tempPack;
-        
+
         for (MGLOfflinePack *pack in packs) {
             NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
             if ([packName isEqualToString:userInfo[@"name"]]) {
@@ -406,20 +407,20 @@ RCT_REMAP_METHOD(removeOfflinePack,
                 break;
             }
         }
-        
+
         if (tempPack == nil) {
             return resolve(@{});
         }
-        
+
         NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:tempPack.context];
-        
-        
+
+
         // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/5508
-        
+
         [_removedPacks addObject:tempPack];
         [self discardThrottleForPack:tempPack];
         [tempPack suspend];
-        
+
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
             [_removedPacks removeObject:tempPack];
             [[MGLOfflineStorage sharedOfflineStorage] removePack:tempPack withCompletionHandler:^(NSError * _Nullable error) {
@@ -447,7 +448,7 @@ RCT_EXPORT_METHOD(spliceAnnotations:(nonnull NSNumber *)reactTag
 {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
-        
+
         if (deleteAll) {
             [mapView removeAllAnnotations];
         } else {
@@ -455,7 +456,7 @@ RCT_EXPORT_METHOD(spliceAnnotations:(nonnull NSNumber *)reactTag
                 [mapView removeAnnotation:key];
             }
         }
-        
+
         for (NSObject * annotationObject in toAdd) {
             [mapView upsertAnnotation:convertToMGLAnnotation(annotationObject)];
         }
@@ -469,7 +470,7 @@ RCT_EXPORT_METHOD(getCenterCoordinateZoomLevel:(nonnull NSNumber *)reactTag
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         CLLocationCoordinate2D region = [mapView centerCoordinate];
         double zoom = [mapView zoomLevel];
-        
+
         callback(@[ @{ @"latitude": @(region.latitude),
                        @"longitude": @(region.longitude),
                        @"zoomLevel": @(zoom) } ]);
@@ -483,12 +484,12 @@ RCT_EXPORT_METHOD(getBounds:(nonnull NSNumber *)reactTag
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         MGLCoordinateBounds bounds = [mapView visibleCoordinateBounds];
         NSMutableArray *callbackArray = [[NSMutableArray alloc] init];
-        
+
         [callbackArray addObject:@(bounds.sw.latitude)];
         [callbackArray addObject:@(bounds.sw.longitude)];
         [callbackArray addObject:@(bounds.ne.latitude)];
         [callbackArray addObject:@(bounds.ne.longitude)];
-        
+
         callback(@[callbackArray]);
     }];
 }
@@ -499,7 +500,7 @@ RCT_EXPORT_METHOD(getDirection:(nonnull NSNumber *)reactTag
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         double direction = [mapView direction];
-        
+
         callback(@[ @(direction) ]);
     }];
 }
@@ -510,7 +511,7 @@ RCT_EXPORT_METHOD(getPitch:(nonnull NSNumber *)reactTag
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         double pitch = [mapView pitch];
-        
+
         callback(@[ @(pitch) ]);
     }];
 }
@@ -523,50 +524,50 @@ RCT_EXPORT_METHOD(easeTo:(nonnull NSNumber *)reactTag
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTMapboxGL *> *viewRegistry) {
         RCTMapboxGL *mapView = viewRegistry[reactTag];
         if ([mapView isKindOfClass:[RCTMapboxGL class]]) {
-            
+
             NSNumber * latitude = options[@"latitude"];
             NSNumber * longitude = options[@"longitude"];
             NSNumber * zoom = options[@"zoomLevel"];
             NSNumber * direction = options[@"direction"];
             NSNumber * pitch = options[@"pitch"];
             NSNumber * altitude = options[@"altitude"];
-            
+
             if (pitch && zoom) {
                 RCTLogError(@"Pitch and zoomLevel can't be set together with MapView.easeTo() on iOS. Use altitude instead of zoomLevel");
                 return;
             }
-            
+
             if (zoom && altitude) {
                 RCTLogError(@"Altitude and zoomLevel are mutually exclusive with MapView.easeTo()");
                 return;
             }
-            
+
             CLLocationCoordinate2D _center = (latitude && longitude)
             ? CLLocationCoordinate2DMake([latitude doubleValue], [longitude doubleValue])
             : mapView.centerCoordinate;
-            
+
             double _direction = direction ? [direction doubleValue] : mapView.direction;
-            
+
             if (pitch || altitude) {
                 MGLMapCamera * oldCamera = (!pitch || !altitude) ? mapView.camera : nil;
                 double _altitude = altitude ? [altitude doubleValue] : oldCamera ? oldCamera.altitude : 0;
                 double _pitch = pitch ? [pitch doubleValue] : oldCamera ? oldCamera.pitch : 0;
-                
+
                 MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:_center
                                                                         fromDistance:_altitude
                                                                                pitch:_pitch
                                                                              heading:_direction];
-                
+
                 [mapView setCamera: camera
                       withDuration: 0.3
            animationTimingFunction: [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]
                  completionHandler: ^{
                      callback(@[[NSNull null]]);
                  }];
-                
+
             } else {
                 double _zoomLevel = zoom ? [zoom doubleValue] : mapView.zoomLevel;
-                
+
                 [mapView setCenterCoordinate: _center
                                    zoomLevel: _zoomLevel
                                    direction: _direction


### PR DESCRIPTION
- Added ability to tap on an annotation callout window.
- Removed `onRightAnnotationTapped` from firing on Android since callout accessories are not supported. 
- Updated example and docs.