### PR TITLE
Update fitBounds to not use the Flight camera

### DIFF
--- a/example/src/components/FitBounds.js
+++ b/example/src/components/FitBounds.js
@@ -31,7 +31,7 @@ class FitBounds extends React.Component {
   }
 
   onFitBounds (i, bounds) {
-    this.map.fitBounds(bounds[0], bounds[1], 0, 2000); // ne sw
+    this.map.fitBounds(bounds[0], bounds[1], 0, 200); // ne sw
   }
 
   render () {

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -321,7 +321,7 @@ class MapView extends React.Component {
    * @param {Number=} duration - Duration of camera animation
    * @return {void}
    */
-  fitBounds (northEastCoordinates, southWestCoordinates, padding = 0, duration = 2000) {
+  fitBounds (northEastCoordinates, southWestCoordinates, padding = 0, duration = 0.0) {
     if (!this._nativeRef) {
       return;
     }
@@ -359,7 +359,7 @@ class MapView extends React.Component {
         ...pad,
       },
       duration: duration,
-      mode: MapboxGL.CameraModes.Flight,
+      mode: MapboxGL.CameraModes.None,
     });
   }
 


### PR DESCRIPTION
* Updates fitBounds on the MapView to not use the flight camera, to make it much faster
* fitBounds default duration has been changed to `0.0`