### PR TITLE
[Android/iOS]: Add support for mapView.getCenter()

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -899,6 +899,20 @@ public class RCTMGLMapView extends MapView implements
         });
     }
 
+    public void getCenter(String callbackID) {
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
+        LatLng center = mMap.getCameraPosition().target;
+
+        WritableArray array = new WritableNativeArray();
+        array.pushDouble(center.getLongitude());
+        array.pushDouble(center.getLatitude());
+        WritableMap payload = new WritableNativeMap();
+        payload.putArray("center", array);
+        event.setPayload(payload);
+
+        mManager.handleEvent(event);
+    }
+
     public void init() {
         setStyleUrl(mStyleURL);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -206,6 +206,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_GET_POINT_IN_VIEW = 5;
     public static final int METHOD_TAKE_SNAP = 6;
     public static final int METHOD_GET_ZOOM = 7;
+    public static final int METHOD_GET_CENTER = 8;
 
     @Nullable
     @Override
@@ -218,6 +219,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
                 .put("takeSnap", METHOD_TAKE_SNAP)
                 .put("getZoom", METHOD_GET_ZOOM)
+                .put("getCenter", METHOD_GET_CENTER)
                 .build();
     }
 
@@ -251,6 +253,8 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 mapView.takeSnap(args.getString(0), args.getBoolean(1));
             case METHOD_GET_ZOOM:
                 mapView.getZoom(args.getString(0));
+            case METHOD_GET_CENTER:
+                mapView.getCenter(args.getString(0));
                 break;
         }
     }

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -238,3 +238,15 @@ Returns the current zoom of the map view.
 ```javascript
 const zoom = await this._map.getZoom();
 ```
+
+#### getCenter()
+
+Returns the map's geographical centerpoint
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+```javascript
+const center = await this._map.getCenter();
+```

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -54,6 +54,7 @@ import PointInMapView from './components/PointInMapView';
 import TakeSnapshot from './components/TakeSnapshot';
 import TakeSnapshotWithMap from './components/TakeSnapshotWithMap';
 import GetZoom from './components/GetZoom';
+import GetCenter from './components/GetCenter';
 
 const styles = StyleSheet.create({
   noPermissionsText: {
@@ -128,6 +129,7 @@ const Examples = [
   new ExampleItem('Take Snapshot Without Map', TakeSnapshot),
   new ExampleItem('Take Snapshot With Map', TakeSnapshotWithMap),
   new ExampleItem('Get Current Zoom', GetZoom),
+  new ExampleItem('Get Center', GetCenter),
 ];
 
 class App extends React.Component {

--- a/example/src/components/GetCenter.js
+++ b/example/src/components/GetCenter.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Text } from 'react-native';
+import MapboxGL from '@mapbox/react-native-mapbox-gl';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+import Bubble from './common/Bubble';
+
+class GetCenter extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      center: [],
+    };
+
+    this.onRegionDidChange = this.onRegionDidChange.bind(this);
+    this.getLat = this.getLat.bind(this);
+    this.getLng = this.getLng.bind(this);
+  }
+
+  async onRegionDidChange () {
+    const center = await this._map.getCenter();
+    this.setState({ center });
+  }
+
+
+  getLng () {
+    const { center } = this.state;
+    return center.length === 2
+      ? `Lng: ${center[0]}`
+      : 'Not available';
+  }
+
+  getLat () {
+    const { center } = this.state;
+    return center.length === 2
+      ? `Lat: ${center[1]}`
+      : 'Not available';
+  }
+
+  render () {
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+          onRegionDidChange={this.onRegionDidChange}
+          zoomLevel={9}
+          ref={(c) => this._map = c}
+          onPress={this.onPress}
+          centerCoordinate={[-73.970895, 40.723279]}
+          style={{ flex: 1 }} />
+
+        <Bubble>
+          <Text>Center</Text>
+          <Text>{this.getLng()}</Text>
+          <Text>{this.getLat()}</Text>
+        </Bubble>
+      </Page>
+    );
+  }
+}
+
+export default GetCenter;

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -173,6 +173,23 @@ RCT_EXPORT_METHOD(getZoom:(nonnull NSNumber*)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(getCenter:(nonnull NSNumber*)reactTag
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+
+        if (![view isKindOfClass:[RCTMGLMapView class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+
+        RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
+        resolve(@{ @"center": @[@(reactMapView.centerCoordinate.longitude), @(reactMapView.centerCoordinate.latitude)]});
+    }];
+}
+
 RCT_EXPORT_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)reactTag
                   atPoint:(NSArray<NSNumber*>*)point
                   withFilter:(NSArray<NSDictionary<NSString *, id> *> *)filter

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -522,6 +522,19 @@ class MapView extends React.Component {
     return res.zoom;
   }
 
+  /**
+   * Returns the map's geographical centerpoint
+   *
+   * @example
+   * const center = await this._map.getCenter();
+   *
+   * @return {Array<Number>} Coordinates
+   */
+  async getCenter () {
+    const res = await this._runNativeCommand('getCenter');
+    return res.center;
+  }
+
   _runNativeCommand (methodName, args = []) {
     if (isAndroid()) {
       return new Promise ((resolve) => {


### PR DESCRIPTION
![](https://media.giphy.com/media/xUNd9JtR6BXhYGi3aU/giphy.gif)

Closes #940 (`getZoom()` was implemented and merged here #1022)