### PR TITLE
[ANDROID] blank info box displayed when annotation has no title

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
@@ -121,12 +121,20 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
         }
     }
 
+    public String getTitle () {
+        return mTitle;
+    }
+
     public void setSnippet(String snippet) {
         mSnippet = snippet;
 
         if (mAnnotation != null) {
             mAnnotation.setSnippet(snippet);
         }
+    }
+
+    public String getSnippet () {
+        return mSnippet;
     }
 
     public void setCoordinate(Point point) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
@@ -113,6 +113,10 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
         return mCallout;
     }
 
+    public boolean hasInfoWindow() {
+        return (mTitle != null || mSnippet != null || mCallout != null);
+    }
+
     public void setTitle(String title) {
         mTitle = title;
 
@@ -121,20 +125,12 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature {
         }
     }
 
-    public String getTitle () {
-        return mTitle;
-    }
-
     public void setSnippet(String snippet) {
         mSnippet = snippet;
 
         if (mAnnotation != null) {
             mAnnotation.setSnippet(snippet);
         }
-    }
-
-    public String getSnippet () {
-        return mSnippet;
     }
 
     public void setCoordinate(Point point) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -405,16 +405,10 @@ public class RCTMGLMapView extends MapView implements
 
         if (id != mActiveMarkerID) {
             final MarkerView markerView = annotation.getMarker();
-            String title = annotation.getTitle();
-            String snippet = annotation.getSnippet();
             annotation.onSelect(true);
             mActiveMarkerID = id;
-            RCTMGLCallout calloutView = annotation.getCalloutView();
-            if (title != null || snippet !== null || (!markerView.isInfoWindowShown() && calloutView != null)) {
+            if (!markerView.isInfoWindowShown() && annotation.hasInfoWindow()) {
                 mMap.selectMarker(markerView);
-            }
-            if (!markerView.isInfoWindowShown() && calloutView != null) {
-                markerView.showInfoWindow(mMap, this);
             }
         }
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -405,11 +405,14 @@ public class RCTMGLMapView extends MapView implements
 
         if (id != mActiveMarkerID) {
             final MarkerView markerView = annotation.getMarker();
-            mMap.selectMarker(markerView);
+            String title = annotation.getTitle();
+            String snippet = annotation.getSnippet();
             annotation.onSelect(true);
             mActiveMarkerID = id;
-
             RCTMGLCallout calloutView = annotation.getCalloutView();
+            if (title != null || snippet !== null || (!markerView.isInfoWindowShown() && calloutView != null)) {
+                mMap.selectMarker(markerView);
+            }
             if (!markerView.isInfoWindowShown() && calloutView != null) {
                 markerView.showInfoWindow(mMap, this);
             }


### PR DESCRIPTION
if an annotation has no title or snipped or callout, when it is selected, a blank info window is shown.
I think its related to this
<img width="771" alt="screen shot 2017-12-14 at 4 18 29 pm" src="https://user-images.githubusercontent.com/9347950/33984316-250997d2-e0f2-11e7-9337-94e3cbd43cb0.png">
