### PR TITLE
Remove direct link to markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install @mapbox/react-native-mapbox-gl --save
 
 * [Android](/android/install.md)
 * [iOS](/ios/install.md)
-* [Example](/example/README.md)
+* [Example](/example)
 
 ## Documentation
 


### PR DESCRIPTION
This way you can still see the readme, but also browse the files.

I found it frustrating to have to navigate up after clicking the link.