### PR TITLE
Fix podspec file to include framework headers

### DIFF
--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.vendored_frameworks = 'Mapbox.framework'
   s.module_name = 'Mapbox'
-  s.source_files = "RCTMapboxGL/*.{h,m}"
+  s.source_files = "RCTMapboxGL/*.{h,m}", "Mapbox.framework/Headers/*.h"
+  s.public_header_files = "Mapbox.framework/Headers/*.h"
 
 end


### PR DESCRIPTION
This PR fixes the podspec file to point to the framework's headers, which was missing before.

Fix #593 
See discussion in #595