### PR TITLE
[v6] Cocoapods

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -1,5 +1,18 @@
 # iOS Installation
 
+## Using CocoaPods
+
+To install with CocoaPods, add the following to your `Podfile`:
+
+```
+  # Mapbox
+  pod 'react-native-mapbox-gl', :path => '../node_modules/@mapbox/react-native-mapbox-gl'
+```
+
+Then run `pod install` and rebuild your project.
+
+## Manual Installation
+
 ### Add Native Mapbox SDK Framework
 
 Select your project in the `Project navigator`. Click `General` tab then add `node_modules/@mapbox/react-native-mapbox-gl/ios/Mapbox.framework` to `Embedded Binaries`. :collision: **Important, make sure you're adding it to general -> `Embedded Binaries` :collision:**

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files	= "lib/ios/RCTMGL/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Mapbox', '3.6'
+  s.dependency 'Mapbox-iOS-SDK', '~> 3.6'
 end


### PR DESCRIPTION
**changes:**

- Update podfile to work with latest iOS SDK
- Add instructions for installing with CocoaPods

**summary:**

Resolves #733 - Looks like cocapods support was mostly there (it was working in v5.x), just needed the Mapbox SDK dependency updated (and instructions).