### PR TITLE
setVisibleCoordinateBounds accepts object rather than 9 parameters

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,7 +115,17 @@ animation has ended.
 ---
 
 ```javascript
-this._map.setVisibleCoordinateBounds(latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop = 0, paddingRight = 0, paddingBottom = 0, paddingLeft = 0, animated = true);
+this._map.setVisibleCoordinateBounds({
+  latitudeSW,
+  longitudeSW,
+  latitudeNE,
+  longitudeNE,
+  paddingTop = 0,
+  paddingRight = 0,
+  paddingBottom = 0,
+  paddingLeft = 0,
+  animated = true
+});
 ```
 
 This method adjusts the center location and the zoomLevel of the map so that

--- a/index.js
+++ b/index.js
@@ -237,8 +237,29 @@ class MapView extends Component {
     return promise;
   }
 
-  setVisibleCoordinateBounds(latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop = 0, paddingRight = 0, paddingBottom = 0, paddingLeft = 0, animated = true) {
-    MapboxGLManager.setVisibleCoordinateBounds(findNodeHandle(this), latitudeSW, longitudeSW, latitudeNE, longitudeNE, paddingTop, paddingRight, paddingBottom, paddingLeft, animated);
+  setVisibleCoordinateBounds({
+    latitudeSW,
+    longitudeSW,
+    latitudeNE,
+    longitudeNE,
+    paddingTop = 0,
+    paddingRight = 0,
+    paddingBottom = 0,
+    paddingLeft = 0,
+    animated = true,
+  }) {
+    MapboxGLManager.setVisibleCoordinateBounds(
+      findNodeHandle(this),
+      latitudeSW,
+      longitudeSW,
+      latitudeNE,
+      longitudeNE,
+      paddingTop,
+      paddingRight,
+      paddingBottom,
+      paddingLeft,
+      animated,
+    );
   }
 
   // Getters


### PR DESCRIPTION
It is very confusing to call `setVisibleCoordinateBounds` since it has 9 parameters o.O
Example:
```js
this.mapView.setVisibleCoordinateBounds(
  firstMarker.lat,
  firstMarker.lon,
  secondMarker.lat,
  secondMarker.lon,
  50,
  15,
  0,
  15,
);
```
What the hell this means? :D It means that you want padding 50 to top, padding 15 to left and right and also padding 0 to bottom.

Instead calling like this makes much more sense and increases readability
```js
this.mapView.setVisibleCoordinateBounds({
  latitudeSW: firstMarker.lat,
  longitudeSW: firstMarker.lon,
  latitudeNE: secondMarker.lat,
  longitudeNE: secondMarker.lon,
  paddingTop: 50,
  paddingLeft: 15,
  paddingRight: 15,
});
```
Notice also that I did not have to add `paddingBottom` because I did not want to change it!

Also note that this is breaking change ⚠️ 