### PR TITLE
Adds support for onUserLocationUpdate

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -145,6 +145,7 @@ public class RCTMGLMapView extends MapView implements
             if (mUserTrackingState == UserTrackingState.POSSIBLE || distToNextLocation > 0.0f) {
                 updateUserLocation(true);
             }
+            sendUserLocationUpdateEvent(nextLocation);
         }
     };
 
@@ -1307,4 +1308,35 @@ public class RCTMGLMapView extends MapView implements
         mManager.handleEvent(event);
         mCameraChangeTracker.setReason(-1);
     }
+
+    private void sendUserLocationUpdateEvent(Location location) {
+        if(location == null){
+            return;
+        }
+        IEvent event = new MapChangeEvent(this, makeLocationChangePayload(location), EventTypes.USER_LOCATION_UPDATED);
+        mManager.handleEvent(event);
+    }
+
+    /**
+     * Create a payload of the location data per the web api geolocation spec
+     * https://dev.w3.org/geo/api/spec-source.html#position
+     * @return
+     */
+    private WritableMap makeLocationChangePayload(Location location) {
+
+        WritableMap positionProperties = new WritableNativeMap();
+        WritableMap coords = new WritableNativeMap();
+
+        coords.putDouble("longitude", location.getLongitude());
+        coords.putDouble("latitude", location.getLatitude());
+        coords.putDouble("altitude", location.getAltitude());
+        coords.putDouble("accuracy", location.getAccuracy());
+        coords.putDouble("heading", location.getBearing());
+        coords.putDouble("speed", location.getSpeed());
+
+        positionProperties.putMap("coords", coords);
+        positionProperties.putDouble("timestamp", location.getTime());
+        return positionProperties;
+    }
+
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -190,6 +190,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put(EventKeys.MAP_CLICK, "onPress")
                 .put(EventKeys.MAP_LONG_CLICK,"onLongPress")
                 .put(EventKeys.MAP_ONCHANGE, "onMapChange")
+                .put(EventKeys.MAP_ON_LOCATION_CHANGE, "onLocationChange")
                 .put(EventKeys.MAP_USER_TRACKING_MODE_CHANGE, "onUserTrackingModeChange")
                 .put(EventKeys.MAP_ANDROID_CALLBACK, "onAndroidCallback")
                 .build();

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
@@ -11,6 +11,7 @@ public class EventKeys {
     public static final String MAP_CLICK = ns("map.press");
     public static final String MAP_LONG_CLICK = ns("map.longpress");
     public static final String MAP_ONCHANGE = ns("map.change");
+    public static final String MAP_ON_LOCATION_CHANGE = ns("map.location.change");
     public static final String MAP_ANDROID_CALLBACK = ns("map.androidcallback");
     public static final String MAP_USER_TRACKING_MODE_CHANGE = ns("map.usertrackingmodechange");
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
@@ -13,6 +13,7 @@ public class EventTypes {
     public static final String REGION_WILL_CHANGE = "regionwillchange";
     public static final String REGION_IS_CHANGING = "regionischanging";
     public static final String REGION_DID_CHANGE  = "regiondidchange";
+    public static final String USER_LOCATION_UPDATED = "userlocationdupdated";
 
     public static final String WILL_START_LOADING_MAP = "willstartloadingmap";
     public static final String DID_FINISH_LOADING_MAP = "didfinishloadingmap";

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -69,6 +69,7 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
         eventTypes.put("RegionWilChange", EventTypes.REGION_WILL_CHANGE);
         eventTypes.put("RegionIsChanging", EventTypes.REGION_IS_CHANGING);
         eventTypes.put("RegionDidChange", EventTypes.REGION_DID_CHANGE);
+        eventTypes.put("UserLocationUpdated", EventTypes.USER_LOCATION_UPDATED);
         eventTypes.put("WillStartLoadingMap", EventTypes.WILL_START_LOADING_MAP);
         eventTypes.put("DidFinishLoadingMap", EventTypes.DID_FINISH_LOADING_MAP);
         eventTypes.put("DidFailLoadingMap", EventTypes.DID_FAIL_LOADING_MAP);

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -30,6 +30,7 @@
 | onRegionWillChange | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region is about to change. |
 | onRegionIsChanging | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region is changing. |
 | onRegionDidChange | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region finished changing |
+| onUserLocationUpdate | `func` | `none` | `false` | This event is triggered whenever the location engine receives a location update |
 | onWillStartLoadingMap | `func` | `none` | `false` | This event is triggered when the map is about to start loading a new map style. |
 | onDidFinishLoadingMap | `func` | `none` | `false` | This is triggered when the map has successfully loaded a new map style. |
 | onDidFailLoadingMap | `func` | `none` | `false` | This event is triggered when the map has failed to load a new map style. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1428,6 +1428,13 @@
         "description": "This event is triggered whenever the currently displayed map region finished changing"
       },
       {
+        "name": "onUserLocationUpdate",
+        "required": false,
+        "type": "func",
+        "default": "none",
+        "description": "This event is triggered whenever the location engine receives a location update"
+      },
+      {
         "name": "onWillStartLoadingMap",
         "required": false,
         "type": "func",

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -55,6 +55,7 @@ import TakeSnapshot from './components/TakeSnapshot';
 import TakeSnapshotWithMap from './components/TakeSnapshotWithMap';
 import GetZoom from './components/GetZoom';
 import GetCenter from './components/GetCenter';
+import UserLocationChange from './components/UserLocationChange';
 
 const styles = StyleSheet.create({
   noPermissionsText: {
@@ -130,6 +131,7 @@ const Examples = [
   new ExampleItem('Take Snapshot With Map', TakeSnapshotWithMap),
   new ExampleItem('Get Current Zoom', GetZoom),
   new ExampleItem('Get Center', GetCenter),
+  new ExampleItem('User Location Updates', UserLocationChange),
 ];
 
 class App extends React.Component {

--- a/example/src/components/UserLocationChange.js
+++ b/example/src/components/UserLocationChange.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Text } from 'react-native';
+import MapboxGL from '@mapbox/react-native-mapbox-gl';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+import Bubble from './common/Bubble';
+
+import sheet from '../styles/sheet';
+
+class UserLocationChange extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      timestamp: 0,
+      latitude: 0.0,
+      longitude: 0.0,
+      altitude: 0.0,
+      heading: 0.0,
+      accuracy: 0.0,
+      speed: 0.0,
+    };
+
+    this.onUserLocationUpdate = this.onUserLocationUpdate.bind(this);
+  }
+
+  onUserLocationUpdate (location) {
+    this.setState({
+      timestamp: location.timestamp,
+      latitude: location.coords.latitude,
+      longitude: location.coords.longitude,
+      altitude: location.coords.altitude,
+      heading: location.coords.heading,
+      accuracy: location.coords.accuracy,
+      speed: location.coords.speed,
+    });
+  }
+
+  renderLocationInfo () {
+    if (this.state.timestamp <= 0) {
+      return null;
+    }
+    return (
+      <Bubble>
+        <Text>Timestamp: {this.state.timestamp}</Text>
+        <Text>Latitude: {this.state.latitude}</Text>
+        <Text>Longitude: {this.state.longitude}</Text>
+        <Text>Altitude: {this.state.altitude}</Text>
+        <Text>Heading: {this.state.heading}</Text>
+        <Text>Accuracy: {this.state.accuracy}</Text>
+        <Text>Speed: {this.state.speed}</Text>
+      </Bubble>
+    );
+  }
+
+  render () {
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+            zoomLevel={16}
+            showUserLocation={true}
+            onUserLocationUpdate={this.onUserLocationUpdate}
+            userTrackingMode={MapboxGL.UserTrackingModes.Follow}
+            style={sheet.matchParent} />
+        {this.renderLocationInfo()}
+      </Page>
+    );
+  }
+}
+
+export default UserLocationChange;

--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -52,6 +52,7 @@ RCT_EXPORT_MODULE();
     [eventTypes setObject:RCT_MAPBOX_DID_FINISH_RENDERING_MAP forKey:@"DidFinishRenderingMap"];
     [eventTypes setObject:RCT_MAPBOX_DID_FINISH_RENDERING_MAP_FULLY forKey:@"DidFinishRenderingMapFully"];
     [eventTypes setObject:RCT_MAPBOX_DID_FINISH_LOADING_STYLE forKey:@"DidFinishLoadingStyle"];
+    [eventTypes setObject:RCT_MAPBOX_USER_LOCATION_UPDATE forKey:@"UserLocationUpdated"];
     
     // user tracking modes
     NSMutableDictionary *userTrackingModes = [[NSMutableDictionary alloc] init];

--- a/ios/RCTMGL/RCTMGLEventTypes.h
+++ b/ios/RCTMGL/RCTMGLEventTypes.h
@@ -13,6 +13,7 @@
 extern NSString *const RCT_MAPBOX_EVENT_TAP;
 extern NSString *const RCT_MAPBOX_EVENT_LONGPRESS;
 
+extern NSString *const RCT_MAPBOX_USER_LOCATION_UPDATE;
 extern NSString *const RCT_MAPBOX_USER_TRACKING_MODE_CHANGE;
 
 extern NSString *const RCT_MAPBOX_REGION_WILL_CHANGE_EVENT;

--- a/ios/RCTMGL/RCTMGLEventTypes.m
+++ b/ios/RCTMGL/RCTMGLEventTypes.m
@@ -13,6 +13,7 @@
 NSString *const RCT_MAPBOX_EVENT_TAP = @"press";
 NSString *const RCT_MAPBOX_EVENT_LONGPRESS = @"longpress";
 
+NSString *const RCT_MAPBOX_USER_LOCATION_UPDATE = @"userlocationdupdated";
 NSString *const RCT_MAPBOX_USER_TRACKING_MODE_CHANGE = @"usertrackingmodechange";
 
 NSString *const RCT_MAPBOX_REGION_WILL_CHANGE_EVENT = @"regionwillchange";

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -366,6 +366,29 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 #pragma mark - MGLMapViewDelegate
 
+- (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(MGLUserLocation *)userLocation
+{
+    if (userLocation == nil) {
+        return;
+    }
+    
+    RCTMGLMapView *reactMapView = (RCTMGLMapView *)mapView;
+    
+    NSDictionary *coords = @{
+      @"speed": @(userLocation.location.speed),
+      @"heading": @(userLocation.heading.trueHeading),
+      @"accuracy": @(userLocation.location.horizontalAccuracy),
+      @"altitude": @(userLocation.location.altitude),
+      @"latitude": @(userLocation.location.coordinate.latitude),
+      @"longitude": @(userLocation.location.coordinate.longitude)
+     };
+    
+    double utcTimestampMS = [userLocation.location.timestamp timeIntervalSince1970] * 1000.0;
+    NSDictionary *payload = @{ @"timestamp": @(utcTimestampMS), @"coords": coords };
+    RCTMGLEvent *locationEvent = [RCTMGLEvent makeEvent:RCT_MAPBOX_USER_LOCATION_UPDATE withPayload:payload];
+    [self fireEvent:locationEvent withCallback:reactMapView.onMapChange];
+}
+
 - (void)mapView:(MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated
 {
     RCTMGLMapView *reactMapView = (RCTMGLMapView *)mapView;

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -169,6 +169,11 @@ class MapView extends React.Component {
     onRegionDidChange: PropTypes.func,
 
     /**
+    * This event is triggered whenever the location engine receives a location update
+    */
+    onUserLocationUpdate: PropTypes.func,
+
+    /**
     * This event is triggered when the map is about to start loading a new map style.
     */
     onWillStartLoadingMap: PropTypes.func,
@@ -617,6 +622,9 @@ class MapView extends React.Component {
         break;
       case MapboxGL.EventTypes.RegionDidChange:
         propName = 'onRegionDidChange';
+        break;
+      case MapboxGL.EventTypes.UserLocationUpdated:
+        propName = 'onUserLocationUpdate';
         break;
       case MapboxGL.EventTypes.WillStartLoadinMap:
         propName = 'onWillStartLoadingMap';


### PR DESCRIPTION
Instead of implementing our own location provider on both Android and iOS (the react geolocation watcher for Android is currently broken), we thought it would be better to have one source of truth for the user's location. 

This PR adds the ability to listen for location changes in javascript, coming from the LocationEngine callbacks in native code. 

A new prop is declared in the MapView - ```onUserLocationUpdate()``` which adheres to the [Web's GEO spec](https://dev.w3.org/geo/api/spec-source.html#position)

Example usage...

```
<MapboxGL.MapView
    onUserLocationUpdate={(location) => {
        console.log("received location", { location });
    }}
    showUserLocation={true}
/>
```

with the location object looking like this

```
{ location:
    { timestamp: 1517273596854,
    coords: { 
        speed: 0,
        heading: 0,
        accuracy: 19.354000091552734,
        altitude: -22.200000762939453,
        latitude: 37.7782095,
        longitude: -122.4087152 
        } 
    } 
}
```
