### PR TITLE
[Android] Fix filters not being applied to a layer after switching styleURL

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -61,7 +61,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
     protected Double mMinZoomLevel;
     protected Double mMaxZoomLevel;
     protected ReadableMap mReactStyle;
-    protected FilterParser.FilterList mFilter;
+    protected Filter.Statement mFilter;
 
     protected MapboxMap mMap;
     protected T mLayer;
@@ -156,13 +156,13 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
     }
 
     public void setFilter(ReadableArray readableFilterArray) {
-        mFilter = FilterParser.getFilterList(readableFilterArray);
+        FilterParser.FilterList filterList = FilterParser.getFilterList(readableFilterArray);
+
+        mFilter = buildFilter(filterList);
 
         if (mLayer != null) {
-            Filter.Statement statement = buildFilter();
-
-            if (statement != null) {
-                updateFilter(statement);
+            if (mFilter != null) {
+                updateFilter(mFilter);
             }
         }
     }
@@ -233,8 +233,8 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         }
     }
 
-    protected Filter.Statement buildFilter() {
-        return FilterParser.parse(mFilter);
+    protected Filter.Statement buildFilter(FilterParser.FilterList filterList) {
+        return FilterParser.parse(filterList);
     }
 
     protected void updateFilter(Filter.Statement statement) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
@@ -28,9 +28,8 @@ public class RCTMGLCircleLayer extends RCTLayer<CircleLayer> {
     public void addToMap(RCTMGLMapView mapView) {
         super.addToMap(mapView);
 
-        Filter.Statement statement = buildFilter();
-        if (statement != null) {
-            updateFilter(statement);
+        if (mFilter != null) {
+            updateFilter(mFilter);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
@@ -30,9 +30,8 @@ public class RCTMGLFillExtrusionLayer extends RCTLayer<FillExtrusionLayer> {
     public void addToMap(RCTMGLMapView mapView) {
         super.addToMap(mapView);
 
-        Filter.Statement statement = buildFilter();
-        if (statement != null) {
-            updateFilter(statement);
+        if (mFilter != null) {
+            updateFilter(mFilter);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
@@ -29,9 +29,8 @@ public class RCTMGLFillLayer extends RCTLayer<FillLayer> {
     public void addToMap(RCTMGLMapView mapView) {
         super.addToMap(mapView);
 
-        Filter.Statement statement = buildFilter();
-        if (statement != null) {
-            updateFilter(statement);
+        if (mFilter != null) {
+            updateFilter(mFilter);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
@@ -29,9 +29,8 @@ public class RCTMGLLineLayer extends RCTLayer<LineLayer> {
     public void addToMap(RCTMGLMapView mapView) {
         super.addToMap(mapView);
 
-        Filter.Statement statement = buildFilter();
-        if (statement != null) {
-            updateFilter(statement);
+        if (mFilter != null) {
+            updateFilter(mFilter);
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
@@ -38,9 +38,8 @@ public class RCTMGLSymbolLayer extends RCTLayer<SymbolLayer> {
     public void addToMap(RCTMGLMapView mapView) {
         super.addToMap(mapView);
 
-        Filter.Statement statement = buildFilter();
-        if (statement != null) {
-            updateFilter(statement);
+        if (mFilter != null) {
+            updateFilter(mFilter);
         }
     }
 


### PR DESCRIPTION
On Android, when switching styleURL of the map, layers are removed and added back to the map. Filters are not correctly applied when this happens.

To test, add a ShapeSource with two layers, both with filters. Add a button to switch styleURL. 

I believe this is because RCTLayer stores a FilterList property. When this is parsed, the items are removed from the array. The next time the layer is added to the map, this FilterList is empty.

My suggestion to fix this is to store the Filter.Statement on the Layer, instead of the FilterList. This solved the issue for me in limited testing.