### PR TITLE
[iOS] Add -convertCoordinate:toPointToView:

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -95,6 +95,31 @@ RCT_EXPORT_VIEW_PROPERTY(onMapChange, RCTBubblingEventBlock)
 
 #pragma mark - React Methods
 
+// Add convertCoordinate:ToPointToView 
+RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)reactTag
+                  atCoordinate:(NSArray<NSNumber*>*)coordinate
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        
+        if (![view isKindOfClass:[RCTMGLMapView class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+        
+        RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
+        // CLLocationCoordinate2DMake(Lat, Lng)
+        CGPoint pointInView = [reactMapView convertCoordinate:CLLocationCoordinate2DMake([coordinate[0] doubleValue], [coordinate[1] doubleValue])
+                                                 toPointToView:reactMapView];
+
+        resolve(@{ @"pointInView": [NSArray arrayWithObjects: [NSNumber numberWithFloat:pointInView.x],
+                                                   [NSNumber numberWithFloat:pointInView.y],
+                                                   nil] });
+    }];
+}
+
 RCT_EXPORT_METHOD(getVisibleBounds:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -95,7 +95,6 @@ RCT_EXPORT_VIEW_PROPERTY(onMapChange, RCTBubblingEventBlock)
 
 #pragma mark - React Methods
 
-// Add convertCoordinate:ToPointToView 
 RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)reactTag
                   atCoordinate:(NSArray<NSNumber*>*)coordinate
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -110,13 +109,11 @@ RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)reactTag
         }
         
         RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
-        // CLLocationCoordinate2DMake(Lat, Lng)
+
         CGPoint pointInView = [reactMapView convertCoordinate:CLLocationCoordinate2DMake([coordinate[0] doubleValue], [coordinate[1] doubleValue])
                                                  toPointToView:reactMapView];
 
-        resolve(@{ @"pointInView": [NSArray arrayWithObjects: [NSNumber numberWithFloat:pointInView.x],
-                                                   [NSNumber numberWithFloat:pointInView.y],
-                                                   nil] });
+        resolve(@{ @"pointInView": @[@(pointInView.x), @(pointInView.y)] });
     }];
 }
 

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -110,7 +110,7 @@ RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)reactTag
         
         RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
 
-        CGPoint pointInView = [reactMapView convertCoordinate:CLLocationCoordinate2DMake([coordinate[0] doubleValue], [coordinate[1] doubleValue])
+        CGPoint pointInView = [reactMapView convertCoordinate:CLLocationCoordinate2DMake([coordinate[1] doubleValue], [coordinate[0] doubleValue])
                                                  toPointToView:reactMapView];
 
         resolve(@{ @"pointInView": @[@(pointInView.x), @(pointInView.y)] });

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -243,7 +243,15 @@ class MapView extends React.Component {
     this._callbackMap = new Map();
   }
 
-  // Add convertCoordinate:ToPointToView
+  /**
+   * Converts a geographic coordinate to a point in the given view’s coordinate system.
+   *
+   * @example
+   * const pointInView = await this._map.getPointInView([-37.817070, 144.949901]);
+   * 
+   * @param {Array<Number>} coordinate - A point expressed in the map view's coordinate system.
+   * @return {Array}
+   */
   async getPointInView (coordinate) {
     const res = await this._runNativeCommand('getPointInView',[
       coordinate,
@@ -251,7 +259,7 @@ class MapView extends React.Component {
     return res.pointInView;
   }
 
-  /**
+    /**
    * The coordinate bounds(ne, sw) visible in the users’s viewport.
    *
    * @example

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -243,6 +243,14 @@ class MapView extends React.Component {
     this._callbackMap = new Map();
   }
 
+  // Add convertCoordinate:ToPointToView
+  async getPointInView (coordinate) {
+    const res = await this._runNativeCommand('getPointInView',[
+      coordinate,
+    ]);
+    return res.pointInView;
+  }
+
   /**
    * The coordinate bounds(ne, sw) visible in the users’s viewport.
    *


### PR DESCRIPTION
My project needs to have the screen locations of points on the map. So I added -convertCoordinate:toPointToView: from mapbox native iOS SDK on react native iOS platform. And I tried to follow the code style as much as possible. 