### PR TITLE
Fixes offlineManager.getPacks crash

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // Mapbox SDK
     compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.9'
 
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.1@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.3.1@aar') {
         transitive=true
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -80,30 +80,23 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
         OfflineManager.CreateOfflineRegionCallback callback = new OfflineManager.CreateOfflineRegionCallback() {
             @Override
             public void onCreate(OfflineRegion offlineRegion) {
-                // TODO: Remove once we update to 5.2.2
-                FileSource.getInstance(mReactContext).deactivate();
-
                 promise.resolve(fromOfflineRegion(offlineRegion));
                 setOfflineRegionObserver(name, offlineRegion);
             }
 
             @Override
             public void onError(String error) {
-                // TODO: Remove once we update to 5.2.2
-                FileSource.getInstance(mReactContext).deactivate();
-                
                 sendEvent(makeErrorEvent(name, EventTypes.OFFLINE_ERROR, error));
             }
         };
-
-        // TODO: Remove once we update to 5.2.2
-        FileSource.getInstance(mReactContext).activate();
 
         offlineManager.createOfflineRegion(definition, metadataBytes, callback);
     }
 
     @ReactMethod
     public void getPacks(final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -127,6 +120,8 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getPackStatus(final String name, final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -162,6 +157,8 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setPackObserver(final String name, final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -186,6 +183,8 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void deletePack(final String name, final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -221,6 +220,8 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void pausePackDownload(final String name, final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -251,6 +252,8 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void resumePackDownload(final String name, final Promise promise) {
+        activateFileSource();
+
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
 
         offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
@@ -445,5 +448,10 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
         }
 
         return null;
+    }
+
+    private void activateFileSource() {
+        FileSource fileSource = FileSource.getInstance(mReactContext);
+        fileSource.activate();
     }
 }

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -87,19 +87,21 @@ RCT_EXPORT_METHOD(createPack:(NSDictionary *)options
 
 RCT_EXPORT_METHOD(getPacks:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSArray<MGLOfflinePack *> *packs = [[MGLOfflineStorage sharedOfflineStorage] packs];
-    NSMutableArray<NSDictionary *> *jsonPacks = [[NSMutableArray alloc] init];
-    
-    if (packs == nil) {
-        resolve(@[]);
-        return;
-    }
-    
-    for (MGLOfflinePack *pack in packs) {
-        [jsonPacks addObject:[self _convertPackToDict:pack]];
-    }
-    
-    resolve(jsonPacks);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSArray<MGLOfflinePack *> *packs = [[MGLOfflineStorage sharedOfflineStorage] packs];
+        NSMutableArray<NSDictionary *> *jsonPacks = [[NSMutableArray alloc] init];
+        
+        if (packs == nil) {
+            resolve(@[]);
+            return;
+        }
+        
+        for (MGLOfflinePack *pack in packs) {
+            [jsonPacks addObject:[self _convertPackToDict:pack]];
+        }
+        
+        resolve(jsonPacks);
+    });
 }
 
 RCT_EXPORT_METHOD(getPackStatus:(NSString *)name

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.0",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.3",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/891, https://github.com/mapbox/react-native-mapbox-gl/issues/907

* Updates to latest iOS and Android SDK's
* Fixes offlineManger.getPack crashes on both platforms

Thanks @aaronblondeau for debugging what was happening on the Android side!