### PR TITLE
[Android] Add getPackStatus function

### DIFF
--- a/__tests__/__mocks__/react-native-mapbox-gl.mock.js
+++ b/__tests__/__mocks__/react-native-mapbox-gl.mock.js
@@ -166,6 +166,7 @@ NativeModules.MGLOfflineModule = {
   },
   getPacks: () => Promise.resolve([]),
   deletePack: () => Promise.resolve(),
+  getPackStatus: () => Promise.resolve({}),
   pausePackDownload: () => Promise.resolve(),
   resumePackDownload: () => Promise.resolve(),
   setTileCountLimit: jest.fn(),

--- a/__tests__/modules/offline/offlineManager.test.js
+++ b/__tests__/modules/offline/offlineManager.test.js
@@ -53,6 +53,18 @@ describe('offlineManager', () => {
     expect(offlinePack).toBeTruthy();
   });
 
+  it('should get pack status', async () => {
+    await MapboxGL.offlineManager.createPack(packOptions);
+    let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);
+    expect(offlinePack).toBeTruthy();    
+    
+    let status = await MapboxGL.offlineManager.getPackStatus(packOptions.name);
+    expect(status).toBeTruthy();
+
+    status = await MapboxGL.offlineManager.getPackStatus('xyz');
+    expect(status).toBeFalsy();
+  });  
+
   it('should delete pack', async () => {
     await MapboxGL.offlineManager.createPack(packOptions);
     let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -115,6 +115,49 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getPackStatus(final String name, final Promise promise) {
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
+            @Override
+            public void onList(OfflineRegion[] offlineRegions) {
+                OfflineRegion region = getRegionByName(name, offlineRegions);
+
+                if (region == null) {
+                    promise.resolve(null);
+                    Log.w(REACT_CLASS, "getPackStatus - Unknown offline region");
+                    return;
+                }
+
+                region.getStatus(new OfflineRegion.OfflineRegionStatusCallback() {
+                    @Override
+                    public void onStatus(OfflineRegionStatus status) {
+                        final WritableMap map = Arguments.createMap();
+                        map.putInt("downloadState", status.getDownloadState());
+                        map.putInt("completedResourceCount", (int)status.getCompletedResourceCount());
+                        map.putInt("completedResourceSize", (int)status.getCompletedResourceSize());
+                        map.putInt("completedTileSize", (int)status.getCompletedTileSize());
+                        map.putInt("completedTileCount", (int)status.getCompletedTileCount());
+                        map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
+                        Log.d(REACT_CLASS, String.format("getPackStatus %s", map));
+                        promise.resolve(map);
+                    }
+
+                    @Override
+                    public void onError(String error) {
+                        promise.reject("getPackStatus", error);
+                    }
+                });
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("getPackStatus", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void deletePack(final String name, final Promise promise) {
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -139,7 +139,6 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
                         map.putInt("completedTileSize", (int)status.getCompletedTileSize());
                         map.putInt("completedTileCount", (int)status.getCompletedTileCount());
                         map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
-                        Log.d(REACT_CLASS, String.format("getPackStatus %s", map));
                         promise.resolve(map);
                     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -91,7 +91,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         applicationId "com.rnmapboxglexample"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -67,7 +67,7 @@ class OfflineManager {
    * const status = await MapboxGL.offlineManager.getStatus('packName');
    *
    * @param  {String}  name  Name of the offline pack.
-   * @return {Object} status Status object
+   * @return {Promise} Promise containing Status object
    */
   async getPackStatus (name) {
     if (!name) {
@@ -76,12 +76,19 @@ class OfflineManager {
 
     await this._initialize();
     const offlinePack = this._offlinePacks[name];
-    
-    if (offlinePack) {
+
+    if (!offlinePack) {
+      return null;
+    }
+
+    try {
       const status = await MapboxGLOfflineManager.getPackStatus(name);
-      return status;
+      return Promise.resolve(status);
+    } catch (err) {
+      return Promise.reject(err);
     }
   }
+
 
   /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -61,6 +61,29 @@ class OfflineManager {
   }
 
   /**
+   * Retrieves the current status from a given pack that are stored in the database.
+   *
+   * @example
+   * const status = await MapboxGL.offlineManager.getStatus('packName');
+   *
+   * @param  {String}  name  Name of the offline pack.
+   * @return {Object} status Status object
+   */
+  async getPackStatus (name) {
+    if (!name) {
+      return;
+    }
+
+    await this._initialize();
+    const offlinePack = this._offlinePacks[name];
+    
+    if (offlinePack) {
+      const status = await MapboxGLOfflineManager.getPackStatus(name);
+      return status;
+    }
+  }
+
+  /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.
    *
    * @example


### PR DESCRIPTION
This PR adds getPackStatus function for Android (Issue #829)

```MapboxGL.offlineManager.getPackStatus('packName')``` will return something like this:

```
status: {
  completedTileCount: 1313,
  requiredResourceCount: 2597,
  completedTileSize: 20150500,
  completedResourceSize: 93329811,
  completedResourceCount: 2597,
  downloadState: 0
}
```