### PR TITLE
Update to latest Mapbox Native SDKs

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -31,10 +31,10 @@ dependencies {
 }
 ```
 
-Update Android SDK version if you did `react-native init`, we want to be on `25` or higher.
-* `compileSdkVersion 25`
-* `buildToolsVersion "25.0.1"`
-* `targetSdkVersion 25`
+Update Android SDK version if you did `react-native init`, we want to be on `26` or higher.
+* `compileSdkVersion 26`
+* `buildToolsVersion "26.0.1"`
+* `targetSdkVersion 26`
 
 ### settings.gradle
 

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -26,12 +26,12 @@ dependencies {
     provided "com.facebook.react:react-native:+"
 
     // Mapbox SDK
-    compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.6'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.9'
 
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.4@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0@aar') {
         transitive=true
     }
 
     // Mapbox plugins
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0'
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -10,6 +10,7 @@ import android.support.annotation.NonNull;
 import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
@@ -641,6 +642,20 @@ public class RCTMGLMapView extends MapView implements
 
     public void init() {
         setStyleUrl(mStyleURL);
+
+        final OnAttachStateChangeListener attachStateChangeListener = new OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View view) {
+                reflow();
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View view) {
+                removeOnAttachStateChangeListener(this);
+            }
+        };
+
+        addOnAttachStateChangeListener(attachStateChangeListener);
     }
 
     private void updateCameraPositionIfNeeded(boolean shouldUpdateTarget) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -90,13 +90,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "com.rnmapboxglexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.6.4",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.0",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",


### PR DESCRIPTION
* Updates Android SDK to 5.2.0 (async rendering!)
* Updates iOS SDK to 3.7.0

Note all android applications will need to start targeting Android SDK version `26` install instructions have been updated