### PR TITLE
Fixes DeadObjectException

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -97,6 +97,7 @@ public class RCTMGLMapView extends MapView implements
     private Handler mHandler;
     private LifecycleEventListener mLifeCycleListener;
     private boolean mPaused;
+    private boolean mDestroyed;
 
     private List<AbstractMapFeature> mFeatures;
     private List<AbstractMapFeature> mQueuedFeatures;
@@ -195,6 +196,12 @@ public class RCTMGLMapView extends MapView implements
     }
 
     @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mDestroyed = true;
+    }
+
+    @Override
     public void onWindowFocusChanged(boolean hasWindowFocus) {
         super.onWindowFocusChanged(hasWindowFocus);
         if (mLocationLayer == null) {
@@ -272,6 +279,10 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public synchronized void dispose() {
+        if (mDestroyed) {
+            return;
+        }
+
         ReactContext reactContext = (ReactContext) mContext;
         reactContext.removeLifecycleEventListener(mLifeCycleListener);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1,6 +1,8 @@
 package com.mapbox.rctmgl.components.mapview;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.RectF;
@@ -14,6 +16,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.MotionEvent;
 
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -35,8 +38,10 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
+import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.annotation.RCTMGLCallout;
@@ -90,6 +95,8 @@ public class RCTMGLMapView extends MapView implements
     private RCTMGLMapViewManager mManager;
     private Context mContext;
     private Handler mHandler;
+    private LifecycleEventListener mLifeCycleListener;
+    private boolean mPaused;
 
     private List<AbstractMapFeature> mFeatures;
     private List<AbstractMapFeature> mQueuedFeatures;
@@ -151,10 +158,13 @@ public class RCTMGLMapView extends MapView implements
     public RCTMGLMapView(Context context, RCTMGLMapViewManager manager, MapboxMapOptions options) {
         super(context, options);
 
-        super.onCreate(null);
-        super.getMapAsync(this);
-
         mContext = context;
+
+        onCreate(null);
+        onStart();
+        onResume();
+        getMapAsync(this);
+
         mManager = manager;
         mCameraUpdateQueue = new CameraUpdateQueue();
 
@@ -170,6 +180,18 @@ public class RCTMGLMapView extends MapView implements
         mHandler = new Handler();
 
         setLifecycleListeners();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mPaused = false;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mPaused = true;
     }
 
     @Override
@@ -249,11 +271,22 @@ public class RCTMGLMapView extends MapView implements
         return mFeatures.get(i);
     }
 
-    public void dispose() {
+    public synchronized void dispose() {
+        ReactContext reactContext = (ReactContext) mContext;
+        reactContext.removeLifecycleEventListener(mLifeCycleListener);
+
         if(mLocationLayer != null){
             mLocationLayer.onStop();
         }
+
         mLocationManger.dispose();
+
+        if (!mPaused) {
+            onPause();
+        }
+
+        onStop();
+        onDestroy();
     }
 
     public RCTMGLPointAnnotation getPointAnnotationByID(String annotationID) {
@@ -1035,7 +1068,8 @@ public class RCTMGLMapView extends MapView implements
 
     private void setLifecycleListeners() {
         final ReactContext reactContext = (ReactContext) mContext;
-        reactContext.addLifecycleEventListener(new LifecycleEventListener() {
+
+        mLifeCycleListener = new LifecycleEventListener() {
             @Override
             public void onHostResume() {
                 if (mShowUserLocation && !mLocationManger.isActive()) {
@@ -1055,10 +1089,10 @@ public class RCTMGLMapView extends MapView implements
             @Override
             public void onHostDestroy() {
                 dispose();
-                onDestroy();
-                reactContext.removeLifecycleEventListener(this);
             }
-        });
+        };
+
+        reactContext.addLifecycleEventListener(mLifeCycleListener);
     }
 
     private void enableLocation() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -73,6 +73,8 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
 
     @Override
     public void onDropViewInstance(RCTMGLMapView mapView) {
+        super.onDropViewInstance(mapView);
+
         try {
             mapView.dispose();
         } catch (Exception e) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -1,11 +1,14 @@
 package com.mapbox.rctmgl.components.mapview;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.mapbox.rctmgl.components.AbstractEventEmitter;
@@ -16,6 +19,7 @@ import com.mapbox.rctmgl.utils.GeoJSONUtils;
 import com.mapbox.services.commons.geojson.Point;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -28,8 +32,11 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final String LOG_TAG = RCTMGLMapViewManager.class.getSimpleName();
     public static final String REACT_CLASS = RCTMGLMapView.class.getSimpleName();
 
+    private Map<Integer, RCTMGLMapView> mViews;
+
     public RCTMGLMapViewManager(ReactApplicationContext context) {
         super(context);
+        mViews = new HashMap<>();
     }
 
     @Override
@@ -38,10 +45,21 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     }
 
     @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        return new MapShadowNode(this);
+    }
+
+    @Override
+    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
+        return MapShadowNode.class;
+    }
+
+    @Override
     protected void onAfterUpdateTransaction(RCTMGLMapView mapView) {
         super.onAfterUpdateTransaction(mapView);
 
         if (mapView.getMapboxMap() == null) {
+            mViews.put(mapView.getId(), mapView);
             mapView.init();
         }
     }
@@ -73,13 +91,17 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
 
     @Override
     public void onDropViewInstance(RCTMGLMapView mapView) {
-        super.onDropViewInstance(mapView);
+        int reactTag = mapView.getId();
 
-        try {
-            mapView.dispose();
-        } catch (Exception e) {
-            Log.w(LOG_TAG, e.getLocalizedMessage());
+        if (mViews.containsKey(reactTag)) {
+            mViews.remove(reactTag);
         }
+
+        super.onDropViewInstance(mapView);
+    }
+
+    public RCTMGLMapView getByReactTag(int reactTag) {
+        return mViews.get(reactTag);
     }
 
     //region React Props
@@ -264,4 +286,33 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     }
 
     //endregion
+
+    private static final class MapShadowNode extends LayoutShadowNode {
+        private Handler mMainHandler;
+        private RCTMGLMapViewManager mViewManager;
+
+        public MapShadowNode(RCTMGLMapViewManager viewManager) {
+            mViewManager = viewManager;
+            mMainHandler = new Handler(Looper.getMainLooper());
+        }
+
+        @Override
+        public void dispose() {
+            super.dispose();
+            diposeNativeMapView();
+        }
+
+        private void diposeNativeMapView() {
+            final RCTMGLMapView mapView = mViewManager.getByReactTag(getReactTag());
+
+            if (mapView != null) {
+                mMainHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mapView.dispose();
+                    }
+                });
+            }
+        }
+    }
 }


### PR DESCRIPTION
* ~~Force TextureView on Android to prevent ANR/DeadObjectException since the Android SDK is expecting `onDestroy` to be called in the parents Activities `onDestroy` with a GLSurfaceView~~

~~One thing to note is there is a ticket open in `gl-native` to figure out a way to get the `GLSurfaceView` and `onDestroy` to work without needing to be called in the parent activity, so we are still keeping that code around because we expect it to work in future releases~~

See https://github.com/mapbox/react-native-mapbox-gl/pull/1033#issuecomment-366581754