### PR TITLE
fixes crash on Android re-enter app

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -12,6 +12,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.MotionEvent;
+import android.view.View.OnAttachStateChangeListener;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
@@ -169,6 +170,22 @@ public class RCTMGLMapView extends MapView implements
         mHandler = new Handler();
 
         setLifecycleListeners();
+            
+        addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                if(mLocationLayer != null){
+                    mLocationLayer.onStart();
+                }
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                if(mLocationLayer != null){
+                    mLocationLayer.onStop();
+                }
+            }
+        });
     }
 
     public void addFeature(View childView, int childPosition) {


### PR DESCRIPTION
#999 #925 

The RCTMGLMapView has a LocationLayer that is registered with the locationEngine, and it never got removed when the view was torn down. This will tell the LocationLayer to stop when the view is detached. 

However, the Lost Engine is still active in the background. This patch simply lets you press back to close the app, and then re-enter without a crash