### PR TITLE
Offline pack updates

### DIFF
--- a/__tests__/__mocks__/react-native-mapbox-gl.mock.js
+++ b/__tests__/__mocks__/react-native-mapbox-gl.mock.js
@@ -169,6 +169,7 @@ NativeModules.MGLOfflineModule = {
   getPackStatus: () => Promise.resolve({}),
   pausePackDownload: () => Promise.resolve(),
   resumePackDownload: () => Promise.resolve(),
+  setPackObserver: () => Promise.resolve(),
   setTileCountLimit: jest.fn(),
   setProgressEventThrottle: jest.fn(),
 };

--- a/__tests__/__mocks__/react-native-mapbox-gl.mock.js
+++ b/__tests__/__mocks__/react-native-mapbox-gl.mock.js
@@ -166,6 +166,7 @@ NativeModules.MGLOfflineModule = {
   },
   getPacks: () => Promise.resolve([]),
   deletePack: () => Promise.resolve(),
+  getPackStatus: () => Promise.resolve({}),
   pausePackDownload: () => Promise.resolve(),
   resumePackDownload: () => Promise.resolve(),
   setTileCountLimit: jest.fn(),

--- a/__tests__/modules/offline/OfflinePack.test.js
+++ b/__tests__/modules/offline/OfflinePack.test.js
@@ -31,4 +31,12 @@ describe('OfflinePack', () => {
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
+
+  it('should get pack status', () => {
+    const spy = jest.spyOn(NativeModules.MGLOfflineModule, 'getPackStatus');
+    const offlinePack = new OfflinePack(fakeNativePack);
+    offlinePack.status();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });

--- a/__tests__/modules/offline/offlineManager.test.js
+++ b/__tests__/modules/offline/offlineManager.test.js
@@ -53,6 +53,18 @@ describe('offlineManager', () => {
     expect(offlinePack).toBeTruthy();
   });
 
+  it('should get pack status', async () => {
+    await MapboxGL.offlineManager.createPack(packOptions);
+    let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);
+    expect(offlinePack).toBeTruthy();    
+    
+    let status = await MapboxGL.offlineManager.getPackStatus(packOptions.name);
+    expect(status).toBeTruthy();
+
+    status = await MapboxGL.offlineManager.getPackStatus('xyz');
+    expect(status).toBeFalsy();
+  });  
+
   it('should delete pack', async () => {
     await MapboxGL.offlineManager.createPack(packOptions);
     let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);

--- a/__tests__/modules/offline/offlineManager.test.js
+++ b/__tests__/modules/offline/offlineManager.test.js
@@ -1,6 +1,6 @@
+import { NativeModules, Platform } from 'react-native';
 import MapboxGL from '../../../javascript';
 import { OfflineModuleEventEmitter } from '../../../javascript/modules/offline/offlineManager';
-import { NativeModules } from 'react-native';
 
 describe('offlineManager', () => {
   const packOptions = {
@@ -143,6 +143,52 @@ describe('offlineManager', () => {
       expect(
         MapboxGL.offlineManager._hasListeners(packOptions.name, MapboxGL.offlineManager._errorListeners)
       ).toBeFalsy();
+    });
+  });
+
+  describe('Android', () => {
+    beforeEach(() => Platform.OS = 'android');
+
+    it('should set pack observer manually', async () => {
+      const spy = jest.spyOn(NativeModules.MGLOfflineModule, 'setPackObserver');
+
+      const name = `test-${Date.now()}`;
+      const noop = () => {};
+      const options = { ...packOptions, name: name };
+      await MapboxGL.offlineManager.createPack(options);
+      await MapboxGL.offlineManager.subscribe(name, noop, noop);
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should not set pack observer manually during create flow', async () => {
+      const spy = jest.spyOn(NativeModules.MGLOfflineModule, 'setPackObserver');
+
+      const name = `test-${Date.now()}`;
+      const noop = () => {};
+      const options = { ...packOptions, name: name };
+      await MapboxGL.offlineManager.createPack(options, noop, noop);
+
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe('iOS', () => {
+    beforeEach(() => Platform.OS = 'ios');
+
+    it('should not set pack observer manually', async () => {
+      const spy = jest.spyOn(NativeModules.MGLOfflineModule, 'setPackObserver');
+
+      const name = `test-${Date.now()}`;
+      const noop = () => {};
+      const options = { ...packOptions, name: name };
+      await MapboxGL.offlineManager.createPack(options);
+      await MapboxGL.offlineManager.subscribe(name, noop, noop);
+
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
     });
   });
 });

--- a/__tests__/modules/offline/offlineManager.test.js
+++ b/__tests__/modules/offline/offlineManager.test.js
@@ -53,18 +53,6 @@ describe('offlineManager', () => {
     expect(offlinePack).toBeTruthy();
   });
 
-  it('should get pack status', async () => {
-    await MapboxGL.offlineManager.createPack(packOptions);
-    let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);
-    expect(offlinePack).toBeTruthy();    
-    
-    let status = await MapboxGL.offlineManager.getPackStatus(packOptions.name);
-    expect(status).toBeTruthy();
-
-    status = await MapboxGL.offlineManager.getPackStatus('xyz');
-    expect(status).toBeFalsy();
-  });  
-
   it('should delete pack', async () => {
     await MapboxGL.offlineManager.createPack(packOptions);
     let offlinePack = await MapboxGL.offlineManager.getPack(packOptions.name);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -161,6 +161,30 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setPackObserver(final String name, final Promise promise) {
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
+            @Override
+            public void onList(OfflineRegion[] offlineRegions) {
+                OfflineRegion region = getRegionByName(name, offlineRegions);
+                boolean hasRegion = region != null;
+
+                if (hasRegion) {
+                    setOfflineRegionObserver(name, region);
+                }
+
+                promise.resolve(hasRegion);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("setPackObserver", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void deletePack(final String name, final Promise promise) {
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -143,14 +143,7 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
                 region.getStatus(new OfflineRegion.OfflineRegionStatusCallback() {
                     @Override
                     public void onStatus(OfflineRegionStatus status) {
-                        final WritableMap map = Arguments.createMap();
-                        map.putInt("downloadState", status.getDownloadState());
-                        map.putInt("completedResourceCount", (int)status.getCompletedResourceCount());
-                        map.putInt("completedResourceSize", (int)status.getCompletedResourceSize());
-                        map.putInt("completedTileSize", (int)status.getCompletedTileSize());
-                        map.putInt("completedTileCount", (int)status.getCompletedTileCount());
-                        map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
-                        promise.resolve(map);
+                        promise.resolve(makeRegionStatus(name, status));
                     }
 
                     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -306,7 +306,7 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
                 Log.d(REACT_CLASS, String.format("Completed Resource count %d", status.getCompletedResourceCount()));
 
                 if (shouldSendUpdate(System.currentTimeMillis(), status)) {
-                    sendEvent(makeStatusEvent(name, region, status));
+                    sendEvent(makeStatusEvent(name, status));
                     timestamp = System.currentTimeMillis();
                 }
                 prevStatus = status;
@@ -359,25 +359,35 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
         return new OfflineEvent(OFFLINE_ERROR, errorType, payload);
     }
 
-    private OfflineEvent makeStatusEvent(String regionName, OfflineRegion region, OfflineRegionStatus status) {
-        WritableMap payload = new WritableNativeMap();
+    private OfflineEvent makeStatusEvent(String regionName, OfflineRegionStatus status) {
+        return new OfflineEvent(OFFLINE_PROGRESS, EventTypes.OFFLINE_STATUS, makeRegionStatus(regionName, status));
+    }
+
+    private WritableMap makeRegionStatus(String regionName, OfflineRegionStatus status) {
+        WritableMap map = Arguments.createMap();
 
         int downloadState = status.getDownloadState();
+        double percentage = 0.0;
 
         if (status.isComplete()) {
             downloadState = COMPLETE_REGION_DOWNLOAD_STATE;
-            payload.putDouble("percentage", 100);
+            percentage = 100.0;
         } else {
-            double percentage = status.getRequiredResourceCount() >= 0
+            percentage = status.getRequiredResourceCount() >= 0
                     ? (100.0 * status.getCompletedResourceCount() / status.getRequiredResourceCount()) :
                     0.0;
-            payload.putDouble("percentage", percentage);
         }
 
-        payload.putInt("state", downloadState);
-        payload.putString("name", regionName);
+        map.putString("name", regionName);
+        map.putInt("state", downloadState);
+        map.putDouble("percentage", percentage);
+        map.putInt("completedResourceCount", (int)status.getCompletedResourceCount());
+        map.putInt("completedResourceSize", (int)status.getCompletedResourceSize());
+        map.putInt("completedTileSize", (int)status.getCompletedTileSize());
+        map.putInt("completedTileCount", (int)status.getCompletedTileCount());
+        map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
 
-        return new OfflineEvent(OFFLINE_PROGRESS, EventTypes.OFFLINE_STATUS, payload);
+        return map;
     }
 
     private LatLngBounds getBoundsFromOptions(ReadableMap options) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -126,6 +126,49 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getPackStatus(final String name, final Promise promise) {
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
+            @Override
+            public void onList(OfflineRegion[] offlineRegions) {
+                OfflineRegion region = getRegionByName(name, offlineRegions);
+
+                if (region == null) {
+                    promise.resolve(null);
+                    Log.w(REACT_CLASS, "getPackStatus - Unknown offline region");
+                    return;
+                }
+
+                region.getStatus(new OfflineRegion.OfflineRegionStatusCallback() {
+                    @Override
+                    public void onStatus(OfflineRegionStatus status) {
+                        final WritableMap map = Arguments.createMap();
+                        map.putInt("downloadState", status.getDownloadState());
+                        map.putInt("completedResourceCount", (int)status.getCompletedResourceCount());
+                        map.putInt("completedResourceSize", (int)status.getCompletedResourceSize());
+                        map.putInt("completedTileSize", (int)status.getCompletedTileSize());
+                        map.putInt("completedTileCount", (int)status.getCompletedTileCount());
+                        map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
+                        Log.d(REACT_CLASS, String.format("getPackStatus %s", map));
+                        promise.resolve(map);
+                    }
+
+                    @Override
+                    public void onError(String error) {
+                        promise.reject("getPackStatus", error);
+                    }
+                });
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("getPackStatus", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void deletePack(final String name, final Promise promise) {
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -150,7 +150,6 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
                         map.putInt("completedTileSize", (int)status.getCompletedTileSize());
                         map.putInt("completedTileCount", (int)status.getCompletedTileCount());
                         map.putInt("requiredResourceCount", (int)status.getRequiredResourceCount());
-                        Log.d(REACT_CLASS, String.format("getPackStatus %s", map));
                         promise.resolve(map);
                     }
 

--- a/example/src/components/CreateOfflineRegion.js
+++ b/example/src/components/CreateOfflineRegion.js
@@ -44,8 +44,7 @@ class CreateOfflineRegion extends React.Component {
 
     this.state = {
       name: `test-${Date.now()}`,
-      percentage: 0,
-      offlineRegion: null,
+      offlineRegionStatus: null,
     };
 
     this.onDownloadProgress = this.onDownloadProgress.bind(this);
@@ -80,15 +79,10 @@ class CreateOfflineRegion extends React.Component {
     );
   }
 
-  onDownloadProgress (offlineRegion, downloadStatus) {
-    // the iOS SDK will return 0 on the first event of a resume offline pack download
-    if (this.state.percentage > downloadStatus.percentage) {
-      return;
-    }
+  onDownloadProgress (offlineRegion, offlineRegionStatus) {
     this.setState({
       name: offlineRegion.name,
-      percentage: downloadStatus.percentage,
-      offlineRegion: offlineRegion,
+      offlineRegionStatus: offlineRegionStatus,
     });
   }
 
@@ -105,13 +99,26 @@ class CreateOfflineRegion extends React.Component {
   }
 
   _formatPercent () {
-    if (!this.state.percentage) {
+    if (!this.state.offlineRegionStatus) {
       return '0%';
     }
-    return `${(''+this.state.percentage).split('.')[0]}%`;
+    return Math.round(this.state.offlineRegionStatus.percentage / 10) / 10;
+  }
+
+  _getRegionDownloadState (downloadState) {
+    switch (downloadState) {
+      case MapboxGL.OfflinePackDownloadState.Active:
+        return 'Active';
+      case MapboxGL.OfflinePackDownloadState.Complete:
+        return 'Complete';
+      default:
+        return 'Inactive';
+    }
   }
 
   render () {
+    const offlineRegionStatus = this.state.offlineRegionStatus;
+
     return (
       <Page {...this.props}>
         <MapboxGL.MapView
@@ -122,13 +129,16 @@ class CreateOfflineRegion extends React.Component {
             centerCoordinate={CENTER_COORD}
             style={sheet.matchParent} />
 
-        {this.state.name !== null ? (
+        {offlineRegionStatus !== null ? (
           <Bubble>
             <View style={{ flex : 1 }}>
 
-              <Text style={styles.percentageText}>
-                Offline pack {this.state.name} is at {this._formatPercent()}
-              </Text>
+              <Text>Download State: {this._getRegionDownloadState(offlineRegionStatus.state)}</Text>
+              <Text>Download Percent: {offlineRegionStatus.percentage}</Text>
+              <Text>Completed Resource Count: {offlineRegionStatus.completedResourceCount}</Text>
+              <Text>Completed Resource Size: {offlineRegionStatus.completedResourceSize}</Text>
+              <Text>Completed Tile Count: {offlineRegionStatus.completedTileCount}</Text>
+              <Text>Required Resource Count: {offlineRegionStatus.requiredResourceCount}</Text>
 
               <View style={styles.buttonCnt}>
                 <TouchableOpacity onPress={this.onResume}>

--- a/example/src/components/CreateOfflineRegion.js
+++ b/example/src/components/CreateOfflineRegion.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Text, View, TouchableOpacity, Dimensions, StyleSheet } from 'react-native';
+
+import {
+  Alert,
+  Text,
+  View,
+  TouchableOpacity,
+  Dimensions,
+  StyleSheet,
+} from 'react-native';
+
 import MapboxGL from '@mapbox/react-native-mapbox-gl';
 import geoViewport from '@mapbox/geo-viewport';
 
@@ -44,6 +53,7 @@ class CreateOfflineRegion extends React.Component {
 
     this.state = {
       name: `test-${Date.now()}`,
+      offlineRegion: null,
       offlineRegionStatus: null,
     };
 
@@ -52,6 +62,7 @@ class CreateOfflineRegion extends React.Component {
 
     this.onResume = this.onResume.bind(this);
     this.onPause = this.onPause.bind(this);
+    this.onStatusRequest = this.onStatusRequest.bind(this);
   }
 
   componentWillUnmount () {
@@ -82,6 +93,7 @@ class CreateOfflineRegion extends React.Component {
   onDownloadProgress (offlineRegion, offlineRegionStatus) {
     this.setState({
       name: offlineRegion.name,
+      offlineRegion: offlineRegion,
       offlineRegionStatus: offlineRegionStatus,
     });
   }
@@ -95,6 +107,13 @@ class CreateOfflineRegion extends React.Component {
   onPause () {
     if (this.state.offlineRegion) {
       this.state.offlineRegion.pause();
+    }
+  }
+
+  async onStatusRequest () {
+    if (this.state.offlineRegion) {
+      const offlineRegionStatus = await this.state.offlineRegion.status();
+      Alert.alert('Get Status', JSON.stringify(offlineRegionStatus, null, 2));
     }
   }
 
@@ -144,6 +163,12 @@ class CreateOfflineRegion extends React.Component {
                 <TouchableOpacity onPress={this.onResume}>
                   <View style={styles.button}>
                     <Text style={styles.buttonTxt}>Resume</Text>
+                  </View>
+                </TouchableOpacity>
+
+                <TouchableOpacity onPress={this.onStatusRequest}>
+                  <View style={styles.button}>
+                    <Text style={styles.buttonTxt}>Status</Text>
                   </View>
                 </TouchableOpacity>
 

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -102,6 +102,21 @@ RCT_EXPORT_METHOD(getPacks:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseR
     resolve(jsonPacks);
 }
 
+RCT_EXPORT_METHOD(getPackStatus:(NSString *)name
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    MGLOfflinePack *pack = [self _getPackFromName:name];
+    
+    if (pack == nil) {
+        resolve(nil);
+        NSLog(@"getPackStatus - Unknown offline region");
+        return;
+    }
+    
+    resolve([self _makeRegionStatusPayload:name pack:pack]);
+}
+
 RCT_EXPORT_METHOD(deletePack:(NSString *)name
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
@@ -233,14 +248,13 @@ RCT_EXPORT_METHOD(setProgressEventThrottle:(NSNumber *)throttleValue)
                                 error:nil];
 }
 
-- (RCTMGLEvent *)_makeProgressEvent:(NSString *)name pack:(MGLOfflinePack *)pack
+- (NSDictionary *)_makeRegionStatusPayload:(NSString *)name pack:(MGLOfflinePack *)pack
 {
-    
     uint64_t completedResources = pack.progress.countOfResourcesCompleted;
     uint64_t expectedResources = pack.progress.countOfResourcesExpected;
     float progressPercentage = (float)completedResources / expectedResources;
     
-    NSDictionary *payload = @{
+    return @{
       @"state": @(pack.state),
       @"name": name,
       @"percentage": @(ceilf(progressPercentage * 100.0)),
@@ -250,8 +264,11 @@ RCT_EXPORT_METHOD(setProgressEventThrottle:(NSNumber *)throttleValue)
       @"completedTileCount": @(pack.progress.countOfTilesCompleted),
       @"requiredResourceCount": @(pack.progress.maximumResourcesExpected)
     };
-    
-    return [RCTMGLEvent makeEvent:RCT_MAPBOX_OFFLINE_PROGRESS withPayload:payload];
+}
+
+- (RCTMGLEvent *)_makeProgressEvent:(NSString *)name pack:(MGLOfflinePack *)pack
+{
+    return [RCTMGLEvent makeEvent:RCT_MAPBOX_OFFLINE_PROGRESS withPayload:[self _makeRegionStatusPayload:name pack:pack]];
 }
 
 - (RCTMGLEvent *)_makeErrorEvent:(NSString *)name type:(NSString *)type message:(NSString *)message

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -243,7 +243,12 @@ RCT_EXPORT_METHOD(setProgressEventThrottle:(NSNumber *)throttleValue)
     NSDictionary *payload = @{
       @"state": @(pack.state),
       @"name": name,
-      @"percentage": @(ceilf(progressPercentage * 100.0))
+      @"percentage": @(ceilf(progressPercentage * 100.0)),
+      @"completedResourceCount": @(pack.progress.countOfResourcesCompleted),
+      @"completedResourceSize": @(pack.progress.countOfBytesCompleted),
+      @"completedTileSize": @(pack.progress.countOfTileBytesCompleted),
+      @"completedTileCount": @(pack.progress.countOfTilesCompleted),
+      @"requiredResourceCount": @(pack.progress.maximumResourcesExpected)
     };
     
     return [RCTMGLEvent makeEvent:RCT_MAPBOX_OFFLINE_PROGRESS withPayload:payload];

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -8,7 +8,7 @@ import {
   isNumber,
   runNativeCommand,
   toJSONString,
-  IS_ANDROID,
+  isAndroid,
   viewPropTypes,
 } from '../utils';
 
@@ -278,7 +278,7 @@ class MapView extends React.Component {
       layerIDs,
     ]);
 
-    if (IS_ANDROID) {
+    if (isAndroid()) {
       return JSON.parse(res.data);
     }
 
@@ -307,7 +307,7 @@ class MapView extends React.Component {
       layerIDs,
     ]);
 
-    if (IS_ANDROID) {
+    if (isAndroid()) {
       return JSON.parse(res.data);
     }
 
@@ -476,7 +476,7 @@ class MapView extends React.Component {
   }
 
   _runNativeCommand (methodName, args = []) {
-    if (IS_ANDROID) {
+    if (isAndroid()) {
       return new Promise ((resolve) => {
         const callbackID = '' + Date.now();
         this._addAddAndroidCallback(callbackID, resolve);
@@ -632,10 +632,10 @@ class MapView extends React.Component {
       onPress: this._onPress,
       onLongPress: this._onLongPress,
       onMapChange: this._onChange,
-      onAndroidCallback: IS_ANDROID ? this._onAndroidCallback : undefined,
+      onAndroidCallback: isAndroid() ? this._onAndroidCallback : undefined,
     };
 
-    if (IS_ANDROID && this.props.textureMode) {
+    if (isAndroid() && this.props.textureMode) {
       return (
         <RCTMGLAndroidTextureMapView {...props} {...callbacks}>
           {this.props.children}
@@ -657,7 +657,7 @@ const RCTMGLMapView = requireNativeComponent(NATIVE_MODULE_NAME, MapView, {
 });
 
 let RCTMGLAndroidTextureMapView;
-if (IS_ANDROID) {
+if (isAndroid()) {
   RCTMGLAndroidTextureMapView = requireNativeComponent(ANDROID_TEXTURE_NATIVE_MODULE_NAME, MapView, {
     nativeOnly: { onMapChange: true, onAndroidCallback: true },
   });

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,5 +1,5 @@
 import { Animated, NativeModules, PermissionsAndroid } from 'react-native';
-import { IS_ANDROID } from './utils';
+import { isAndroid } from './utils';
 import * as geoUtils from './utils/geoUtils';
 
 // components
@@ -31,7 +31,7 @@ let MapboxGL = { ...NativeModules.MGLModule };
 
 // static methods
 MapboxGL.requestAndroidLocationPermissions = async function () {
-  if (IS_ANDROID) {
+  if (isAndroid()) {
     const res = await PermissionsAndroid.requestMultiple([
       PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
       PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION,

--- a/javascript/modules/offline/OfflinePack.js
+++ b/javascript/modules/offline/OfflinePack.js
@@ -24,6 +24,10 @@ class OfflinePack {
     return this._metadata;
   }
 
+  status () {
+    return MapboxGLOfflineManager.getPackStatus(this.name);
+  }
+
   resume () {
     return MapboxGLOfflineManager.resumePackDownload(this.name);
   }

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -67,7 +67,7 @@ class OfflineManager {
    * const status = await MapboxGL.offlineManager.getStatus('packName');
    *
    * @param  {String}  name  Name of the offline pack.
-   * @return {Object} status Status object
+   * @return {Promise} Promise containing Status object
    */
   async getPackStatus (name) {
     if (!name) {
@@ -76,12 +76,19 @@ class OfflineManager {
 
     await this._initialize();
     const offlinePack = this._offlinePacks[name];
-    
-    if (offlinePack) {
+
+    if (!offlinePack) {
+      return null;
+    }
+
+    try {
       const status = await MapboxGLOfflineManager.getPackStatus(name);
-      return status;
+      return Promise.resolve(status);
+    } catch (err) {
+      return Promise.reject(err);
     }
   }
+
 
   /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -61,6 +61,29 @@ class OfflineManager {
   }
 
   /**
+   * Retrieves the current status from a given pack that are stored in the database.
+   *
+   * @example
+   * const status = await MapboxGL.offlineManager.getStatus('packName');
+   *
+   * @param  {String}  name  Name of the offline pack.
+   * @return {Object} status Status object
+   */
+  async getPackStatus (name) {
+    if (!name) {
+      return;
+    }
+
+    await this._initialize();
+    const offlinePack = this._offlinePacks[name];
+    
+    if (offlinePack) {
+      const status = await MapboxGLOfflineManager.getPackStatus(name);
+      return status;
+    }
+  }
+
+  /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.
    *
    * @example

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -61,36 +61,6 @@ class OfflineManager {
   }
 
   /**
-   * Retrieves the current status from a given pack that are stored in the database.
-   *
-   * @example
-   * const status = await MapboxGL.offlineManager.getStatus('packName');
-   *
-   * @param  {String}  name  Name of the offline pack.
-   * @return {Promise} Promise containing Status object
-   */
-  async getPackStatus (name) {
-    if (!name) {
-      return;
-    }
-
-    await this._initialize();
-    const offlinePack = this._offlinePacks[name];
-
-    if (!offlinePack) {
-      return null;
-    }
-
-    try {
-      const status = await MapboxGLOfflineManager.getPackStatus(name);
-      return Promise.resolve(status);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-  }
-
-
-  /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.
    *
    * @example

--- a/javascript/utils/index.js
+++ b/javascript/utils/index.js
@@ -11,7 +11,10 @@ import {
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 export const viewPropTypes = ViewPropTypes || View.props;
-export const IS_ANDROID = Platform.OS === 'android';
+
+export function isAndroid () {
+  return Platform.OS === 'android';
+}
 
 export function isFunction (fn) {
   return typeof fn === 'function';
@@ -43,12 +46,12 @@ export function runNativeCommand (module, name, nativeRef, args = []) {
     throw new Error(`Could not find handle for native ref ${module}.${name}`);
   }
 
-  const managerInstance = IS_ANDROID ? NativeModules.UIManager[module] : NativeModules[getIOSModuleName(module)];
+  const managerInstance = isAndroid() ? NativeModules.UIManager[module] : NativeModules[getIOSModuleName(module)];
   if (!managerInstance) {
     throw new Error(`Could not find ${module}`);
   }
 
-  if (IS_ANDROID) {
+  if (isAndroid()) {
     return NativeModules.UIManager.dispatchViewManagerCommand(
       handle,
       managerInstance.Commands[name],


### PR DESCRIPTION
* Adds extra information to offline region status https://github.com/mapbox/react-native-mapbox-gl/issues/829
* Adds `status` method to offline packs, incase you wanted to grab just the current state of pack.
* Adds `setPackObserver` to Android to allow us to resume a pack download if we happened to not go to the create flow. The iOS SDK handles this internally for us