### PR TITLE
Add support for zoomEnabled on MapView

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -94,6 +94,7 @@ public class RCTMGLMapView extends MapView implements
     private Boolean mAttributionEnabled;
     private Boolean mLogoEnabled;
     private Boolean mCompassEnabled;
+    private Boolean mZoomEnabled;
     private boolean mShowUserLocation;
 
     private long mActiveMarkerID = -1;
@@ -442,6 +443,11 @@ public class RCTMGLMapView extends MapView implements
         updateInsets();
     }
 
+    public void setReactZoomEnabled(boolean zoomEnabled) {
+        mZoomEnabled = zoomEnabled;
+        updateUISettings();
+    }
+
     public void setReactScrollEnabled(boolean scrollEnabled) {
         mScrollEnabled = scrollEnabled;
         updateUISettings();
@@ -678,6 +684,10 @@ public class RCTMGLMapView extends MapView implements
 
         if (mCompassEnabled != null && uiSettings.isCompassEnabled() != mCompassEnabled) {
             uiSettings.setCompassEnabled(mCompassEnabled);
+        }
+
+        if (mZoomEnabled != null && uiSettings.isZoomGesturesEnabled() != mZoomEnabled) {
+            uiSettings.setZoomGesturesEnabled(mZoomEnabled);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -90,6 +90,11 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         mapView.setReactAnimated(isAnimated);
     }
 
+    @ReactProp(name="zoomEnabled")
+    public void setZoomEnabled(RCTMGLMapView mapView, boolean zoomEnabled) {
+        mapView.setReactZoomEnabled(zoomEnabled);
+    }
+
     @ReactProp(name="scrollEnabled")
     public void setScrollEnabled(RCTMGLMapView mapView, boolean scrollEnabled) {
         mapView.setReactScrollEnabled(scrollEnabled);

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -16,6 +16,7 @@
 | zoomLevel | `number` | `16` | `false` | Initial zoom level of map |
 | minZoomLevel | `number` | `none` | `false` | Min zoom level of map |
 | maxZoomLevel | `number` | `none` | `false` | Max zoom level of map |
+| zoomEnabled | `bool` | `none` | `false` | Enable/Disable zoom on the map |
 | scrollEnabled | `bool` | `true` | `false` | Enable/Disable scroll on the map |
 | pitchEnabled | `bool` | `true` | `false` | Enable/Disable pitch on map |
 | rotateEnabled | `bool` | `true` | `false` | Enable/Disable rotation on map |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1206,6 +1206,13 @@
         "description": "Max zoom level of map"
       },
       {
+        "name": "zoomEnabled",
+        "required": false,
+        "type": "bool",
+        "default": "none",
+        "description": "Enable/Disable zoom on the map"
+      },
+      {
         "name": "scrollEnabled",
         "required": false,
         "type": "bool",

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -32,6 +32,7 @@
 @property (nonatomic, assign) BOOL reactLogoEnabled;
 @property (nonatomic, assign) BOOL reactCompassEnabled;
 @property (nonatomic, assign) BOOL reactShowUserLocation;
+@property (nonatomic, assign) BOOL reactZoomEnabled;
 
 @property (nonatomic, copy) NSString *reactCenterCoordinate;
 @property (nonatomic, copy) NSString *reactStyleURL;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -107,6 +107,11 @@ static double const M2PI = M_PI * 2;
 }
 #pragma clang diagnostic pop
 
+- (void)setReactZoomEnabled:(BOOL)reactZoomEnabled
+{
+    _reactZoomEnabled = reactZoomEnabled;
+    self.zoomEnabled = _reactZoomEnabled;
+}
 
 - (void)setReactScrollEnabled:(BOOL)reactScrollEnabled
 {

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -75,6 +75,7 @@ RCT_REMAP_VIEW_PROPERTY(attributionEnabled, reactAttributionEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(logoEnabled, reactLogoEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(showUserLocation, reactShowUserLocation, BOOL)
 RCT_REMAP_VIEW_PROPERTY(compassEnabled, reactCompassEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)
 RCT_REMAP_VIEW_PROPERTY(centerCoordinate, reactCenterCoordinate, NSString)

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -88,6 +88,11 @@ class MapView extends React.Component {
     maxZoomLevel: PropTypes.number,
 
     /**
+     * Enable/Disable zoom on the map
+     */
+    zoomEnabled: PropTypes.bool,
+
+    /**
      * Enable/Disable scroll on the map
      */
     scrollEnabled: PropTypes.bool,
@@ -609,23 +614,7 @@ class MapView extends React.Component {
   render () {
     let props = {
       ...this.props,
-      animated: this.props.animated,
       centerCoordinate: this._getCenterCoordinate(),
-      showUserLocation: this.props.showUserLocation,
-      userTrackingMode: this.props.userTrackingMode,
-      heading: this.props.heading,
-      pitch: this.props.pitch,
-      style: this.props.style,
-      styleURL: this.props.styleURL,
-      zoomLevel: this.props.zoomLevel,
-      minZoomLevel: this.props.minZoomLevel,
-      maxZoomLevel: this.props.maxZoomLevel,
-      scrollEnabled: this.props.scrollEnabled,
-      pitchEnabled: this.props.pitchEnabled,
-      rotateEnabled: this.props.rotateEnabled,
-      attributionEnabled: this.props.attributionEnabled,
-      logoEnabled: this.props.logoEnabled,
-      compassEnabled: this.props.compassEnabled,
       contentInset: this._getContentInset(),
     };
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "prop-types": ">=15.5.8",
-    "react": "16.0.0-alpha.12",
+    "react": "^16.0.0-alpha || ^16.0.0-beta || ^16.0.0",
     "react-native": ">=0.47.1"
   },
   "dependencies": {


### PR DESCRIPTION
Adds support for https://github.com/mapbox/react-native-mapbox-gl/issues/745 and fixes https://github.com/mapbox/react-native-mapbox-gl/issues/759

* There is now a `zoomEnabled` proptype on the `MapView`
* Fixes `React` peerDep warning