### PR TITLE
Android sdk 5.4.1 update

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // Mapbox SDK
     compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.9'
 
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.3.1@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar') {
         transitive=true
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -251,8 +251,10 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 break;
             case METHOD_TAKE_SNAP:
                 mapView.takeSnap(args.getString(0), args.getBoolean(1));
+                break;
             case METHOD_GET_ZOOM:
                 mapView.getZoom(args.getString(0));
+                break;
             case METHOD_GET_CENTER:
                 mapView.getCenter(args.getString(0));
                 break;


### PR DESCRIPTION
* Updates to latest Android 5.4.1 SDK
* Adds missing break statements to RCTMGLMapViewManager