### PR TITLE
Solves String.format issue while printing double values

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
@@ -157,7 +157,7 @@ public class ConvertUtils {
             value = map.getDouble(key);
         } catch (NoSuchKeyException e) {
             // key not found use default value
-            Log.d(LOG_TAG, String.format("No key found for %s, using default value %d", key, defaultValue));
+            Log.d(LOG_TAG, String.format("No key found for %s, using default value %f", key, defaultValue));
         }
 
         return value;


### PR DESCRIPTION
`String.format` was crashing under Android because `defaultValue` is a double and `%d` is for decimal numeric system, not decimal point.