### PR TITLE
v6 cannot read offline packages from v5

### DIFF
--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -268,7 +268,21 @@ RCT_EXPORT_METHOD(setProgressEventThrottle:(NSNumber *)throttleValue)
 
 - (NSDictionary *)_unarchiveMetadata:(MGLOfflinePack *)pack
 {
-    NSString *data = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
+    id data = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
+    // Version v5 store data as NSDictionary while v6 store data as JSON string.
+    // User might save offline pack in v5 and then try to read in v6.
+    // In v5 are metadata stored nested which need to be handled in JS.
+    // Example of how data are stored in v5
+    // {
+    //      name: "New York",
+    //      metadata: {
+    //          customMeta: "...",
+    //      }
+    // }
+    if ([data isKindOfClass:[NSDictionary class]]) {;
+        return data;
+    }
+    
     return [NSJSONSerialization JSONObjectWithData:[data dataUsingEncoding:NSUTF8StringEncoding]
                                 options:NSJSONReadingMutableContainers
                                 error:nil];

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -279,7 +279,7 @@ RCT_EXPORT_METHOD(setProgressEventThrottle:(NSNumber *)throttleValue)
     //          customMeta: "...",
     //      }
     // }
-    if ([data isKindOfClass:[NSDictionary class]]) {;
+    if ([data isKindOfClass:[NSDictionary class]]) {
         return data;
     }
     


### PR DESCRIPTION
This PR fixes issue https://github.com/mapbox/react-native-mapbox-gl/issues/735. 

v5 and v6 have different ways of storing metadata of offline packs. In v6 we are expecting string JSON while in v5 it was NSDictionary.