### PR TITLE
[v6] [Android] Fixes `onRegionDidChange` event not firing

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -242,7 +242,7 @@ public class RCTMGLMapView extends MapView implements
                 event = new MapChangeEvent(this, EventTypes.REGION_IS_CHANGING);
                 break;
             case REGION_DID_CHANGE:
-                event = new MapChangeEvent(this, makeRegionPayload(false), EventTypes.REGION_WILL_CHANGE);
+                event = new MapChangeEvent(this, makeRegionPayload(false), EventTypes.REGION_DID_CHANGE);
                 break;
             case REGION_DID_CHANGE_ANIMATED:
                 event = new MapChangeEvent(this, makeRegionPayload(true), EventTypes.REGION_DID_CHANGE);


### PR DESCRIPTION
Fixes `onRegionDidChange` event not firing by change EventType to `REGION_DID_CHANGE`

Fixes #682 