### PR TITLE
Fix wrong project name on Android

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -27,8 +27,8 @@ Edit the following files:
 // file: android/settings.gradle
 ...
 
-include ':@mapbox/reactnativemapboxgl'
-project(':@mapbox/reactnativemapboxgl').projectDir = new File(rootProject.projectDir, '../node_modules/@mapbox/react-native-mapbox-gl/android')
+include ':@mapbox/react-native-mapbox-gl'
+project(':@mapbox/react-native-mapbox-gl').projectDir = new File(rootProject.projectDir, '../node_modules/@mapbox/react-native-mapbox-gl/android')
 ```
 
 ```gradle


### PR DESCRIPTION
Without this change Mapbox can't be installed to Android :)