### PR TITLE
More accurate headers

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -21,7 +21,7 @@ allprojects {
 }
 ```
 
-### app:build.gradle
+####  _$(PROJECT_ROOT)/android/app/build.gradle_
 
 Add project under `dependencies`
 
@@ -36,7 +36,7 @@ Update Android SDK version if you did `react-native init`, we want to be on `25`
 * `buildToolsVersion "25.0.1"`
 * `targetSdkVersion 25`
 
-### settings.gradle
+#### _$(PROJECT_ROOT)/android/settings.gradle_
 
 Include project, so gradle knows where to find the project
 

--- a/android/install.md
+++ b/android/install.md
@@ -2,7 +2,7 @@
 
 ## Gradle Setup
 
-#### _$(PROJECT_ROOT)/android/app/build.gradle_
+#### $(PROJECT_ROOT)/android/app/build.gradle
 
 We need to add some `repositories` in order to get our dependencies.
 
@@ -21,7 +21,7 @@ allprojects {
 }
 ```
 
-####  _$(PROJECT_ROOT)/android/app/build.gradle_
+#### $(PROJECT_ROOT)/android/app/build.gradle
 
 Add project under `dependencies`
 
@@ -36,7 +36,7 @@ Update Android SDK version if you did `react-native init`, we want to be on `25`
 * `buildToolsVersion "25.0.1"`
 * `targetSdkVersion 25`
 
-#### _$(PROJECT_ROOT)/android/settings.gradle_
+#### $(PROJECT_ROOT)/android/settings.gradle
 
 Include project, so gradle knows where to find the project
 
@@ -45,7 +45,7 @@ include ':mapbox-react-native-mapbox-gl'
 project(':mapbox-react-native-mapbox-gl').projectDir = new File(rootProject.projectDir, '../node_modules/@mapbox/react-native-mapbox-gl/android/rctmgl')
 ```
 
-### MainApplication.java
+#### MainApplication.java
 
 We need to register our package
 

--- a/android/install.md
+++ b/android/install.md
@@ -2,7 +2,7 @@
 
 ## Gradle Setup
 
-### project:build.gradle
+#### _$(PROJECT_ROOT)/android/app/build.gradle_
 
 We need to add some `repositories` in order to get our dependencies.
 

--- a/android/install.md
+++ b/android/install.md
@@ -2,7 +2,7 @@
 
 ## Gradle Setup
 
-#### $(PROJECT_ROOT)/android/app/build.gradle
+#### $PROJECT_ROOT/android/app/build.gradle
 
 We need to add some `repositories` in order to get our dependencies.
 
@@ -21,7 +21,7 @@ allprojects {
 }
 ```
 
-#### $(PROJECT_ROOT)/android/app/build.gradle
+#### $PROJECT_ROOT/android/app/build.gradle
 
 Add project under `dependencies`
 
@@ -36,7 +36,7 @@ Update Android SDK version if you did `react-native init`, we want to be on `25`
 * `buildToolsVersion "25.0.1"`
 * `targetSdkVersion 25`
 
-#### $(PROJECT_ROOT)/android/settings.gradle
+#### $PROJECT_ROOT/android/settings.gradle
 
 Include project, so gradle knows where to find the project
 


### PR DESCRIPTION
As someone that hasn't worked a lot with Android previously, it's not obvious that the headers was referring to files. 

Eg:  **project:build.gradle** . Is that a function in a class or a relative path to a file?
I changed the headers to make that more clear.