### PR TITLE
[Android] Fixes stale active marker id

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
@@ -5,8 +5,12 @@ import android.graphics.PointF;
 import android.view.MotionEvent;
 import android.view.View;
 
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.mapbox.mapboxsdk.annotations.MarkerView;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
@@ -48,6 +52,11 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
     @Override
     public boolean dispatchTouchEvent(MotionEvent event) {
         return false;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        setMeasuredDimension(getWidth(), getHeight());
     }
 
     @Override
@@ -163,7 +172,6 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
     }
 
     public void onDeselect() {
-
         mManager.handleEvent(makeEvent(false));
     }
 
@@ -176,12 +184,7 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
 
         final RCTMGLPointAnnotation self = this;
         if (mIsSelected) {
-            post(new Runnable() {
-                @Override
-                public void run() {
-                    mMapView.selectAnnotation(self);
-                }
-            });
+            mMapView.selectAnnotation(self);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -174,6 +174,12 @@ public class RCTMGLMapView extends MapView implements
         if (feature instanceof RCTSource) {
             mSources.remove(childPosition);
         } else if (feature instanceof RCTMGLPointAnnotation) {
+            RCTMGLPointAnnotation annotation = (RCTMGLPointAnnotation) feature;
+
+            if (annotation.getMapboxID() == mActiveMarkerID) {
+                mActiveMarkerID = -1;
+            }
+
             mPointAnnotations.remove(childPosition);
         }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -79,10 +79,10 @@ public class RCTMGLMapView extends MapView implements
     private Context mContext;
     private Handler mHandler;
 
-    private SparseArray<RCTSource> mSources;
-    private SparseArray<RCTMGLPointAnnotation> mPointAnnotations;
-    private SparseArray<AbstractMapFeature> mQueuedFeatures;
-    private SparseArray<AbstractMapFeature> mFeatures;
+    private List<AbstractMapFeature> mFeatures;
+    private List<AbstractMapFeature> mQueuedFeatures;
+    private Map<String, RCTMGLPointAnnotation> mPointAnnotations;
+    private Map<String, RCTSource> mSources;
 
     private CameraUpdateQueue mCameraUpdateQueue;
 
@@ -125,10 +125,10 @@ public class RCTMGLMapView extends MapView implements
         mManager = manager;
         mCameraUpdateQueue = new CameraUpdateQueue();
 
-        mSources = new SparseArray<>();
-        mPointAnnotations = new SparseArray<>();
-        mQueuedFeatures = new SparseArray<>();
-        mFeatures = new SparseArray<>();
+        mSources = new HashMap<>();
+        mPointAnnotations = new HashMap<>();
+        mQueuedFeatures = new ArrayList<>();
+        mFeatures = new ArrayList<>();
 
         mHandler = new Handler();
 
@@ -139,12 +139,14 @@ public class RCTMGLMapView extends MapView implements
         AbstractMapFeature feature = null;
 
         if (childView instanceof RCTSource) {
-            mSources.put(childPosition, (RCTSource) childView);
+            RCTSource source = (RCTSource) childView;
+            mSources.put(source.getID(), source);
             feature = (AbstractMapFeature) childView;
         } else if (childView instanceof RCTMGLLight) {
             feature = (AbstractMapFeature) childView;
         } else if (childView instanceof RCTMGLPointAnnotation) {
-            mPointAnnotations.put(childPosition, (RCTMGLPointAnnotation) childView);
+            RCTMGLPointAnnotation annotation = (RCTMGLPointAnnotation) childView;
+            mPointAnnotations.put(annotation.getID(), annotation);
             feature = (AbstractMapFeature) childView;
         } else {
             ViewGroup children = (ViewGroup) childView;
@@ -157,9 +159,9 @@ public class RCTMGLMapView extends MapView implements
         if (feature != null) {
             if (mMap != null) {
                 feature.addToMap(this);
-                mFeatures.put(childPosition, feature);
+                mFeatures.add(childPosition, feature);
             } else {
-                mQueuedFeatures.put(childPosition, feature);
+                mQueuedFeatures.add(childPosition, feature);
             }
         }
     }
@@ -172,7 +174,8 @@ public class RCTMGLMapView extends MapView implements
         }
 
         if (feature instanceof RCTSource) {
-            mSources.remove(childPosition);
+            RCTSource source = (RCTSource) feature;
+            mSources.remove(source.getID());
         } else if (feature instanceof RCTMGLPointAnnotation) {
             RCTMGLPointAnnotation annotation = (RCTMGLPointAnnotation) feature;
 
@@ -180,11 +183,11 @@ public class RCTMGLMapView extends MapView implements
                 mActiveMarkerID = -1;
             }
 
-            mPointAnnotations.remove(childPosition);
+            mPointAnnotations.remove(annotation.getID());
         }
 
         feature.removeFromMap(this);
-        mFeatures.remove(childPosition);
+        mFeatures.remove(feature);
     }
 
     public int getFeatureCount() {
@@ -192,7 +195,7 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public AbstractMapFeature getFeatureAt(int i) {
-        return mFeatures.get(mFeatures.keyAt(i));
+        return mFeatures.get(i);
     }
 
     public void dispose() {
@@ -207,8 +210,8 @@ public class RCTMGLMapView extends MapView implements
             return null;
         }
 
-        for (int i = 0; i < mPointAnnotations.size(); i++) {
-            RCTMGLPointAnnotation annotation = mPointAnnotations.get(mPointAnnotations.keyAt(i));
+        for (String key : mPointAnnotations.keySet()) {
+            RCTMGLPointAnnotation annotation = mPointAnnotations.get(key);
 
             if (annotation != null && annotationID.equals(annotation.getID())) {
                 return annotation;
@@ -219,13 +222,14 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public RCTMGLPointAnnotation getPointAnnotationByMarkerID(long markerID) {
-        for (int i = 0; i < mPointAnnotations.size(); i++) {
-            RCTMGLPointAnnotation annotation = mPointAnnotations.get(mPointAnnotations.keyAt(i));
+        for (String key : mPointAnnotations.keySet()) {
+            RCTMGLPointAnnotation annotation = mPointAnnotations.get(key);
 
             if (annotation != null && markerID == annotation.getMapboxID()) {
                 return annotation;
             }
         }
+
         return null;
     }
 
@@ -269,10 +273,9 @@ public class RCTMGLMapView extends MapView implements
 
         if (mQueuedFeatures.size() > 0) {
             for (int i = 0; i < mQueuedFeatures.size(); i++) {
-                int childPosition = mQueuedFeatures.keyAt(i);
-                AbstractMapFeature feature = mQueuedFeatures.get(childPosition);
+                AbstractMapFeature feature = mQueuedFeatures.get(i);
                 feature.addToMap(this);
-                mFeatures.put(childPosition, feature);
+                mFeatures.add(feature);
             }
             mQueuedFeatures = null;
         }
@@ -308,8 +311,8 @@ public class RCTMGLMapView extends MapView implements
         boolean isEventCaptured = false;
 
         if (mActiveMarkerID != -1) {
-            for (int i = 0; i < mPointAnnotations.size(); i++) {
-                RCTMGLPointAnnotation annotation = mPointAnnotations.get(mPointAnnotations.keyAt(i));
+            for (String key : mPointAnnotations.keySet()) {
+                RCTMGLPointAnnotation annotation = mPointAnnotations.get(key);
 
                 if (mActiveMarkerID == annotation.getMapboxID()) {
                     isEventCaptured = deselectAnnotation(annotation);
@@ -375,8 +378,8 @@ public class RCTMGLMapView extends MapView implements
         RCTMGLPointAnnotation activeAnnotation = null;
         RCTMGLPointAnnotation nextActiveAnnotation = null;
 
-        for (int i = 0; i < mPointAnnotations.size(); i++) {
-            RCTMGLPointAnnotation annotation = mPointAnnotations.get(mPointAnnotations.keyAt(i));
+        for (String key : mPointAnnotations.keySet()) {
+            RCTMGLPointAnnotation annotation = mPointAnnotations.get(key);
             final long curMarkerID = annotation.getMapboxID();
 
             if (selectedMarkerID == curMarkerID) {
@@ -899,8 +902,8 @@ public class RCTMGLMapView extends MapView implements
         if (mSources.size() == 0) {
             return;
         }
-        for (int i = 0; i < mSources.size(); i++) {
-            RCTSource source = mSources.get(mSources.keyAt(i));
+        for (String key : mSources.keySet()) {
+            RCTSource source = mSources.get(key);
             source.removeFromMap(this);
         }
     }
@@ -909,8 +912,8 @@ public class RCTMGLMapView extends MapView implements
         if (mSources.size() == 0) {
             return;
         }
-        for (int i = 0; i < mSources.size(); i++) {
-            RCTSource source = mSources.get(mSources.keyAt(i));
+        for (String key : mSources.keySet()) {
+            RCTSource source = mSources.get(key);
             source.addToMap(this);
         }
     }
@@ -918,8 +921,8 @@ public class RCTMGLMapView extends MapView implements
     private List<RCTSource> getAllTouchableSources() {
         List<RCTSource> sources = new ArrayList<>();
 
-        for (int i = 0; i < mSources.size(); i++) {
-            RCTSource source = mSources.get(mSources.keyAt(i));
+        for (String key : mSources.keySet()) {
+            RCTSource source = mSources.get(key);
 
             if (source.hasPressListener()) {
                 sources.add(source);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
@@ -37,12 +37,12 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
     protected Map<String, Double> mTouchHitbox;
 
     protected List<RCTLayer> mLayers;
-    private SparseArray<RCTLayer> mQueuedLayers;
+    private List<RCTLayer> mQueuedLayers;
 
     public RCTSource(Context context) {
         super(context);
         mLayers = new ArrayList<>();
-        mQueuedLayers = new SparseArray<>();
+        mQueuedLayers = new ArrayList<>();
     }
 
     public String getID() {
@@ -124,8 +124,7 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
 
         if (mQueuedLayers != null && mQueuedLayers.size() > 0) { // first load
             for (int i = 0; i < mQueuedLayers.size(); i++) {
-                int childPosition = mQueuedLayers.keyAt(i);
-                addLayerToMap(mQueuedLayers.get(childPosition), childPosition);
+                addLayerToMap(mQueuedLayers.get(i), i);
             }
             mQueuedLayers = null;
         } else if (mLayers.size() > 0) { // handles the case of switching style url, but keeping layers on map
@@ -153,7 +152,7 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
 
         RCTLayer layer = (RCTLayer) childView;
         if (mMap == null) {
-            mQueuedLayers.put(childPosition, layer);
+            mQueuedLayers.add(childPosition, layer);
         } else {
             addLayerToMap(layer, childPosition);
         }


### PR DESCRIPTION
* Fixes active marker id not being set to -1, when we remove that marker from map.
* Prevents onDeselect handler being called if annotation does not have a callout
* Overrides onMeasure in RCTMGLPointAnnotation, to directly give known width and height
* Updates MapView child view insertion order