### PR TITLE
Fixes iconImage crash, and icons not appearing in release mode

### DIFF
--- a/__tests__/utils/MapboxStyleSheet.test.js
+++ b/__tests__/utils/MapboxStyleSheet.test.js
@@ -33,7 +33,7 @@ describe('MapboxStyleSheet', () => {
     verifyStyleSheetsMatch({ fillPattern: 'test' }, {
       fillPattern: {
         styletype: 'constant',
-        payload: { value: 'test', image: true },
+        payload: { value: 'test', image: true, shouldAddImage: false },
         __MAPBOX_STYLE__: true,
       },
     });
@@ -43,7 +43,7 @@ describe('MapboxStyleSheet', () => {
     verifyStyleSheetsMatch({ fillPattern: 123 }, {
       fillPattern: {
         styletype: 'constant',
-        payload: { value: 'asset://test.png' , image: true },
+        payload: { value: 'asset://test.png' , image: true, shouldAddImage: true },
         __MAPBOX_STYLE__: true,
       },
     });
@@ -197,7 +197,7 @@ describe('MapboxStyleSheet', () => {
 
     verifyStyleSheetsMatch(styles, {
       fillOpacity: { styletype: 'constant', payload: { value: 0.84 }, __MAPBOX_STYLE__: true },
-      fillPattern: { styletype: 'constant', payload: { value: 'test', image: true }, __MAPBOX_STYLE__: true },
+      fillPattern: { styletype: 'constant', payload: { value: 'test', image: true, shouldAddImage: false }, __MAPBOX_STYLE__: true },
     });
   });
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -7,10 +7,8 @@ import android.location.Location;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.util.Log;
-import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.view.MotionEvent;
 
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -43,7 +41,6 @@ import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotationAdapter;
 import com.mapbox.rctmgl.components.camera.CameraStop;
 import com.mapbox.rctmgl.components.camera.CameraUpdateQueue;
 import com.mapbox.rctmgl.components.styles.light.RCTMGLLight;
-import com.mapbox.rctmgl.components.styles.sources.RCTMGLShapeSource;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
 import com.mapbox.rctmgl.events.AndroidCallbackEvent;
 import com.mapbox.rctmgl.events.IEvent;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
@@ -1,8 +1,8 @@
 package com.mapbox.rctmgl.components.styles;
 
+import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.StringDef;
 
 import com.facebook.common.util.UriUtil;
 import com.facebook.react.bridge.ReadableMap;
@@ -20,10 +20,12 @@ import java.util.Map;
  */
 
 public class RCTMGLStyle {
+    private Context mContext;
     private ReadableMap mReactStyle;
     private MapboxMap mMap;
 
-    public RCTMGLStyle(@NonNull ReadableMap reactStyle, @NonNull MapboxMap map) {
+    public RCTMGLStyle(@NonNull Context context, @NonNull ReadableMap reactStyle, @NonNull MapboxMap map) {
+        mContext = context;
         mReactStyle = reactStyle;
         mMap = map;
     }
@@ -58,12 +60,23 @@ public class RCTMGLStyle {
         return new RCTMGLStyleValue(styleValueConfig);
     }
 
-    public void addImage(String uriStr) {
-        if (!shouldAddImage(uriStr)) {
+    public void addImage(RCTMGLStyleValue styleValue) {
+        addImage(styleValue, null);
+    }
+
+    public void addImage(RCTMGLStyleValue styleValue, DownloadMapImageTask.OnAllImagesLoaded callback) {
+        String uriStr = styleValue.getString(RCTMGLStyleFactory.VALUE_KEY);
+        boolean shouldAddImage = styleValue.getBoolean(RCTMGLStyleFactory.SHOULD_ADD_IMAGE_KEY);
+
+        if (!shouldAddImage) {
+            if (callback != null) {
+                callback.onAllImagesLoaded();
+            }
             return;
         }
+
         Map.Entry[] images = new Map.Entry[]{ new AbstractMap.SimpleEntry(uriStr, uriStr) };
-        DownloadMapImageTask task = new DownloadMapImageTask(mMap, null);
+        DownloadMapImageTask task = new DownloadMapImageTask(mContext, mMap, callback);
         task.execute(images);
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -15,13 +15,15 @@ import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.light.Light;
 import com.mapbox.mapboxsdk.style.light.Position;
+import com.mapbox.rctmgl.utils.DownloadMapImageTask;
 
 import java.util.List;
 
 public class RCTMGLStyleFactory {
     public static final String VALUE_KEY = "value";
+    public static final String SHOULD_ADD_IMAGE_KEY = "shouldAddImage";
 
-    public static void setFillLayerStyle(FillLayer layer, RCTMGLStyle style) {
+    public static void setFillLayerStyle(final FillLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -29,7 +31,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "visibility":
@@ -66,8 +68,12 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setFillTranslateAnchor(layer, styleValue);
               break;
             case "fillPattern":
-              style.addImage(styleValue.getString(VALUE_KEY));
-              RCTMGLStyleFactory.setFillPattern(layer, styleValue);
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.setFillPattern(layer, styleValue);
+                  }
+              });
               break;
             case "fillPatternTransition":
               RCTMGLStyleFactory.setFillPatternTransition(layer, styleValue);
@@ -75,7 +81,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setLineLayerStyle(LineLayer layer, RCTMGLStyle style) {
+    public static void setLineLayerStyle(final LineLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -83,7 +89,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "lineCap":
@@ -153,8 +159,12 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setLineDasharrayTransition(layer, styleValue);
               break;
             case "linePattern":
-              style.addImage(styleValue.getString(VALUE_KEY));
-              RCTMGLStyleFactory.setLinePattern(layer, styleValue);
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.setLinePattern(layer, styleValue);
+                  }
+              });
               break;
             case "linePatternTransition":
               RCTMGLStyleFactory.setLinePatternTransition(layer, styleValue);
@@ -162,7 +172,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setSymbolLayerStyle(SymbolLayer layer, RCTMGLStyle style) {
+    public static void setSymbolLayerStyle(final SymbolLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -170,7 +180,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "symbolPlacement":
@@ -204,8 +214,12 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setIconTextFitPadding(layer, styleValue);
               break;
             case "iconImage":
-              style.addImage(styleValue.getString(VALUE_KEY));
-              RCTMGLStyleFactory.setIconImage(layer, styleValue);
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.setIconImage(layer, styleValue);
+                  }
+              });
               break;
             case "iconRotate":
               RCTMGLStyleFactory.setIconRotate(layer, styleValue);
@@ -366,7 +380,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setCircleLayerStyle(CircleLayer layer, RCTMGLStyle style) {
+    public static void setCircleLayerStyle(final CircleLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -374,7 +388,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "visibility":
@@ -440,7 +454,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setFillExtrusionLayerStyle(FillExtrusionLayer layer, RCTMGLStyle style) {
+    public static void setFillExtrusionLayerStyle(final FillExtrusionLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -448,7 +462,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "visibility":
@@ -476,8 +490,12 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setFillExtrusionTranslateAnchor(layer, styleValue);
               break;
             case "fillExtrusionPattern":
-              style.addImage(styleValue.getString(VALUE_KEY));
-              RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
+                  }
+              });
               break;
             case "fillExtrusionPatternTransition":
               RCTMGLStyleFactory.setFillExtrusionPatternTransition(layer, styleValue);
@@ -497,7 +515,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setRasterLayerStyle(RasterLayer layer, RCTMGLStyle style) {
+    public static void setRasterLayerStyle(final RasterLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -505,7 +523,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "visibility":
@@ -556,7 +574,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setBackgroundLayerStyle(BackgroundLayer layer, RCTMGLStyle style) {
+    public static void setBackgroundLayerStyle(final BackgroundLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -564,7 +582,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "visibility":
@@ -577,8 +595,12 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setBackgroundColorTransition(layer, styleValue);
               break;
             case "backgroundPattern":
-              style.addImage(styleValue.getString(VALUE_KEY));
-              RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
+                  }
+              });
               break;
             case "backgroundPatternTransition":
               RCTMGLStyleFactory.setBackgroundPatternTransition(layer, styleValue);
@@ -592,7 +614,7 @@ public class RCTMGLStyleFactory {
         }
       }
     }
-    public static void setLightLayerStyle(Light layer, RCTMGLStyle style) {
+    public static void setLightLayerStyle(final Light layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -600,7 +622,7 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
             case "anchor":

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayer.java
@@ -22,6 +22,6 @@ public class RCTMGLBackgroundLayer extends RCTLayer<BackgroundLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setBackgroundLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setBackgroundLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
@@ -47,7 +47,7 @@ public class RCTMGLCircleLayer extends RCTLayer<CircleLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setCircleLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setCircleLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
@@ -49,7 +49,7 @@ public class RCTMGLFillExtrusionLayer extends RCTLayer<FillExtrusionLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setFillExtrusionLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setFillExtrusionLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
@@ -48,7 +48,7 @@ public class RCTMGLFillLayer extends RCTLayer<FillLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setFillLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setFillLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
@@ -48,7 +48,7 @@ public class RCTMGLLineLayer extends RCTLayer<LineLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setLineLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setLineLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayer.java
@@ -24,6 +24,6 @@ public class RCTMGLRasterLayer extends RCTLayer<RasterLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setRasterLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setRasterLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
@@ -57,7 +57,7 @@ public class RCTMGLSymbolLayer extends RCTLayer<SymbolLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setSymbolLayerStyle(mLayer, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setSymbolLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/light/RCTMGLLight.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/light/RCTMGLLight.java
@@ -47,6 +47,6 @@ public class RCTMGLLight extends AbstractMapFeature {
     }
 
     private void setLight(Light light) {
-        RCTMGLStyleFactory.setLightLayerStyle(light, new RCTMGLStyle(mReactStyle, mMap));
+        RCTMGLStyleFactory.setLightLayerStyle(light, new RCTMGLStyle(getContext(), mReactStyle, mMap));
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -82,7 +82,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
                 }
             };
 
-            DownloadMapImageTask task = new DownloadMapImageTask(map, imagesLoadedCallback);
+            DownloadMapImageTask task = new DownloadMapImageTask(getContext(), map, imagesLoadedCallback);
             task.execute(mImages.toArray(new Map.Entry[mImages.size()]));
             return;
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
@@ -1,7 +1,10 @@
 package com.mapbox.rctmgl.utils;
 
+import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.LruCache;
 
@@ -23,6 +26,10 @@ public class BitmapUtils {
     };
 
     public static Bitmap getBitmapFromURL(String url) {
+        return BitmapUtils.getBitmapFromURL(url, null);
+    }
+
+    public static Bitmap getBitmapFromURL(String url, BitmapFactory.Options options) {
         Bitmap bitmap = getImage(url);
 
         if (bitmap != null) {
@@ -31,7 +38,7 @@ public class BitmapUtils {
 
         try {
             InputStream bitmapStream = new URL(url).openStream();
-            bitmap = BitmapFactory.decodeStream(bitmapStream);
+            bitmap = BitmapFactory.decodeStream(bitmapStream, null, options);
             bitmapStream.close();
             addImage(url, bitmap);
         } catch (Exception e) {
@@ -39,6 +46,12 @@ public class BitmapUtils {
         }
 
         return bitmap;
+    }
+
+    public static Bitmap getBitmapFromResource(Context context, String resourceName, BitmapFactory.Options options) {
+        Resources resources = context.getResources();
+        int resID = resources.getIdentifier(resourceName, "drawable", context.getPackageName());
+        return BitmapFactory.decodeResource(resources, resID, options);
     }
 
     private static void addImage(String imageURL, Bitmap bitmap) {

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -46,3 +46,4 @@ reactnativemapboxgl.iml
 .idea
 accesstoken
 env.json
+android/app/rnmapboxglexample.keystore

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -83,6 +83,8 @@ const styles = StyleSheet.create({
   },
 });
 
+MapboxGL.setAccessToken(config.get('accessToken'));
+
 class ExampleItem {
   constructor (label, Component) {
     this.label = label;
@@ -140,7 +142,6 @@ class App extends React.Component {
         isFetchingAndroidPermission: false,
       });
     }
-    MapboxGL.setAccessToken(config.get('accessToken'));
   }
 
   getActiveItem () {
@@ -164,7 +165,6 @@ class App extends React.Component {
         <TouchableOpacity onPress={() => this.onExamplePress(index)}>
           <View style={styles.exampleListItem}>
             <Text style={styles.exampleListLabel}>{item.label}</Text>
-
             <Icon name='keyboard-arrow-right' />
           </View>
         </TouchableOpacity>

--- a/example/src/components/CustomIcon.js
+++ b/example/src/components/CustomIcon.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, Platform } from 'react-native';
+import { Text } from 'react-native';
 import MapboxGL from '@mapbox/react-native-mapbox-gl';
 
 import BaseExamplePropTypes from './common/BaseExamplePropTypes';
@@ -13,7 +13,7 @@ const styles = MapboxGL.StyleSheet.create({
   icon: {
     iconImage: exampleIcon,
     iconAllowOverlap: true,
-    iconSize: Platform.OS === 'android' ? 1 : 0.5,
+    iconSize: 0.5,
   },
 });
 

--- a/ios/RCTMGL/RCTMGLStyle.m
+++ b/ios/RCTMGL/RCTMGLStyle.m
@@ -58,8 +58,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self setFillPattern:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self setFillPattern:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }
@@ -136,8 +138,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self setLinePattern:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self setLinePattern:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }
@@ -190,8 +194,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self setIconImage:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self setIconImage:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }
@@ -403,8 +409,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }
@@ -502,8 +510,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self setBackgroundPattern:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self setBackgroundPattern:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }

--- a/ios/RCTMGL/RCTMGLStyle.m
+++ b/ios/RCTMGL/RCTMGLStyle.m
@@ -53,7 +53,7 @@
     } else if ([prop isEqualToString:@"fillTranslateAnchor"]) {
       [self setFillTranslateAnchor:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillPattern"]) {
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self setFillPattern:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -133,7 +133,7 @@
     } else if ([prop isEqualToString:@"lineDasharrayTransition"]) {
       [self setLineDasharrayTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"linePattern"]) {
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self setLinePattern:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -189,7 +189,7 @@
     } else if ([prop isEqualToString:@"iconTextFitPadding"]) {
       [self setIconTextFitPadding:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"iconImage"]) {
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self setIconImage:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -404,7 +404,7 @@
     } else if ([prop isEqualToString:@"fillExtrusionTranslateAnchor"]) {
       [self setFillExtrusionTranslateAnchor:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillExtrusionPattern"]) {
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -505,7 +505,7 @@
     } else if ([prop isEqualToString:@"backgroundColorTransition"]) {
       [self setBackgroundColorTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"backgroundPattern"]) {
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self setBackgroundPattern:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -1892,17 +1892,6 @@
 }
 
 
-
-- (BOOL)_shouldAddImage:(NSString *)str
-{
-    return str != nil && [self _isValidURL:str];
-}
-
-- (BOOL)_isValidURL:(NSString *)str
-{
-    NSURL *url = [NSURL URLWithString:str];
-    return [UIApplication.sharedApplication canOpenURL:url];
-}
 
 - (BOOL)_hasReactStyle:(NSDictionary *)reactStyle
 {

--- a/javascript/utils/MapboxStyleSheet.js
+++ b/javascript/utils/MapboxStyleSheet.js
@@ -100,7 +100,7 @@ function resolveImage (imageURL) {
   let resolved = imageURL;
 
   if (typeof imageURL === 'number') { // required from JS, local file resolve it's asset filepath
-    const res = resolveAssetSource(imageURL);
+    const res = resolveAssetSource(imageURL) || {};
 
     // we found a local uri
     if (res.uri) {
@@ -131,7 +131,11 @@ function makeStyleValue (prop, value, extras = {}, shouldMarkAsStyle = true) {
       item = new MapStyleTranslationItem(value.x, value.y, extraData); // supports object based API
     }
   } else if (styleMap[prop] === StyleTypes.Image) {
-    item = new MapStyleConstantItem(resolveImage(value), { image: true, ...extraData });
+    item = new MapStyleConstantItem(resolveImage(value), {
+      image: true,
+      shouldAddImage: typeof value === 'number', // required from JS, tell native code to add image to map style
+      ...extraData,
+    });
   } else {
     item = new MapStyleConstantItem(value, extraData);
   }

--- a/scripts/templates/RCTMGLStyle.m.ejs
+++ b/scripts/templates/RCTMGLStyle.m.ejs
@@ -41,8 +41,10 @@
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
-            [_style setImage:image forName:styleValue.payload[@"value"]];
-            [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
+            dispatch_async(dispatch_get_main_queue(), ^{
+              [_style setImage:image forName:styleValue.payload[@"value"]];
+              [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
+            });
           }
         }];
       }

--- a/scripts/templates/RCTMGLStyle.m.ejs
+++ b/scripts/templates/RCTMGLStyle.m.ejs
@@ -36,7 +36,7 @@
   <% for (let i = 0; i < layer.properties.length; i++) { -%>
   <%- ifOrElseIf(i) -%> ([prop isEqualToString:@"<%= layer.properties[i].name %>"]) {
   <%_ if (layer.properties[i].image) { _%>
-      if (![self _shouldAddImage:styleValue.payload[@"value"]]) {
+      if (![styleValue.payload[@"shouldAddImage"] boolValue]) {
         [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
       } else {
         [RCTMGLUtils fetchImage:_bridge url:styleValue.payload[@"value"] callback:^(NSError *error, UIImage *image) {
@@ -91,17 +91,6 @@
 <%_ } _%>
 <% } %>
 <% } %>
-
-- (BOOL)_shouldAddImage:(NSString *)str
-{
-    return str != nil && [self _isValidURL:str];
-}
-
-- (BOOL)_isValidURL:(NSString *)str
-{
-    NSURL *url = [NSURL URLWithString:str];
-    return [UIApplication.sharedApplication canOpenURL:url];
-}
 
 - (BOOL)_hasReactStyle:(NSDictionary *)reactStyle
 {

--- a/scripts/templates/RCTMGLStyleFactory.java.ejs
+++ b/scripts/templates/RCTMGLStyleFactory.java.ejs
@@ -18,14 +18,16 @@ import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.light.Light;
 import com.mapbox.mapboxsdk.style.light.Position;
+import com.mapbox.rctmgl.utils.DownloadMapImageTask;
 
 import java.util.List;
 
 public class RCTMGLStyleFactory {
     public static final String VALUE_KEY = "value";
+    public static final String SHOULD_ADD_IMAGE_KEY = "shouldAddImage";
 
   <%_ for (const layer of layers) { _%>
-    public static void <%- setLayerMethodName(layer) -%>(<%- getLayerType(layer, 'android') -%> layer, RCTMGLStyle style) {
+    public static void <%- setLayerMethodName(layer) -%>(final <%- getLayerType(layer, 'android') -%> layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
 
       if (styleKeys.size() == 0) {
@@ -33,15 +35,21 @@ public class RCTMGLStyleFactory {
       }
 
       for (String styleKey : styleKeys) {
-        RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
+        final RCTMGLStyleValue styleValue = style.getStyleValueForKey(styleKey);
 
         switch (styleKey) {
           <%_ for (const prop of layer.properties) { _%>
             case "<%= prop.name %>":
               <%_ if (prop.image) { _%>
-              style.addImage(styleValue.getString(VALUE_KEY));
-              <%_ } _%>
+              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
+                  @Override
+                  public void onAllImagesLoaded() {
+                      RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
+                  }
+              });
+              <%_ } else { _%>
               RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
+              <%_ } _%>
               break;
             <%_ if (prop.transition) { _%>
             case "<%= prop.name %>Transition":


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/920, https://github.com/mapbox/react-native-mapbox-gl/issues/918, https://github.com/mapbox/react-native-mapbox-gl/issues/857

* When trying to set the image on the map style, our code was assuming it would be called on the main thread, and in some cases it would be called on a background thread and cause the application to crash. We don't assume what thread we are on now, and just set the images on the main thread.
* Updated logic to make sure we are properly adding images to the map style while in release mode(offline bundle)