### PR TITLE
Cross platform location

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -229,9 +229,6 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public void dispose() {
-        if (mLocationLayer != null) {
-            mLocationLayer.removeCompassListener(mLocationManger);
-        }
         mLocationManger.dispose();
     }
 
@@ -386,7 +383,7 @@ public class RCTMGLMapView extends MapView implements
                 }
 
                 double currentMapRotation = getMapRotation();
-                if (lastMapRotation != currentMapRotation) {
+                if (lastMapRotation != currentMapRotation && mCameraChangeTracker.isUserInteraction()) {
                     updateUserTrackingMode(UserTrackingMode.FOLLOW);
                 }
 
@@ -1001,7 +998,6 @@ public class RCTMGLMapView extends MapView implements
     private void updateLocationLayer() {
         if (mLocationLayer == null) {
             mLocationLayer = new LocationLayerPlugin(this, mMap, mLocationManger.getEngine());
-            mLocationLayer.addCompassListener(mLocationManger);
         }
 
         int userLayerMode = UserTrackingMode.getMapLayerMode(mUserLocation.getTrackingMode(), mShowUserLocation);
@@ -1190,10 +1186,13 @@ public class RCTMGLMapView extends MapView implements
     }
 
     private double getDirectionForUserLocationUpdate() {
+        // NOTE: The direction of this is used for map rotation only, not location layer rotation
         CameraPosition currentCamera = mMap.getCameraPosition();
         double direction = currentCamera.bearing;
 
-        if (mUserLocation.getTrackingMode() == UserTrackingMode.FollowWithCourse) {
+
+        int userTrackingMode = mUserLocation.getTrackingMode();
+        if (userTrackingMode == UserTrackingMode.FollowWithHeading || userTrackingMode == UserTrackingMode.FollowWithCourse) {
             direction = mUserLocation.getBearing();
         }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -175,6 +175,11 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         mapView.setReactUserTrackingMode(userTrackingMode);
     }
 
+    @ReactProp(name="userLocationVerticalAlignment")
+    public void setUserLocationVerticalAlignment(RCTMGLMapView mapView, int userLocationVerticalAlignment) {
+        mapView.setReactUserLocationVerticalAlignment(userLocationVerticalAlignment);
+    }
+
     //endregion
 
     //region Custom Events

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -185,6 +185,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put(EventKeys.MAP_CLICK, "onPress")
                 .put(EventKeys.MAP_LONG_CLICK,"onLongPress")
                 .put(EventKeys.MAP_ONCHANGE, "onMapChange")
+                .put(EventKeys.MAP_USER_TRACKING_MODE_CHANGE, "onUserTrackingModeChange")
                 .put(EventKeys.MAP_ANDROID_CALLBACK, "onAndroidCallback")
                 .build();
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/helpers/CameraChangeTracker.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/helpers/CameraChangeTracker.java
@@ -1,0 +1,37 @@
+package com.mapbox.rctmgl.components.mapview.helpers;
+
+import android.util.Log;
+
+/**
+ * Created by nickitaliano on 12/12/17.
+ */
+
+public class CameraChangeTracker {
+    public static final int USER_GESTURE = 1;
+    public static final int USER_ANIMATION = 2;
+    public static final int SDK = 3;
+    public static final int EMPTY = -1;
+
+    private int reason;
+    private boolean isRegionChangeAnimated;
+
+    public void setReason(int reason) {
+        this.reason = reason;
+    }
+
+    public void setRegionChangeAnimated(boolean isRegionChangeAnimated) {
+        this.isRegionChangeAnimated = isRegionChangeAnimated;
+    }
+
+    public boolean isUserInteraction() {
+        return reason == USER_GESTURE || reason == USER_ANIMATION;
+    }
+
+    public boolean isAnimated() {
+        return isRegionChangeAnimated;
+    }
+
+    public boolean isEmpty() {
+        return reason == EMPTY;
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
+import com.mapbox.rctmgl.location.UserLocationLayerConstants;
 import com.mapbox.rctmgl.utils.ConvertUtils;
 import com.mapbox.rctmgl.utils.DownloadMapImageTask;
 import com.mapbox.rctmgl.utils.FilterParser;
@@ -170,6 +171,16 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         if (!hasInitialized()) {
             return;
         }
+
+        String userBackgroundID = UserLocationLayerConstants.BACKGROUND_LAYER_ID;
+        Layer userLocationBackgroundLayer = mMap.getLayer(userBackgroundID);
+
+        // place below user location layer
+        if (userLocationBackgroundLayer != null) {
+            mMap.addLayerBelow(mLayer, userBackgroundID);
+            return;
+        }
+
         mMap.addLayer(mLayer);
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapUserTrackingModeEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapUserTrackingModeEvent.java
@@ -1,0 +1,33 @@
+package com.mapbox.rctmgl.events;
+
+import android.view.View;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.mapbox.rctmgl.events.constants.EventKeys;
+import com.mapbox.rctmgl.events.constants.EventTypes;
+
+/**
+ * Created by nickitaliano on 12/19/17.
+ */
+
+public class MapUserTrackingModeEvent extends AbstractEvent {
+    private int mUserTrackingMode;
+
+    public MapUserTrackingModeEvent(View view, int userTrackingMode) {
+        super(view, EventTypes.MAP_USER_TRACKING_MODE_CHANGE);
+        mUserTrackingMode = userTrackingMode;
+    }
+
+    @Override
+    public String getKey() {
+        return EventKeys.MAP_USER_TRACKING_MODE_CHANGE;
+    }
+
+    @Override
+    public WritableMap getPayload() {
+        WritableMap payload = Arguments.createMap();
+        payload.putInt("userTrackingMode", mUserTrackingMode);
+        return payload;
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
@@ -12,6 +12,7 @@ public class EventKeys {
     public static final String MAP_LONG_CLICK = ns("map.longpress");
     public static final String MAP_ONCHANGE = ns("map.change");
     public static final String MAP_ANDROID_CALLBACK = ns("map.androidcallback");
+    public static final String MAP_USER_TRACKING_MODE_CHANGE = ns("map.usertrackingmodechange");
 
     // point annotation events
     public static final String POINT_ANNOTATION_SELECTED = ns("pointannotation.selected");

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
@@ -8,6 +8,7 @@ public class EventTypes {
     // map event types
     public static final String MAP_CLICK = "press";
     public static final String MAP_LONG_CLICK = "longpress";
+    public static final String MAP_USER_TRACKING_MODE_CHANGE = "usertrackingmodechange";
 
     public static final String REGION_WILL_CHANGE = "regionwillchange";
     public static final String REGION_IS_CHANGING = "regionischanging";

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -2,55 +2,47 @@ package com.mapbox.rctmgl.location;
 
 import android.content.Context;
 import android.location.Location;
+import android.util.Log;
 
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.locationlayer.CompassListener;
 import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
+import com.mapbox.services.android.location.MockLocationEngine;
 import com.mapbox.services.android.telemetry.location.GoogleLocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
 import com.mapbox.services.android.telemetry.location.LostLocationEngine;
 import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
+import com.mapbox.services.api.directions.v5.DirectionsCriteria;
+import com.mapbox.services.api.directions.v5.MapboxDirections;
+import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.services.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.commons.models.Position;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * Created by nickitaliano on 12/12/17.
  */
 
 @SuppressWarnings({"MissingPermission"})
-public class LocationManager implements LocationEngineListener, CompassListener {
+public class LocationManager implements LocationEngineListener {
+    // TODO: Add JS API to allow easier UI testing
+    private static final boolean MOCK_LOCATION = false;
+    private static final double[] originCoord = new double[]{ -74.135319, 40.795952 };
+    private static final double[] destCoord = new double[]{ -74.134510, 40.787626 };
+
     private LocationEngine locationEngine;
-
-    private float previousUserHeading = 0.0f;
     private OnUserLocationChange userLocationListener;
-
     private Context context;
-
-    @Override
-    public void onCompassChanged(float userHeading) {
-        Location location = getLastKnownLocation();
-
-        if (location == null || previousUserHeading == userHeading) {
-            return;
-        }
-
-        previousUserHeading = userHeading;
-        location.setBearing(userHeading);
-        onLocationChanged(location);
-    }
-
-    @Override
-    public void onCompassAccuracyChange(int compassStatus) {
-        Location location = getLastKnownLocation();
-
-        if (location == null) {
-            return;
-        }
-
-        location.setAccuracy(compassStatus);
-        onLocationChanged(location);
-    }
 
     public interface OnUserLocationChange {
         void onLocationChange(Location location);
@@ -66,11 +58,49 @@ public class LocationManager implements LocationEngineListener, CompassListener 
         }
 
         if (locationEngine == null) {
-            locationEngine = new LostLocationEngine(context);
-            locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
-            locationEngine.addLocationEngineListener(this);
-            locationEngine.setFastestInterval(1000);
-            locationEngine.activate();
+            if (MOCK_LOCATION) {
+                Position origin = Position.fromCoordinates(originCoord);
+                Position dest = Position.fromCoordinates(destCoord);
+
+                List<Position> positionList = new ArrayList<>();
+                positionList.add(origin);
+                positionList.add(dest);
+
+                MapboxDirections client = new MapboxDirections.Builder<>()
+                        .setAccessToken(Mapbox.getAccessToken())
+                        .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+                        .setSteps(true)
+                        .setCoordinates(positionList)
+                        .build();
+
+                final LocationManager self = this;
+                client.enqueueCall(new Callback<DirectionsResponse>() {
+                    @Override
+                    public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+                        DirectionsRoute route = response.body().getRoutes().get(0);
+
+                        MockLocationEngine mockLocationEngine = new MockLocationEngine();
+                        mockLocationEngine.setRoute(route);
+
+                        locationEngine = mockLocationEngine;
+                        locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+                        locationEngine.addLocationEngineListener(self);
+                        locationEngine.setFastestInterval(1000);
+                        locationEngine.activate();
+                    }
+
+                    @Override
+                    public void onFailure(Call<DirectionsResponse> call, Throwable t) {
+
+                    }
+                });
+            } else {
+                locationEngine = LostLocationEngine.getLocationEngine(context);
+                locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+                locationEngine.addLocationEngineListener(this);
+                locationEngine.setFastestInterval(1000);
+                locationEngine.activate();
+            }
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -1,0 +1,131 @@
+package com.mapbox.rctmgl.location;
+
+import android.content.Context;
+import android.location.Location;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.plugins.locationlayer.CompassListener;
+import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
+import com.mapbox.services.android.telemetry.location.GoogleLocationEngine;
+import com.mapbox.services.android.telemetry.location.LocationEngine;
+import com.mapbox.services.android.telemetry.location.LocationEngineListener;
+import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
+import com.mapbox.services.android.telemetry.location.LostLocationEngine;
+import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
+
+/**
+ * Created by nickitaliano on 12/12/17.
+ */
+
+@SuppressWarnings({"MissingPermission"})
+public class LocationManager implements LocationEngineListener, CompassListener {
+    private LocationEngine locationEngine;
+
+    private float previousUserHeading = 0.0f;
+    private OnUserLocationChange userLocationListener;
+
+    private Context context;
+
+    @Override
+    public void onCompassChanged(float userHeading) {
+        Location location = getLastKnownLocation();
+
+        if (location == null || previousUserHeading == userHeading) {
+            return;
+        }
+
+        previousUserHeading = userHeading;
+        location.setBearing(userHeading);
+        onLocationChanged(location);
+    }
+
+    @Override
+    public void onCompassAccuracyChange(int compassStatus) {
+        Location location = getLastKnownLocation();
+
+        if (location == null) {
+            return;
+        }
+
+        location.setAccuracy(compassStatus);
+        onLocationChanged(location);
+    }
+
+    public interface OnUserLocationChange {
+        void onLocationChange(Location location);
+    }
+
+    public LocationManager(Context context) {
+        this.context = context;
+    }
+
+    public void enable() {
+        if (!PermissionsManager.areLocationPermissionsGranted(context)) {
+            return;
+        }
+
+        if (locationEngine == null) {
+            locationEngine = new LostLocationEngine(context);
+            locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+            locationEngine.addLocationEngineListener(this);
+            locationEngine.setFastestInterval(1000);
+            locationEngine.activate();
+        }
+    }
+
+    public void disable() {
+        if (locationEngine == null) {
+            return;
+        }
+        locationEngine.deactivate();
+    }
+
+    public void dispose() {
+        if (locationEngine == null) {
+            return;
+        }
+        disable();
+        locationEngine.removeLocationUpdates();
+        locationEngine.removeLocationEngineListener(this);
+    }
+
+    public void setOnLocationChangeListener(OnUserLocationChange listener) {
+        this.userLocationListener = listener;
+    }
+
+    public boolean isActive() {
+        if (locationEngine == null) {
+            return false;
+        }
+        return locationEngine.isConnected();
+    }
+
+    public Location getLastKnownLocation() {
+        if (locationEngine == null) {
+            return null;
+        }
+        return locationEngine.getLastLocation();
+    }
+
+    public LocationEngine getEngine() {
+        return locationEngine;
+    }
+
+    @Override
+    public void onConnected() {
+        locationEngine.requestLocationUpdates();
+
+        Location lastKnownLocation = getLastKnownLocation();
+        if (lastKnownLocation != null) {
+            onLocationChanged(lastKnownLocation);
+        }
+    }
+
+    @Override
+    public void onLocationChanged(Location location) {
+        if (this.userLocationListener != null) {
+            this.userLocationListener.onLocationChange(location);
+        }
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocation.java
@@ -1,0 +1,70 @@
+package com.mapbox.rctmgl.location;
+
+import android.graphics.PointF;
+import android.graphics.RectF;
+import android.location.Location;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.plugins.locationlayer.TurfTransformation;
+import com.mapbox.rctmgl.utils.GeoJSONUtils;
+import com.mapbox.services.api.utils.turf.TurfConstants;
+import com.mapbox.services.api.utils.turf.TurfHelpers;
+import com.mapbox.services.api.utils.turf.TurfMeasurement;
+import com.mapbox.services.commons.geojson.Point;
+
+/**
+ * Created by nickitaliano on 12/13/17.
+ */
+
+public class UserLocation {
+    private Location currentLocation;
+    private int userTrackingMode = UserTrackingMode.NONE;
+
+    public UserLocation() {
+        this(null);
+    }
+
+    public UserLocation(Location currentLocation) {
+        this.currentLocation = currentLocation;
+    }
+
+    public Location getCurrentLocation() {
+        return currentLocation;
+    }
+
+    public double getBearing() {
+        if (currentLocation == null) {
+            return 0.0;
+        }
+        return currentLocation.getBearing();
+    }
+
+    public LatLng getCoordinate() {
+        if (currentLocation == null) {
+            return null;
+        }
+
+        return new LatLng(currentLocation.getLatitude(), currentLocation.getLongitude());
+    }
+
+    public void setCurrentLocation(Location currentLocation) {
+        this.currentLocation = currentLocation;
+    }
+
+    public void setTrackingMode(int userTrackingMode) {
+        this.userTrackingMode = userTrackingMode;
+    }
+
+    public int getTrackingMode() {
+        return userTrackingMode;
+    }
+
+    public float getDistance(Location location) {
+        if (currentLocation == null) {
+            return 0.0f;
+        }
+        return currentLocation.distanceTo(location);
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocation.java
@@ -2,7 +2,9 @@ package com.mapbox.rctmgl.location;
 
 import android.graphics.PointF;
 import android.graphics.RectF;
+import android.hardware.GeomagneticField;
 import android.location.Location;
+import android.util.Log;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -20,6 +22,8 @@ import com.mapbox.services.commons.geojson.Point;
 
 public class UserLocation {
     private Location currentLocation;
+    private Location previousLocation;
+
     private int userTrackingMode = UserTrackingMode.NONE;
 
     public UserLocation() {
@@ -50,6 +54,7 @@ public class UserLocation {
     }
 
     public void setCurrentLocation(Location currentLocation) {
+        this.previousLocation = this.currentLocation;
         this.currentLocation = currentLocation;
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocationLayerConstants.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocationLayerConstants.java
@@ -1,0 +1,13 @@
+package com.mapbox.rctmgl.location;
+
+/**
+ * Created by nickitaliano on 1/8/18.
+ */
+
+public class UserLocationLayerConstants {
+    public static final String BACKGROUND_LAYER_ID = "mapbox-location-stroke-layer";
+    public static final String FOREGROUND_LAYER_ID = "mapbox-location-layer";
+    public static final String ACCURACY_LAYER_ID = "mapbox-location-accuracy-layer";
+    public static final String BEARING_LAYER_ID = "mapbox-location-bearing-layer";
+    public static final String NAVIGATION_LAYER_ID = "mapbox-location-navigation-layer";
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocationVerticalAlignment.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserLocationVerticalAlignment.java
@@ -1,0 +1,11 @@
+package com.mapbox.rctmgl.location;
+
+/**
+ * Created by nickitaliano on 12/13/17.
+ */
+
+public class UserLocationVerticalAlignment {
+    public static final int CENTER = 0;
+    public static final int TOP = 1;
+    public static final int BOTTOM = 2;
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingMode.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingMode.java
@@ -1,0 +1,30 @@
+package com.mapbox.rctmgl.location;
+
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerMode;
+
+/**
+ * Created by nickitaliano on 12/13/17.
+ */
+
+public class UserTrackingMode {
+    public static final int NONE = 0;
+    public static final int FOLLOW = 1;
+    public static final int FollowWithCourse = 2;
+    public static final int FollowWithHeading = 3;
+
+    public static int getMapLayerMode(int mode, boolean isShowUserLocation) {
+        if (!isShowUserLocation || mode == NONE) {
+            return LocationLayerMode.TRACKING;
+        } else if (mode == FollowWithCourse) {
+            return LocationLayerMode.NAVIGATION;
+        } else if (mode == FollowWithHeading) {
+            return LocationLayerMode.COMPASS;
+        } else {
+            return LocationLayerMode.TRACKING;
+        }
+    }
+
+    public static boolean isUserGesture(int reason) {
+        return reason == 1 || reason == 2; // user gesture or animation
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingState.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingState.java
@@ -1,0 +1,19 @@
+package com.mapbox.rctmgl.location;
+
+/**
+ * Created by nickitaliano on 12/13/17.
+ */
+
+public class UserTrackingState {
+    // The map view not yet tracked the user location
+    public static final int POSSIBLE = 0;
+
+    // The map view has begun to move to the first user location
+    public static final int BEGAN = 1;
+
+    // The map views begins a significant transition
+    public static final int SIGNIFICANT_TRANSITION = 2;
+
+    // The map view has finished moving to the user location
+    public static final int CHANGED = 3;
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -19,6 +19,7 @@ import com.mapbox.rctmgl.components.camera.constants.CameraMode;
 import com.mapbox.rctmgl.components.styles.RCTMGLStyleValue;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
 import com.mapbox.rctmgl.events.constants.EventTypes;
+import com.mapbox.rctmgl.location.UserTrackingMode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +39,6 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
     public RCTMGLModule(ReactApplicationContext reactApplicationContext) {
         super(reactApplicationContext);
         mReactContext = reactApplicationContext;
-        mUiThreadHandler = new Handler(Looper.getMainLooper());
     }
 
     @Override
@@ -80,10 +80,10 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
 
         // user tracking modes
         Map<String, Integer> userTrackingModes = new HashMap<>();
-        userTrackingModes.put("None", LocationLayerMode.NONE);
-        userTrackingModes.put("Follow", LocationLayerMode.TRACKING);
-        userTrackingModes.put("FollowWithCourse", LocationLayerMode.NAVIGATION);
-        userTrackingModes.put("FollowWithHeading", LocationLayerMode.COMPASS);
+        userTrackingModes.put("None", UserTrackingMode.NONE);
+        userTrackingModes.put("Follow", UserTrackingMode.FOLLOW);
+        userTrackingModes.put("FollowWithCourse", UserTrackingMode.FollowWithCourse);
+        userTrackingModes.put("FollowWithHeading", UserTrackingMode.FollowWithHeading);
 
         // camera modes
         Map<String, Integer> cameraModes = new HashMap<>();
@@ -262,7 +262,7 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setAccessToken(final String accessToken) {
-        mUiThreadHandler.post(new Runnable() {
+        mReactContext.runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
                 Mapbox.getInstance(getReactApplicationContext(), accessToken);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -19,6 +19,7 @@ import com.mapbox.rctmgl.components.camera.constants.CameraMode;
 import com.mapbox.rctmgl.components.styles.RCTMGLStyleValue;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
 import com.mapbox.rctmgl.events.constants.EventTypes;
+import com.mapbox.rctmgl.location.UserLocationVerticalAlignment;
 import com.mapbox.rctmgl.location.UserTrackingMode;
 
 import java.util.HashMap;
@@ -84,6 +85,12 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
         userTrackingModes.put("Follow", UserTrackingMode.FOLLOW);
         userTrackingModes.put("FollowWithCourse", UserTrackingMode.FollowWithCourse);
         userTrackingModes.put("FollowWithHeading", UserTrackingMode.FollowWithHeading);
+
+        // user location vertical alignment
+        Map<String, Integer> userLocationVerticalAlignment = new HashMap<>();
+        userLocationVerticalAlignment.put("Center", UserLocationVerticalAlignment.CENTER);
+        userLocationVerticalAlignment.put("Top", UserLocationVerticalAlignment.TOP);
+        userLocationVerticalAlignment.put("Bottom", UserLocationVerticalAlignment.BOTTOM);
 
         // camera modes
         Map<String, Integer> cameraModes = new HashMap<>();
@@ -231,6 +238,7 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
                 .put("StyleURL", styleURLS)
                 .put("EventTypes", eventTypes)
                 .put("UserTrackingModes", userTrackingModes)
+                .put("UserLocationVerticalAlignment", userLocationVerticalAlignment)
                 .put("CameraModes", cameraModes)
                 .put("StyleSource", styleSourceConsts)
                 .put("InterpolationMode", interpolationModes)

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/GeoViewport.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/GeoViewport.java
@@ -1,0 +1,38 @@
+package com.mapbox.rctmgl.utils;
+
+import android.graphics.PointF;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.geometry.VisibleRegion;
+
+/**
+ * Created by nickitaliano on 1/5/18.
+ * Ported from https://github.com/mapbox/geo-viewport/blob/master/index.js
+ * This port only assumes we will have 512 vector tile sizes
+ */
+
+public class GeoViewport {
+    private static SphericalMercator sphericalMercator = new SphericalMercator();
+
+    public static VisibleRegion getRegion(LatLng centerCoord, int zoomLevel, int viewportWidth, int viewportHeight) {
+        PointF px = sphericalMercator.getPX(centerCoord, zoomLevel);
+
+        LatLng tl = sphericalMercator.getLatLng(new PointF(
+                px.x - (viewportWidth / 2),
+                px.y - (viewportHeight / 2)
+        ), zoomLevel);
+
+        LatLng br = sphericalMercator.getLatLng(new PointF(
+                px.x + (viewportWidth / 2),
+                px.y + (viewportHeight / 2)
+        ), zoomLevel);
+
+        LatLng farLeft = tl;
+        LatLng farRight = new LatLng(tl.getLatitude(), br.getLongitude());
+        LatLng nearLeft = new LatLng(br.getLatitude(), tl.getLongitude());
+        LatLng nearRight = br;
+
+        return new VisibleRegion(farLeft, farRight, nearLeft, nearRight, null);
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/SphericalMercator.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/SphericalMercator.java
@@ -1,0 +1,69 @@
+package com.mapbox.rctmgl.utils;
+
+import android.graphics.Point;
+import android.graphics.PointF;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by nickitaliano on 1/4/18.
+ * Ported from https://github.com/mapbox/sphericalmercator/blob/master/sphericalmercator.js
+ * This port only assumes we will have 512 vector tile sizes
+ */
+
+public class SphericalMercator {
+    public static final double D2R = Math.PI / 180;
+    public static final double R2D = 180 / Math.PI;
+
+    private static Map<String, List<Double>> cache;
+
+    public SphericalMercator() {
+        int tileSize = 512;
+
+        if (cache == null) {
+            cache = new HashMap<>();
+            cache.put("Bc", new ArrayList<Double>());
+            cache.put("Cc", new ArrayList<Double>());
+            cache.put("zc", new ArrayList<Double>());
+            cache.put("Ac", new ArrayList<Double>());
+
+            double size = (double) tileSize;
+            for (int d = 0; d < 30; d++) {
+                cache.get("Bc").add(size / 360);
+                cache.get("Cc").add(size / (2 * Math.PI));
+                cache.get("zc").add(size / 2);
+                cache.get("Ac").add(size);
+                size *= 2;
+            }
+        }
+    }
+
+    public PointF getPX(LatLng latLng, int zoomLevel) {
+        double d = cache.get("zc").get(zoomLevel);
+        double f = Math.min(Math.max(Math.sin(D2R * latLng.getLatitude()), -0.9999), 0.9999);
+        double x = Math.round(d + latLng.getLongitude() * cache.get("Bc").get(zoomLevel));
+        double y = Math.round(d + 0.5 * Math.log((1 + f) / (1 - f)) * (-cache.get("Cc").get(zoomLevel)));
+
+        if (x > cache.get("Ac").get(zoomLevel)) {
+            x = cache.get("Ac").get(zoomLevel);
+        }
+
+        if (y > cache.get("Ac").get(zoomLevel)) {
+            y = cache.get("Ac").get(zoomLevel);
+        }
+
+        return new PointF((float) x, (float) y);
+    }
+
+    public LatLng getLatLng(PointF px, int zoomLevel) {
+        double g = ((double)px.y - cache.get("zc").get(zoomLevel)) / (-cache.get("Cc").get(zoomLevel));
+        double lon = ((double) px.x - cache.get("zc").get(zoomLevel)) / cache.get("Bc").get(zoomLevel);
+        double lat = R2D * (2 * Math.atan(Math.exp(g)) - 0.5 * Math.PI);
+        return new LatLng(lat, lon);
+    }
+}

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -8,6 +8,7 @@
 | centerCoordinate | `arrayOf` | `none` | `false` | Initial center coordinate on map [lng, lat] |
 | showUserLocation | `bool` | `none` | `false` | Shows the users location on the map |
 | userTrackingMode | `number` | `MapboxGL.UserTrackingModes.None` | `false` | The mode used to track the user location on the map |
+| userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |
 | contentInset | `union` | `none` | `false` | The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport. |
 | heading | `number` | `0` | `false` | Initial heading on map |
 | pitch | `number` | `0` | `false` | Initial pitch on map |
@@ -39,8 +40,7 @@
 | onDidFinishRenderingMap | `func` | `none` | `false` | This event is triggered when the map finished rendering the map. |
 | onDidFinishRenderingMapFully | `func` | `none` | `false` | This event is triggered when the map fully finished rendering the map. |
 | onDidFinishLoadingStyle | `func` | `none` | `false` | This event is triggered when a style has finished loading. |
-| onFlyToComplete | `func` | `none` | `false` | This event is triggered when a fly to animation is cancelled or completed after calling flyTo |
-| onSetCameraComplete | `func` | `none` | `false` | This event is triggered once the camera is finished after calling setCamera |
+| onUserTrackingModeChange | `func` | `none` | `false` | This event is triggered when the users tracking mode is changed. |
 
 ### methods
 #### getVisibleBounds()

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1188,6 +1188,13 @@
         "description": "The mode used to track the user location on the map"
       },
       {
+        "name": "userLocationVerticalAlignment",
+        "required": false,
+        "type": "number",
+        "default": "none",
+        "description": "The vertical alignment of the user location within in map. This is only enabled while tracking the users location."
+      },
+      {
         "name": "contentInset",
         "required": false,
         "type": "union",
@@ -1405,18 +1412,11 @@
         "description": "This event is triggered when a style has finished loading."
       },
       {
-        "name": "onFlyToComplete",
+        "name": "onUserTrackingModeChange",
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "This event is triggered when a fly to animation is cancelled or completed after calling flyTo"
-      },
-      {
-        "name": "onSetCameraComplete",
-        "required": false,
-        "type": "func",
-        "default": "none",
-        "description": "This event is triggered once the camera is finished after calling setCamera"
+        "description": "This event is triggered when the users tracking mode is changed."
       }
     ],
     "composes": [

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
 
     <uses-sdk
         android:minSdkVersion="16"
@@ -24,6 +23,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -31,6 +31,7 @@ import ShowClick from './components/ShowClick';
 import FlyTo from './components/FlyTo';
 import FitBounds from './components/FitBounds';
 import SetUserTrackingModes from './components/SetUserTrackingModes';
+import SetUserLocationVerticalAlignment from './components/SetUserLocationVerticalAlignment';
 import ShowRegionDidChange from './components/ShowRegionDidChange';
 import CustomIcon from './components/CustomIcon';
 import YoYo from './components/YoYo';
@@ -100,6 +101,7 @@ const Examples = [
   new ExampleItem('Fly To', FlyTo),
   new ExampleItem('Fit Bounds', FitBounds),
   new ExampleItem('Set User Tracking Modes', SetUserTrackingModes),
+  new ExampleItem('Set User Location Vertical Alignment', SetUserLocationVerticalAlignment),
   new ExampleItem('Show Region Did Change', ShowRegionDidChange),
   new ExampleItem('Custom Icon', CustomIcon),
   new ExampleItem('Yo Yo Camera', YoYo),

--- a/example/src/components/SetUserLocationVerticalAlignment.js
+++ b/example/src/components/SetUserLocationVerticalAlignment.js
@@ -7,7 +7,7 @@ import TabBarPage from './common/TabBarPage';
 import sheet from '../styles/sheet';
 import { onSortOptions } from '../utils';
 
-class ShowMap extends React.Component {
+class SetUserLocationVerticalAlignment extends React.Component {
   static propTypes = {
     ...BaseExamplePropTypes,
   };
@@ -15,36 +15,35 @@ class ShowMap extends React.Component {
   constructor (props) {
     super(props);
 
-    this._mapOptions = Object.keys(MapboxGL.StyleURL).map((key) => {
+    this._alignmentOptions = Object.keys(MapboxGL.UserLocationVerticalAlignment).map((key) => {
       return {
         label: key,
-        data: MapboxGL.StyleURL[key],
+        data: MapboxGL.UserLocationVerticalAlignment[key],
       };
     }).sort(onSortOptions);
 
     this.state = {
-      styleURL: this._mapOptions[0].data,
+      currentAlignmentMode: this._alignmentOptions[0].data,
     };
 
-    this.onMapChange = this.onMapChange.bind(this);
+    this.onAlignmentChange = this.onAlignmentChange.bind(this);
   }
 
-  onMapChange (index, styleURL) {
-    this.setState({ styleURL: styleURL });
+  onAlignmentChange (index, userLocationVerticalAlignment) {
+    this.setState({ currentAlignmentMode: userLocationVerticalAlignment });
   }
 
   render () {
     return (
-      <TabBarPage {...this.props} scrollable options={this._mapOptions} onOptionPress={this.onMapChange}>
+      <TabBarPage {...this.props} options={this._alignmentOptions} onOptionPress={this.onAlignmentChange}>
         <MapboxGL.MapView
             showUserLocation={true}
-            zoomLevel={12}
             userTrackingMode={MapboxGL.UserTrackingModes.Follow}
-            styleURL={this.state.styleURL}
+            userLocationVerticalAlignment={this.state.currentAlignmentMode}
             style={sheet.matchParent} />
       </TabBarPage>
     );
   }
 }
 
-export default ShowMap;
+export default SetUserLocationVerticalAlignment;

--- a/example/src/components/SetUserTrackingModes.js
+++ b/example/src/components/SetUserTrackingModes.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Text } from 'react-native';
 import MapboxGL from '@mapbox/react-native-mapbox-gl';
 
 import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 import TabBarPage from './common/TabBarPage';
+import Bubble from './common/Bubble';
 
 import sheet from '../styles/sheet';
 import { onSortOptions } from '../utils';
@@ -23,14 +25,37 @@ class SetUserTrackingModes extends React.Component {
     }).sort(onSortOptions);
 
     this.state = {
-      userTrackingMode: this._trackingOptions[0].data,
+      userSelectedUserTrackingMode: this._trackingOptions[0].data,
+      currentTrackingMode: this._trackingOptions[0].data,
     };
 
     this.onTrackingChange = this.onTrackingChange.bind(this);
+    this.onUserTrackingModeChange = this.onUserTrackingModeChange.bind(this);
   }
 
   onTrackingChange (index, userTrackingMode) {
-    this.setState({ userTrackingMode: userTrackingMode });
+    this.setState({
+      userSelectedUserTrackingMode: userTrackingMode,
+      currentTrackingMode: userTrackingMode,
+    });
+  }
+
+  onUserTrackingModeChange (e) {
+    const userTrackingMode = e.nativeEvent.payload.userTrackingMode;
+    this.setState({ currentTrackingMode: userTrackingMode });
+  }
+
+  get userTrackingModeText () {
+    switch (this.state.currentTrackingMode) {
+      case MapboxGL.UserTrackingModes.Follow:
+        return 'Follow';
+      case MapboxGL.UserTrackingModes.FollowWithCourse:
+        return 'FollowWithCourse';
+      case MapboxGL.UserTrackingModes.FollowWithHeading:
+        return 'FolloWithHeading';
+      default:
+        return 'None';
+    }
   }
 
   render () {
@@ -38,8 +63,13 @@ class SetUserTrackingModes extends React.Component {
       <TabBarPage {...this.props} scrollable options={this._trackingOptions} onOptionPress={this.onTrackingChange}>
         <MapboxGL.MapView
             showUserLocation={true}
-            userTrackingMode={this.state.userTrackingMode}
+            userTrackingMode={this.state.userSelectedUserTrackingMode}
+            onUserTrackingModeChange={this.onUserTrackingModeChange}
             style={sheet.matchParent} />
+
+        <Bubble style={{ marginBottom: 100 }}>
+          <Text>User Tracking Mode: {this.userTrackingModeText}</Text>
+        </Bubble>
       </TabBarPage>
     );
   }

--- a/ios/RCTMGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMGL.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		C410D5D51F7AD0B300CF822A /* RCTMGLLight.m in Sources */ = {isa = PBXBuildFile; fileRef = C410D5D41F7AD0B300CF822A /* RCTMGLLight.m */; };
 		C410D5D81F7AD0C100CF822A /* RCTMGLLightManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C410D5D71F7AD0C100CF822A /* RCTMGLLightManager.m */; };
 		C41DCC9D1FBBA8F000895BB4 /* FilterList.m in Sources */ = {isa = PBXBuildFile; fileRef = C41DCC9C1FBBA8F000895BB4 /* FilterList.m */; };
+		C42219B51FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = C42219B41FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.m */; };
+		C42219BC1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C42219BB1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.m */; };
+		C42219BF1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C42219BE1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.m */; };
 		C42236A41F6B012000FA9C1C /* RCTMGLStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = C42236A31F6B012000FA9C1C /* RCTMGLStyle.m */; };
 		C42236A71F6C7F4E00FA9C1C /* RCTMGLFillExtrusionLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C42236A61F6C7F4E00FA9C1C /* RCTMGLFillExtrusionLayer.m */; };
 		C42236AA1F6C7F6200FA9C1C /* RCTMGLFillExtrusionLayerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C42236A91F6C7F6200FA9C1C /* RCTMGLFillExtrusionLayerManager.m */; };
@@ -79,6 +82,13 @@
 		C410D5D71F7AD0C100CF822A /* RCTMGLLightManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMGLLightManager.m; sourceTree = "<group>"; };
 		C41DCC9B1FBBA8F000895BB4 /* FilterList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterList.h; sourceTree = "<group>"; };
 		C41DCC9C1FBBA8F000895BB4 /* FilterList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FilterList.m; sourceTree = "<group>"; };
+		C42219B31FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLFaux3DUserLocationAnnotationView.h; sourceTree = "<group>"; };
+		C42219B41FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLFaux3DUserLocationAnnotationView.m; sourceTree = "<group>"; };
+		C42219B91FEB211700EE9E35 /* MGLUserLocationHeadingIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationHeadingIndicator.h; sourceTree = "<group>"; };
+		C42219BA1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationHeadingArrowLayer.h; sourceTree = "<group>"; };
+		C42219BB1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLUserLocationHeadingArrowLayer.m; sourceTree = "<group>"; };
+		C42219BD1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationHeadingBeamLayer.h; sourceTree = "<group>"; };
+		C42219BE1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLUserLocationHeadingBeamLayer.m; sourceTree = "<group>"; };
 		C42236A21F6B012000FA9C1C /* RCTMGLStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMGLStyle.h; sourceTree = "<group>"; };
 		C42236A31F6B012000FA9C1C /* RCTMGLStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMGLStyle.m; sourceTree = "<group>"; };
 		C42236A51F6C7F4E00FA9C1C /* RCTMGLFillExtrusionLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMGLFillExtrusionLayer.h; sourceTree = "<group>"; };
@@ -197,6 +207,20 @@
 			name = Light;
 			sourceTree = "<group>";
 		};
+		C42219B21FEB1FD600EE9E35 /* Location */ = {
+			isa = PBXGroup;
+			children = (
+				C42219B31FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.h */,
+				C42219B41FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.m */,
+				C42219B91FEB211700EE9E35 /* MGLUserLocationHeadingIndicator.h */,
+				C42219BA1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.h */,
+				C42219BB1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.m */,
+				C42219BD1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.h */,
+				C42219BE1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.m */,
+			);
+			name = Location;
+			sourceTree = "<group>";
+		};
 		C43773B91F56024900AF6D71 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -277,6 +301,7 @@
 		C4D1443F1F4E16F600396F26 /* RCTMGL */ = {
 			isa = PBXGroup;
 			children = (
+				C42219B21FEB1FD600EE9E35 /* Location */,
 				C43773B91F56024900AF6D71 /* Components */,
 				C43CA5031F507B8D000B9CB7 /* Events */,
 				C4D144941F4E2EC800396F26 /* Utils */,
@@ -487,6 +512,7 @@
 				C42236AA1F6C7F6200FA9C1C /* RCTMGLFillExtrusionLayerManager.m in Sources */,
 				C4FB12331F799F190055AE1F /* RCTMGLRasterLayer.m in Sources */,
 				C4D1444C1F4E178100396F26 /* RCTMGLMapView.m in Sources */,
+				C42219BF1FEB21D500EE9E35 /* MGLUserLocationHeadingBeamLayer.m in Sources */,
 				C410D5D51F7AD0B300CF822A /* RCTMGLLight.m in Sources */,
 				C42236A41F6B012000FA9C1C /* RCTMGLStyle.m in Sources */,
 				C4FD1DC21FCF550E00213AF2 /* RCTMGLImageSourceManager.m in Sources */,
@@ -507,11 +533,13 @@
 				C4FB10FE1F707A140055AE1F /* RCTMGLLineLayer.m in Sources */,
 				C4EAF1831F6336E20016DEE8 /* RCTMGLVectorSource.m in Sources */,
 				C4EAF1891F633C010016DEE8 /* RCTMGLVectorSourceManager.m in Sources */,
+				C42219BC1FEB215E00EE9E35 /* MGLUserLocationHeadingArrowLayer.m in Sources */,
 				C4FB122D1F7972A00055AE1F /* RCTMGLRasterSource.m in Sources */,
 				C4C87B941F9143DA0064AE95 /* RCTMGLCalloutManager.m in Sources */,
 				C410D5D81F7AD0C100CF822A /* RCTMGLLightManager.m in Sources */,
 				C4EAF17D1F6324970016DEE8 /* RCTMGLSource.m in Sources */,
 				C4FB11131F71EC9F0055AE1F /* RCTMGLSymbolLayerManager.m in Sources */,
+				C42219B51FEB205300EE9E35 /* MGLFaux3DUserLocationAnnotationView.m in Sources */,
 				C4C87A601F844C820064AE95 /* FilterParser.m in Sources */,
 				C4FD1DBF1FCF54FB00213AF2 /* RCTMGLImageSource.m in Sources */,
 				C41DCC9D1FBBA8F000895BB4 /* FilterList.m in Sources */,

--- a/ios/RCTMGL/MGLFaux3DUserLocationAnnotationView.h
+++ b/ios/RCTMGL/MGLFaux3DUserLocationAnnotationView.h
@@ -1,0 +1,23 @@
+//
+//  MGLFaux3DUserLocationAnnotationView.h
+//  RCTMGL
+//
+//  Created by Nick Italiano on 12/20/17.
+//  Copyright © 2017 Mapbox Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+@import Mapbox;
+
+extern const CGFloat MGLUserLocationAnnotationDotSize;
+extern const CGFloat MGLUserLocationAnnotationHaloSize;
+
+extern const CGFloat MGLUserLocationAnnotationPuckSize;
+extern const CGFloat MGLUserLocationAnnotationArrowSize;
+
+// Threshold in radians between heading indicator rotation updates.
+extern const CGFloat MGLUserLocationHeadingUpdateThreshold;
+
+@interface MGLFaux3DUserLocationAnnotationView : MGLUserLocationAnnotationView
+
+@end

--- a/ios/RCTMGL/MGLFaux3DUserLocationAnnotationView.m
+++ b/ios/RCTMGL/MGLFaux3DUserLocationAnnotationView.m
@@ -1,0 +1,473 @@
+//
+// https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+//
+
+#import "MGLFaux3DUserLocationAnnotationView.h"
+
+#import "MGLUserLocationHeadingIndicator.h"
+#import "MGLUserLocationHeadingArrowLayer.h"
+#import "MGLUserLocationHeadingBeamLayer.h"
+
+#import "RCTMGLMapView.h"
+
+const CGFloat MGLUserLocationAnnotationDotSize = 22.0;
+const CGFloat MGLUserLocationAnnotationHaloSize = 115.0;
+
+const CGFloat MGLUserLocationAnnotationPuckSize = 45.0;
+const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuckSize * 0.5;
+
+const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
+
+@implementation MGLFaux3DUserLocationAnnotationView
+{
+    BOOL _puckModeActivated;
+    
+    CALayer *_puckDot;
+    CAShapeLayer *_puckArrow;
+    
+    CALayer<MGLUserLocationHeadingIndicator> *_headingIndicatorLayer;
+    CALayer *_accuracyRingLayer;
+    CALayer *_dotBorderLayer;
+    CALayer *_dotLayer;
+    CALayer *_haloLayer;
+    
+    CLLocationDirection _oldHeadingAccuracy;
+    CLLocationAccuracy _oldHorizontalAccuracy;
+    double _oldZoom;
+    double _oldPitch;
+}
+
+- (CALayer *)hitTestLayer
+{
+    // Only the main dot should be interactive (i.e., exclude the accuracy ring and halo).
+    return _dotBorderLayer ?: _puckDot;
+}
+
+- (void)update
+{
+    if (CGSizeEqualToSize(self.frame.size, CGSizeZero))
+    {
+        CGFloat frameSize = (self.mapView.userTrackingMode == MGLUserTrackingModeFollowWithCourse) ? MGLUserLocationAnnotationPuckSize : MGLUserLocationAnnotationDotSize;
+        [self updateFrameWithSize:frameSize];
+    }
+    
+    if (CLLocationCoordinate2DIsValid(self.userLocation.coordinate))
+    {
+        RCTMGLMapView *reactMapView = (RCTMGLMapView *)self.mapView;
+        (reactMapView.reactUserTrackingMode == MGLUserTrackingModeFollowWithCourse) ? [self drawPuck] : [self drawDot];
+        [self updatePitch];
+    }
+    
+    _haloLayer.hidden = ! CLLocationCoordinate2DIsValid(self.mapView.userLocation.coordinate) || self.mapView.userLocation.location.horizontalAccuracy > 10;
+}
+
+- (void)setTintColor:(UIColor *)tintColor
+{
+    CGColorRef newTintColor = [tintColor CGColor];
+    
+    if (_puckModeActivated)
+    {
+        _puckArrow.fillColor = newTintColor;
+    }
+    else
+    {
+        _accuracyRingLayer.backgroundColor = newTintColor;
+        _haloLayer.backgroundColor = newTintColor;
+        _dotLayer.backgroundColor = newTintColor;
+        [_headingIndicatorLayer updateTintColor:newTintColor];
+    }
+}
+
+- (void)updatePitch
+{
+    if (self.mapView.camera.pitch != _oldPitch)
+    {
+        // disable implicit animation
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        
+        CATransform3D t = CATransform3DRotate(CATransform3DIdentity, MGLRadiansFromDegrees(self.mapView.camera.pitch), 1.0, 0, 0);
+        self.layer.sublayerTransform = t;
+        
+        [self updateFaux3DEffect];
+        
+        [CATransaction commit];
+        
+        _oldPitch = self.mapView.camera.pitch;
+    }
+}
+
+- (void)updateFaux3DEffect
+{
+    CGFloat pitch = MGLRadiansFromDegrees(self.mapView.camera.pitch);
+    
+    if (_puckDot)
+    {
+        _puckDot.shadowOffset = CGSizeMake(0, fmaxf(pitch * 10.f, 1.f));
+        _puckDot.shadowRadius = fmaxf(pitch * 5.f, 0.75f);
+    }
+    
+    if (_dotBorderLayer)
+    {
+        _dotBorderLayer.shadowOffset = CGSizeMake(0.f, pitch * 10.f);
+        _dotBorderLayer.shadowRadius = fmaxf(pitch * 5.f, 3.f);
+    }
+    
+    if (_dotLayer)
+    {
+        _dotLayer.zPosition = pitch * 2.f;
+    }
+}
+
+- (void)updateFrameWithSize:(CGFloat)size
+{
+    CGSize newSize = CGSizeMake(size, size);
+    if (CGSizeEqualToSize(self.frame.size, newSize))
+    {
+        return;
+    }
+    
+    // Update frame size, keeping the existing center point.
+    CGPoint oldCenter = self.center;
+    CGRect newFrame = self.frame;
+    newFrame.size = newSize;
+    [self setFrame:newFrame];
+    [self setCenter:oldCenter];
+}
+
+- (void)drawPuck
+{
+    if ( ! _puckModeActivated)
+    {
+        self.layer.sublayers = nil;
+        
+        _headingIndicatorLayer = nil;
+        _accuracyRingLayer = nil;
+        _haloLayer = nil;
+        _dotBorderLayer = nil;
+        _dotLayer = nil;
+        
+        [self updateFrameWithSize:MGLUserLocationAnnotationPuckSize];
+    }
+    
+    // background dot (white with black shadow)
+    //
+    if ( ! _puckDot)
+    {
+        _puckDot = [self circleLayerWithSize:MGLUserLocationAnnotationPuckSize];
+        _puckDot.backgroundColor = [[UIColor whiteColor] CGColor];
+        _puckDot.shadowColor = [[UIColor blackColor] CGColor];
+        _puckDot.shadowOpacity = 0.25;
+        _puckDot.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_puckDot.bounds] CGPath];
+        
+        if (self.mapView.camera.pitch)
+        {
+            [self updateFaux3DEffect];
+        }
+        else
+        {
+            _puckDot.shadowOffset = CGSizeMake(0, 1);
+            _puckDot.shadowRadius = 0.75;
+        }
+        
+        [self.layer addSublayer:_puckDot];
+    }
+    
+    // arrow
+    //
+    if ( ! _puckArrow)
+    {
+        _puckArrow = [CAShapeLayer layer];
+        _puckArrow.path = [[self puckArrow] CGPath];
+        _puckArrow.fillColor = [self.mapView.tintColor CGColor];
+        _puckArrow.bounds = CGRectMake(0, 0, round(MGLUserLocationAnnotationArrowSize), round(MGLUserLocationAnnotationArrowSize));
+        _puckArrow.position = CGPointMake(CGRectGetMidX(super.bounds), CGRectGetMidY(super.bounds));
+        _puckArrow.shouldRasterize = YES;
+        _puckArrow.rasterizationScale = [UIScreen mainScreen].scale;
+        _puckArrow.drawsAsynchronously = YES;
+        
+        _puckArrow.lineJoin = @"round";
+        _puckArrow.lineWidth = 1.f;
+        _puckArrow.strokeColor = _puckArrow.fillColor;
+        
+        [self.layer addSublayer:_puckArrow];
+    }
+    if (self.userLocation.location.course >= 0)
+    {
+        _puckArrow.affineTransform = CGAffineTransformRotate(CGAffineTransformIdentity, -MGLRadiansFromDegrees(self.mapView.direction - self.userLocation.location.course));
+    }
+    
+    if ( ! _puckModeActivated)
+    {
+        _puckModeActivated = YES;
+        
+        [self updateFaux3DEffect];
+    }
+}
+
+- (UIBezierPath *)puckArrow
+{
+    CGFloat max = MGLUserLocationAnnotationArrowSize;
+    
+    UIBezierPath *bezierPath = UIBezierPath.bezierPath;
+    [bezierPath moveToPoint:    CGPointMake(max * 0.5, 0)];
+    [bezierPath addLineToPoint: CGPointMake(max * 0.1, max)];
+    [bezierPath addLineToPoint: CGPointMake(max * 0.5, max * 0.65)];
+    [bezierPath addLineToPoint: CGPointMake(max * 0.9, max)];
+    [bezierPath addLineToPoint: CGPointMake(max * 0.5, 0)];
+    [bezierPath closePath];
+    
+    return bezierPath;
+}
+
+- (void)drawDot
+{
+    if (_puckModeActivated)
+    {
+        self.layer.sublayers = nil;
+        
+        _puckDot = nil;
+        _puckArrow = nil;
+        
+        [self updateFrameWithSize:MGLUserLocationAnnotationDotSize];
+    }
+    
+    // heading indicator (tinted, beam or arrow)
+    RCTMGLMapView *reactMapView = (RCTMGLMapView *)self.mapView;
+    BOOL headingTrackingModeEnabled = reactMapView.reactUserTrackingMode == MGLUserTrackingModeFollowWithHeading;
+    BOOL showHeadingIndicator = self.mapView.showsUserHeadingIndicator || headingTrackingModeEnabled;
+
+    if (showHeadingIndicator)
+    {
+        _headingIndicatorLayer.hidden = NO;
+        CLLocationDirection headingAccuracy = self.userLocation.heading.headingAccuracy;
+        
+        if (([_headingIndicatorLayer isMemberOfClass:[MGLUserLocationHeadingBeamLayer class]] && ! headingTrackingModeEnabled) ||
+            ([_headingIndicatorLayer isMemberOfClass:[MGLUserLocationHeadingArrowLayer class]] && headingTrackingModeEnabled))
+        {
+            [_headingIndicatorLayer removeFromSuperlayer];
+            _headingIndicatorLayer = nil;
+            _oldHeadingAccuracy = -1;
+        }
+        
+        if ( ! _headingIndicatorLayer && headingAccuracy)
+        {
+            if (headingTrackingModeEnabled)
+            {
+                _headingIndicatorLayer = [[MGLUserLocationHeadingBeamLayer alloc] initWithUserLocationAnnotationView:self];
+                [self.layer insertSublayer:_headingIndicatorLayer below:_dotBorderLayer];
+            }
+            else
+            {
+                _headingIndicatorLayer = [[MGLUserLocationHeadingArrowLayer alloc] initWithUserLocationAnnotationView:self];
+                [self.layer addSublayer:_headingIndicatorLayer];
+                _headingIndicatorLayer.zPosition = 1;
+            }
+        }
+        
+        if (_oldHeadingAccuracy != headingAccuracy)
+        {
+            [_headingIndicatorLayer updateHeadingAccuracy:headingAccuracy];
+            _oldHeadingAccuracy = headingAccuracy;
+        }
+        
+        if (self.userLocation.heading.trueHeading >= 0)
+        {
+            CGFloat rotation = -MGLRadiansFromDegrees(self.mapView.direction - self.userLocation.heading.trueHeading);
+            
+            // Don't rotate if the change is imperceptible.
+            if (fabs(rotation) > MGLUserLocationHeadingUpdateThreshold)
+            {
+                [CATransaction begin];
+                [CATransaction setDisableActions:YES];
+                
+                _headingIndicatorLayer.affineTransform = CGAffineTransformRotate(CGAffineTransformIdentity, rotation);
+                
+                [CATransaction commit];
+            }
+        }
+    }
+    else
+    {
+        [_headingIndicatorLayer removeFromSuperlayer];
+        _headingIndicatorLayer = nil;
+    }
+    
+    // update accuracy ring (if zoom or horizontal accuracy have changed)
+    //
+    if (_accuracyRingLayer && (_oldZoom != self.mapView.zoomLevel || _oldHorizontalAccuracy != self.userLocation.location.horizontalAccuracy))
+    {
+        CGFloat accuracyRingSize = [self calculateAccuracyRingSize];
+        
+        // only show the accuracy ring if it won't be obscured by the location dot
+        if (accuracyRingSize > MGLUserLocationAnnotationDotSize + 15)
+        {
+            _accuracyRingLayer.hidden = NO;
+            
+            // disable implicit animation of the accuracy ring, unless triggered by a change in accuracy
+            BOOL shouldDisableActions = _oldHorizontalAccuracy == self.userLocation.location.horizontalAccuracy;
+            
+            [CATransaction begin];
+            [CATransaction setDisableActions:shouldDisableActions];
+            
+            _accuracyRingLayer.bounds = CGRectMake(0, 0, accuracyRingSize, accuracyRingSize);
+            _accuracyRingLayer.cornerRadius = accuracyRingSize / 2.0;
+            
+            // match the halo to the accuracy ring
+            _haloLayer.bounds = _accuracyRingLayer.bounds;
+            _haloLayer.cornerRadius = _accuracyRingLayer.cornerRadius;
+            _haloLayer.shouldRasterize = NO;
+            
+            [CATransaction commit];
+        }
+        else
+        {
+            _accuracyRingLayer.hidden = YES;
+            
+            _haloLayer.bounds = CGRectMake(0, 0, MGLUserLocationAnnotationHaloSize, MGLUserLocationAnnotationHaloSize);
+            _haloLayer.cornerRadius = MGLUserLocationAnnotationHaloSize / 2.0;
+            _haloLayer.shouldRasterize = YES;
+            _haloLayer.rasterizationScale = [UIScreen mainScreen].scale;
+        }
+        
+        // store accuracy and zoom so we're not redrawing unchanged location updates
+        _oldHorizontalAccuracy = self.userLocation.location.horizontalAccuracy;
+        _oldZoom = self.mapView.zoomLevel;
+    }
+    
+    // accuracy ring (circular, tinted, mostly-transparent)
+    //
+    if ( ! _accuracyRingLayer && self.userLocation.location.horizontalAccuracy)
+    {
+        CGFloat accuracyRingSize = [self calculateAccuracyRingSize];
+        _accuracyRingLayer = [self circleLayerWithSize:accuracyRingSize];
+        _accuracyRingLayer.backgroundColor = [self.mapView.tintColor CGColor];
+        _accuracyRingLayer.opacity = 0.1;
+        _accuracyRingLayer.shouldRasterize = NO;
+        _accuracyRingLayer.allowsGroupOpacity = NO;
+        
+        [self.layer addSublayer:_accuracyRingLayer];
+    }
+    
+    // expanding sonar-like pulse (circular, tinted, fades out)
+    //
+    if ( ! _haloLayer)
+    {
+        _haloLayer = [self circleLayerWithSize:MGLUserLocationAnnotationHaloSize];
+        _haloLayer.backgroundColor = [self.mapView.tintColor CGColor];
+        _haloLayer.allowsGroupOpacity = NO;
+        _haloLayer.zPosition = -0.1f;
+        
+        // set defaults for the animations
+        CAAnimationGroup *animationGroup = [self loopingAnimationGroupWithDuration:3.0];
+        
+        // scale out radially with initial acceleration
+        CAKeyframeAnimation *boundsAnimation = [CAKeyframeAnimation animationWithKeyPath:@"transform.scale.xy"];
+        boundsAnimation.values = @[@0, @0.35, @1];
+        boundsAnimation.keyTimes = @[@0, @0.2, @1];
+        
+        // go transparent as scaled out, start semi-opaque
+        CAKeyframeAnimation *opacityAnimation = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
+        opacityAnimation.values = @[@0.4, @0.4, @0];
+        opacityAnimation.keyTimes = @[@0, @0.2, @1];
+        
+        animationGroup.animations = @[boundsAnimation, opacityAnimation];
+        
+        [_haloLayer addAnimation:animationGroup forKey:@"animateTransformAndOpacity"];
+        
+        [self.layer addSublayer:_haloLayer];
+    }
+    
+    // background dot (white with black shadow)
+    //
+    if ( ! _dotBorderLayer)
+    {
+        _dotBorderLayer = [self circleLayerWithSize:MGLUserLocationAnnotationDotSize];
+        _dotBorderLayer.backgroundColor = [[UIColor whiteColor] CGColor];
+        _dotBorderLayer.shadowColor = [[UIColor blackColor] CGColor];
+        _dotBorderLayer.shadowOpacity = 0.25;
+        _dotBorderLayer.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_dotBorderLayer.bounds] CGPath];
+        
+        if (self.mapView.camera.pitch)
+        {
+            [self updateFaux3DEffect];
+        }
+        else
+        {
+            _dotBorderLayer.shadowOffset = CGSizeMake(0, 0);
+            _dotBorderLayer.shadowRadius = 3;
+        }
+        
+        [self.layer addSublayer:_dotBorderLayer];
+    }
+    
+    // inner dot (pulsing, tinted)
+    //
+    if ( ! _dotLayer)
+    {
+        _dotLayer = [self circleLayerWithSize:MGLUserLocationAnnotationDotSize * 0.75];
+        _dotLayer.backgroundColor = [self.mapView.tintColor CGColor];
+        
+        // set defaults for the animations
+        CAAnimationGroup *animationGroup = [self loopingAnimationGroupWithDuration:1.5];
+        animationGroup.autoreverses = YES;
+        animationGroup.fillMode = kCAFillModeBoth;
+        
+        // scale the dot up and down
+        CABasicAnimation *pulseAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale.xy"];
+        pulseAnimation.fromValue = @0.8;
+        pulseAnimation.toValue = @1;
+        
+        // fade opacity in and out, subtly
+        CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+        opacityAnimation.fromValue = @0.8;
+        opacityAnimation.toValue = @1;
+        
+        animationGroup.animations = @[pulseAnimation, opacityAnimation];
+        
+        [_dotLayer addAnimation:animationGroup forKey:@"animateTransformAndOpacity"];
+        
+        [self.layer addSublayer:_dotLayer];
+    }
+    
+    if (_puckModeActivated)
+    {
+        _puckModeActivated = NO;
+        
+        [self updateFaux3DEffect];
+    }
+}
+
+- (CALayer *)circleLayerWithSize:(CGFloat)layerSize
+{
+    layerSize = round(layerSize);
+    
+    CALayer *circleLayer = [CALayer layer];
+    circleLayer.bounds = CGRectMake(0, 0, layerSize, layerSize);
+    circleLayer.position = CGPointMake(CGRectGetMidX(super.bounds), CGRectGetMidY(super.bounds));
+    circleLayer.cornerRadius = layerSize / 2.0;
+    circleLayer.shouldRasterize = YES;
+    circleLayer.rasterizationScale = [UIScreen mainScreen].scale;
+    circleLayer.drawsAsynchronously = YES;
+    
+    return circleLayer;
+}
+
+- (CAAnimationGroup *)loopingAnimationGroupWithDuration:(CGFloat)animationDuration
+{
+    CAAnimationGroup *animationGroup = [CAAnimationGroup animation];
+    animationGroup.duration = animationDuration;
+    animationGroup.repeatCount = INFINITY;
+    animationGroup.removedOnCompletion = NO;
+    animationGroup.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault];
+    
+    return animationGroup;
+}
+
+- (CGFloat)calculateAccuracyRingSize
+{
+    // diameter in screen points
+    return round(self.userLocation.location.horizontalAccuracy / [self.mapView metersPerPointAtLatitude:self.userLocation.coordinate.latitude] * 2.0);
+}
+
+@end

--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -60,6 +60,12 @@ RCT_EXPORT_MODULE();
     [userTrackingModes setObject:[NSNumber numberWithInt:MGLUserTrackingModeFollowWithHeading] forKey:@"FollowWithHeading"];
     [userTrackingModes setObject:[NSNumber numberWithInt:MGLUserTrackingModeFollowWithCourse] forKey:@"FollowWithCourse"];
     
+    // user location vertical alignment
+    NSMutableDictionary *userLocationVerticalAlignment = [[NSMutableDictionary alloc] init];
+    [userLocationVerticalAlignment setObject:[NSNumber numberWithInt:MGLAnnotationVerticalAlignmentTop] forKey:@"Top"];
+    [userLocationVerticalAlignment setObject:[NSNumber numberWithInt:MGLAnnotationVerticalAlignmentCenter] forKey:@"Center"];
+    [userLocationVerticalAlignment setObject:[NSNumber numberWithInt:MGLAnnotationVerticalAlignmentBottom] forKey:@"Bottom"];
+    
     // camera modes
     NSMutableDictionary *cameraModes = [[NSMutableDictionary alloc] init];
     [cameraModes setObject:[NSNumber numberWithInt:RCT_MAPBOX_CAMERA_MODE_FLIGHT] forKey:@"Flight"];
@@ -205,6 +211,7 @@ RCT_EXPORT_MODULE();
          @"StyleURL": styleURLS,
          @"EventTypes": eventTypes,
          @"UserTrackingModes": userTrackingModes,
+         @"UserLocationVerticalAlignment": userLocationVerticalAlignment,
          @"CameraModes": cameraModes,
          @"StyleSource": styleSourceConsts,
          @"InterpolationMode": interpolationModes,

--- a/ios/RCTMGL/MGLUserLocationHeadingArrowLayer.h
+++ b/ios/RCTMGL/MGLUserLocationHeadingArrowLayer.h
@@ -1,0 +1,11 @@
+#import <QuartzCore/QuartzCore.h>
+#import "MGLUserLocationHeadingIndicator.h"
+@import Mapbox;
+
+@interface MGLUserLocationHeadingArrowLayer : CAShapeLayer <MGLUserLocationHeadingIndicator>
+
+- (instancetype)initWithUserLocationAnnotationView:(MGLUserLocationAnnotationView *)userLocationView;
+- (void)updateHeadingAccuracy:(CLLocationDirection)accuracy;
+- (void)updateTintColor:(CGColorRef)color;
+
+@end

--- a/ios/RCTMGL/MGLUserLocationHeadingArrowLayer.m
+++ b/ios/RCTMGL/MGLUserLocationHeadingArrowLayer.m
@@ -1,0 +1,57 @@
+#import "MGLUserLocationHeadingArrowLayer.h"
+#import "MGLFaux3DUserLocationAnnotationView.h"
+
+const CGFloat MGLUserLocationHeadingArrowSize = 6;
+
+@implementation MGLUserLocationHeadingArrowLayer
+
+- (instancetype)initWithUserLocationAnnotationView:(MGLUserLocationAnnotationView *)userLocationView
+{
+    CGFloat size = userLocationView.bounds.size.width + MGLUserLocationHeadingArrowSize;
+    
+    self = [super init];
+    self.bounds = CGRectMake(0, 0, size, size);
+    self.position = CGPointMake(CGRectGetMidX(userLocationView.bounds), CGRectGetMidY(userLocationView.bounds));
+    self.path = [self arrowPath];
+    self.fillColor = userLocationView.tintColor.CGColor;
+    self.shouldRasterize = YES;
+    self.rasterizationScale = UIScreen.mainScreen.scale;
+    self.drawsAsynchronously = YES;
+    
+    self.strokeColor = UIColor.whiteColor.CGColor;
+    self.lineWidth = 1.0;
+    self.lineJoin = kCALineJoinRound;
+    
+    return self;
+}
+
+- (void)updateHeadingAccuracy:(CLLocationDirection)accuracy
+{
+    // unimplemented
+}
+
+- (void)updateTintColor:(CGColorRef)color
+{
+    self.fillColor = color;
+}
+
+- (CGPathRef)arrowPath {
+    CGFloat center = roundf(CGRectGetMidX(self.bounds));
+    CGFloat size = MGLUserLocationHeadingArrowSize;
+    
+    CGPoint top =       CGPointMake(center,         0);
+    CGPoint left =      CGPointMake(center - size,  size);
+    CGPoint right =     CGPointMake(center + size,  size);
+    CGPoint middle =    CGPointMake(center,         size / M_PI);
+    
+    UIBezierPath *bezierPath = [UIBezierPath bezierPath];
+    [bezierPath moveToPoint:top];
+    [bezierPath addLineToPoint:left];
+    [bezierPath addQuadCurveToPoint:right controlPoint:middle];
+    [bezierPath addLineToPoint:top];
+    [bezierPath closePath];
+    
+    return bezierPath.CGPath;
+}
+
+@end

--- a/ios/RCTMGL/MGLUserLocationHeadingBeamLayer.h
+++ b/ios/RCTMGL/MGLUserLocationHeadingBeamLayer.h
@@ -1,0 +1,11 @@
+#import <QuartzCore/QuartzCore.h>
+#import "MGLUserLocationHeadingIndicator.h"
+@import Mapbox;
+
+@interface MGLUserLocationHeadingBeamLayer : CALayer <MGLUserLocationHeadingIndicator>
+
+- (MGLUserLocationHeadingBeamLayer *)initWithUserLocationAnnotationView:(MGLUserLocationAnnotationView *)userLocationView;
+- (void)updateHeadingAccuracy:(CLLocationDirection)accuracy;
+- (void)updateTintColor:(CGColorRef)color;
+
+@end

--- a/ios/RCTMGL/MGLUserLocationHeadingBeamLayer.m
+++ b/ios/RCTMGL/MGLUserLocationHeadingBeamLayer.m
@@ -1,0 +1,102 @@
+#import "MGLUserLocationHeadingBeamLayer.h"
+#import "MGLFaux3DUserLocationAnnotationView.h"
+
+@implementation MGLUserLocationHeadingBeamLayer
+{
+    CAShapeLayer *_maskLayer;
+}
+
+- (instancetype)initWithUserLocationAnnotationView:(MGLUserLocationAnnotationView *)userLocationView
+{
+    CGFloat size = MGLUserLocationAnnotationHaloSize;
+    
+    self = [super init];
+    self.bounds = CGRectMake(0, 0, size, size);
+    self.position = CGPointMake(CGRectGetMidX(userLocationView.bounds), CGRectGetMidY(userLocationView.bounds));
+    self.contents = (__bridge id)[self gradientImageWithTintColor:userLocationView.tintColor.CGColor];
+    self.contentsGravity = kCAGravityBottom;
+    self.contentsScale = UIScreen.mainScreen.scale;
+    self.opacity = 0.4;
+    self.shouldRasterize = YES;
+    self.rasterizationScale = UIScreen.mainScreen.scale;
+    self.drawsAsynchronously = YES;
+    
+    _maskLayer = [CAShapeLayer layer];
+    _maskLayer.frame = self.bounds;
+    _maskLayer.path = [self clippingMaskForAccuracy:0];
+    self.mask = _maskLayer;
+    
+    return self;
+}
+
+- (void)updateHeadingAccuracy:(CLLocationDirection)accuracy
+{
+    // recalculate the clipping mask based on updated accuracy
+    _maskLayer.path = [self clippingMaskForAccuracy:accuracy];
+}
+
+- (void)updateTintColor:(CGColorRef)color
+{
+    // redraw the raw tinted gradient
+    self.contents = (__bridge id)[self gradientImageWithTintColor:color];
+}
+
+- (CGImageRef)gradientImageWithTintColor:(CGColorRef)tintColor
+{
+    UIImage *image;
+    
+    CGFloat haloRadius = MGLUserLocationAnnotationHaloSize / 2.0;
+    
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(MGLUserLocationAnnotationHaloSize, haloRadius), NO, 0);
+    
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    // gradient from the tint color to no-alpha tint color
+    CGFloat gradientLocations[] = {0.0, 1.0};
+    CGGradientRef gradient = CGGradientCreateWithColors(
+                                                        colorSpace,
+                                                        (__bridge CFArrayRef)@[(__bridge id)tintColor,
+                                                                               (id)CFBridgingRelease(CGColorCreateCopyWithAlpha(tintColor, 0))],
+                                                        gradientLocations);
+    
+    // draw the gradient from the center point to the edge (full halo radius)
+    CGPoint centerPoint = CGPointMake(haloRadius, haloRadius);
+    CGContextDrawRadialGradient(context, gradient,
+                                centerPoint, 0.0,
+                                centerPoint, haloRadius,
+                                kNilOptions);
+    
+    image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    CGGradientRelease(gradient);
+    CGColorSpaceRelease(colorSpace);
+    
+    return image.CGImage;
+}
+
+- (CGPathRef)clippingMaskForAccuracy:(CGFloat)accuracy
+{
+    // size the mask using accuracy, but keep within a good display range
+    CGFloat clippingDegrees = 90 - accuracy;
+    clippingDegrees = fmin(clippingDegrees, 70); // most accurate
+    clippingDegrees = fmax(clippingDegrees, 10); // least accurate
+    
+    CGRect ovalRect = CGRectMake(0, 0, MGLUserLocationAnnotationHaloSize, MGLUserLocationAnnotationHaloSize);
+    UIBezierPath *ovalPath = UIBezierPath.bezierPath;
+    
+    // clip the oval to ± incoming accuracy degrees (converted to radians), from the top
+    [ovalPath addArcWithCenter:CGPointMake(CGRectGetMidX(ovalRect), CGRectGetMidY(ovalRect))
+                        radius:CGRectGetWidth(ovalRect) / 2.0
+                    startAngle:MGLRadiansFromDegrees(-180 + clippingDegrees)
+                      endAngle:MGLRadiansFromDegrees(-clippingDegrees)
+                     clockwise:YES];
+    
+    [ovalPath addLineToPoint:CGPointMake(CGRectGetMidX(ovalRect), CGRectGetMidY(ovalRect))];
+    [ovalPath closePath];
+    
+    return ovalPath.CGPath;
+}
+
+@end

--- a/ios/RCTMGL/MGLUserLocationHeadingIndicator.h
+++ b/ios/RCTMGL/MGLUserLocationHeadingIndicator.h
@@ -1,0 +1,10 @@
+#import <QuartzCore/QuartzCore.h>
+@import Mapbox;
+
+@protocol MGLUserLocationHeadingIndicator <NSObject>
+
+- (instancetype)initWithUserLocationAnnotationView:(MGLUserLocationAnnotationView *)userLocationView;
+- (void)updateHeadingAccuracy:(CLLocationDirection)accuracy;
+- (void)updateTintColor:(CGColorRef)color;
+
+@end

--- a/ios/RCTMGL/RCTMGLEventTypes.h
+++ b/ios/RCTMGL/RCTMGLEventTypes.h
@@ -13,6 +13,8 @@
 extern NSString *const RCT_MAPBOX_EVENT_TAP;
 extern NSString *const RCT_MAPBOX_EVENT_LONGPRESS;
 
+extern NSString *const RCT_MAPBOX_USER_TRACKING_MODE_CHANGE;
+
 extern NSString *const RCT_MAPBOX_REGION_WILL_CHANGE_EVENT;
 extern NSString *const RCT_MAPBOX_REGION_IS_CHANGING;
 extern NSString *const RCT_MAPBOX_REGION_DID_CHANGE;

--- a/ios/RCTMGL/RCTMGLEventTypes.m
+++ b/ios/RCTMGL/RCTMGLEventTypes.m
@@ -13,6 +13,8 @@
 NSString *const RCT_MAPBOX_EVENT_TAP = @"press";
 NSString *const RCT_MAPBOX_EVENT_LONGPRESS = @"longpress";
 
+NSString *const RCT_MAPBOX_USER_TRACKING_MODE_CHANGE = @"usertrackingmodechange";
+
 NSString *const RCT_MAPBOX_REGION_WILL_CHANGE_EVENT = @"regionwillchange";
 NSString *const RCT_MAPBOX_REGION_IS_CHANGING = @"regionischanging";
 NSString *const RCT_MAPBOX_REGION_DID_CHANGE = @"regiondidchange";

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -40,6 +40,7 @@
 
 @property (nonatomic, assign) BOOL isUserInteraction;
 @property (nonatomic, assign) int reactUserTrackingMode;
+@property (nonatomic, assign) int reactUserLocationVerticalAlignment;
 
 @property (nonatomic, assign) double heading;
 @property (nonatomic, assign) double pitch;

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -50,6 +50,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onLongPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onMapChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onUserTrackingModeChange;
 
 - (CLLocationDistance)getMetersPerPixelAtLatitude:(double)latitude withZoom:(double)zoomLevel;
 - (CLLocationDistance)altitudeFromZoom:(double)zoomLevel;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -226,7 +226,8 @@ static double const M2PI = M_PI * 2;
 - (void)setReactUserTrackingMode:(int)reactUserTrackingMode
 {
     _reactUserTrackingMode = reactUserTrackingMode;
-    [self setUserTrackingMode:(NSUInteger)_reactUserTrackingMode animated:_animated];
+    [self setUserTrackingMode:_reactUserTrackingMode animated:NO];
+    self.showsUserHeadingIndicator = (NSUInteger)_reactUserTrackingMode == MGLUserTrackingModeFollowWithHeading;
 }
 
 #pragma mark - methods

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -230,6 +230,12 @@ static double const M2PI = M_PI * 2;
     self.showsUserHeadingIndicator = (NSUInteger)_reactUserTrackingMode == MGLUserTrackingModeFollowWithHeading;
 }
 
+- (void)setReactUserLocationVerticalAlignment:(int)reactUserLocationVerticalAlignment
+{
+    _reactUserLocationVerticalAlignment = reactUserLocationVerticalAlignment;
+    self.userLocationVerticalAlignment = reactUserLocationVerticalAlignment;
+}
+
 #pragma mark - methods
 
 - (CLLocationDistance)getMetersPerPixelAtLatitude:(double)latitude withZoom:(double)zoomLevel

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -83,6 +83,7 @@ RCT_REMAP_VIEW_PROPERTY(centerCoordinate, reactCenterCoordinate, NSString)
 RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 
 RCT_REMAP_VIEW_PROPERTY(userTrackingMode, reactUserTrackingMode, int)
+RCT_REMAP_VIEW_PROPERTY(userLocationVerticalAlignment, reactUserLocationVerticalAlignment, int)
 
 RCT_EXPORT_VIEW_PROPERTY(heading, double)
 RCT_EXPORT_VIEW_PROPERTY(pitch, double)

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -17,6 +17,7 @@
 #import "CameraStop.h"
 #import "CameraUpdateQueue.h"
 #import "FilterParser.h"
+#import "MGLFaux3DUserLocationAnnotationView.h"
 
 @interface RCTMGLMapViewManager() <MGLMapViewDelegate>
 @end
@@ -314,7 +315,7 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
         RCTMGLPointAnnotation *rctAnnotation = (RCTMGLPointAnnotation *)annotation;
         return [rctAnnotation getAnnotationView];
     } else if ([annotation isKindOfClass:[MGLUserLocation class]]) {
-        return [[RCTMGLUserLocationAnnotationView alloc] init];
+        return [[MGLFaux3DUserLocationAnnotationView alloc] init];
     }
     return nil;
 }

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -92,6 +92,7 @@ RCT_REMAP_VIEW_PROPERTY(maxZoomLevel, reactMaxZoomLevel, double)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLongPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMapChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onUserTrackingModeChange, RCTBubblingEventBlock)
 
 #pragma mark - React Methods
 
@@ -288,6 +289,18 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 #pragma mark - MGLMapViewDelegate
 
+- (void)mapView:(MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated
+{
+    RCTMGLMapView *reactMapView = (RCTMGLMapView *)mapView;
+    if (reactMapView.onUserTrackingModeChange == nil) {
+        return;
+    }
+    
+    NSDictionary *payload = @{ @"userTrackingMode": @(mode) };
+    RCTMGLEvent *event = [RCTMGLEvent makeEvent:RCT_MAPBOX_USER_TRACKING_MODE_CHANGE withPayload:payload];
+    [self fireEvent:event withCallback:reactMapView.onUserTrackingModeChange];
+}
+
 - (BOOL)mapView:(MGLMapView *)mapView shouldChangeFromCamera:(MGLMapCamera *)oldCamera toCamera:(MGLMapCamera *)newCamera
 {
     RCTMGLMapView *reactMapView = (RCTMGLMapView *)mapView;
@@ -300,6 +313,8 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
     if ([annotation isKindOfClass:[RCTMGLPointAnnotation class]]) {
         RCTMGLPointAnnotation *rctAnnotation = (RCTMGLPointAnnotation *)annotation;
         return [rctAnnotation getAnnotationView];
+    } else if ([annotation isKindOfClass:[MGLUserLocation class]]) {
+        return [[RCTMGLUserLocationAnnotationView alloc] init];
     }
     return nil;
 }

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -206,15 +206,8 @@ class MapView extends React.Component {
     */
     onDidFinishLoadingStyle: PropTypes.func,
 
-    /**
-    * This event is triggered when a fly to animation is cancelled or completed after calling flyTo
-    */
-    onFlyToComplete: PropTypes.func,
 
-    /**
-     * This event is triggered once the camera is finished after calling setCamera
-     */
-    onSetCameraComplete: PropTypes.func,
+    onUserTrackingModeChange: PropTypes.func,
   };
 
   static defaultProps = {
@@ -633,6 +626,7 @@ class MapView extends React.Component {
       onLongPress: this._onLongPress,
       onMapChange: this._onChange,
       onAndroidCallback: isAndroid() ? this._onAndroidCallback : undefined,
+      onUserTrackingModeChange: this.props.onUserTrackingModeChange,
     };
 
     if (isAndroid() && this.props.textureMode) {

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -48,6 +48,11 @@ class MapView extends React.Component {
     userTrackingMode: PropTypes.number,
 
     /**
+     * The vertical alignment of the user location within in map. This is only enabled while tracking the users location.
+     */
+    userLocationVerticalAlignment: PropTypes.number,
+
+    /**
      * The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport.
      */
     contentInset: PropTypes.oneOfType([
@@ -206,7 +211,9 @@ class MapView extends React.Component {
     */
     onDidFinishLoadingStyle: PropTypes.func,
 
-
+    /**
+     * This event is triggered when the users tracking mode is changed.
+     */
     onUserTrackingModeChange: PropTypes.func,
   };
 


### PR DESCRIPTION
* Polyfills `userTrackingMode` tracking on Android
* Adds `onUserTrackingMode` callback to MapView
* Enables userLocationVerticalAlignment support on iOS.
* Polyfills support for userLocationVerticalAlignment on Android
* Adds userLocationVerticalAlignment example
* [Android] Add support for updating map rotation based on user location for `followWithCourse` and `followWithHeading`

Bugfixes include
* Fixes Android not recentering camera when the developer sets a new tracking mode
* Fixes Android overriding `centerCoordinate` when `showUserLocation` is active
* Fixes Android not sending first region event
* Fixes iOS removing navigation icon anytime `followWithCourse` changes.
* [Android] Prevent user location layer from appearing under other layers
  
  
  
  
  
  