### PR TITLE
[iOS] Add React dependency to Podspec

### DIFF
--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.source_files	= "ios/RCTMGL/**/*.{h,m}"
 
   s.vendored_frameworks = 'ios/Mapbox.framework'
+  s.dependency 'React'
 end


### PR DESCRIPTION
Support older versions of Swift by allowing `use_frameworks!` in CocoaPods