### PR TITLE
Better version tracking on Mapbox.framework downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn.lock
 # project specific
 ios/Mapbox.framework
 ios/temp.zip
+ios/.framework_version
 android/build/
 android/.gradle/
 android/.idea/

--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 
-VERSION=$1
-
-echo "Downloading Mapbox GL iOS $VERSION, this may take a minute."
 cd ios/
+
+VERSION=$1
+CURRENT_VERSION=$(cat .framework_version)
+
+if [ "$VERSION" == "$CURRENT_VERSION" ]; then
+  echo "The newest version is already installed. Exiting."
+  exit 0
+fi
 
 if ! which curl > /dev/null; then echo "curl command not found. Please install curl"; exit 1; fi;
 if ! which unzip > /dev/null; then echo "unzip command not found. Please install unzip"; exit 1; fi;
@@ -22,3 +27,5 @@ rm temp.zip
 if ! [ -d ./Mapbox.framework ]; then
   echo "Mapbox.framework not found. Please reinstall react-native-mapbox-gl"; exit 1;
 fi;
+
+echo "$VERSION" > .framework_version

--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -10,6 +10,8 @@ if [ "$VERSION" == "$CURRENT_VERSION" ]; then
   exit 0
 fi
 
+echo "Downloading Mapbox GL iOS $VERSION, this may take a minute."
+
 if ! which curl > /dev/null; then echo "curl command not found. Please install curl"; exit 1; fi;
 if ! which unzip > /dev/null; then echo "unzip command not found. Please install unzip"; exit 1; fi;
 


### PR DESCRIPTION
Added a `.framework_version` file to check against and only delete and re-download the Mapbox.framework when the version has changed.