### PR TITLE
[iOS] Fixes not setting PointAnnotation coordinate

### DIFF
--- a/ios/RCTMGL/RCTMGLPointAnnotation.h
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.h
@@ -21,7 +21,9 @@
 @property (nonatomic, copy) NSString *id;
 @property (nonatomic, copy) NSString *reactTitle;
 @property (nonatomic, copy) NSString *reactSnippet;
+
 @property (nonatomic, copy) NSString *reactCoordinate;
+@property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 
 @property (nonatomic, copy) NSDictionary<NSString *, NSNumber *> *anchor;
 

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -85,23 +85,15 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
     }
 }
 
+- (void)setReactCoordinate:(NSString *)reactCoordinate
+{
+    _reactCoordinate = reactCoordinate;
+    [self _updateCoordinate];
+}
+
 - (NSString *)reuseIdentifier
 {
     return _id;
-}
-
-- (CLLocationCoordinate2D)coordinate
-{
-    if (_reactCoordinate == nil) {
-        return CLLocationCoordinate2DMake(0.0, 0.0);
-    }
-    
-    MGLPointFeature *feature = (MGLPointFeature *)[RCTMGLUtils shapeFromGeoJSON:_reactCoordinate];
-    if (feature == nil) {
-        return CLLocationCoordinate2DMake(0.0, 0.0);
-    }
-    
-    return feature.coordinate;
 }
 
 - (NSString *)title
@@ -172,6 +164,22 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
     }
     
     self.centerOffset = CGVectorMake(dx, dy);
+}
+
+- (void)_updateCoordinate
+{
+    if (_reactCoordinate == nil) {
+        return;
+    }
+    
+    MGLPointFeature *feature = (MGLPointFeature *)[RCTMGLUtils shapeFromGeoJSON:_reactCoordinate];
+    if (feature == nil) {
+        return;
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+       self.coordinate = feature.coordinate;
+    });
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/750

* Fixes PointAnnotation being updated due by overriding `coordinate` and removing `readonly` modifier on the property.