### PR TITLE
Prevent Callout touch event from bubbling to superview on iOS

### DIFF
--- a/ios/RCTMGL/RCTMGLCallout.m
+++ b/ios/RCTMGL/RCTMGLCallout.m
@@ -26,6 +26,16 @@
 @synthesize anchoredToAnnotation = _anchoredToAnnotation;
 @synthesize dismissesAutomatically = _dismissesAutomatically;
 
+- (instancetype)init
+{
+    if (self = [super init]) {
+        // prevent tap from bubbling up to it's superview
+        UITapGestureRecognizer *captureTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:nil];
+        [self addGestureRecognizer:captureTap];
+    }
+    return self;
+}
+
 // https://github.com/mapbox/mapbox-gl-native/issues/9228
 - (void)setCenter:(CGPoint)center {
     center.y = center.y - CGRectGetMidY(self.bounds);


### PR DESCRIPTION
We added a gesture recongizer to RCTMGLCallout to prevent the map
from getting the touch event. Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/726