### PR TITLE
fixing crash when for rendering shapes on dead maps

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -979,6 +979,10 @@ public class RCTMGLMapView extends MapView implements
         getViewTreeObserver().dispatchOnGlobalLayout();
     }
 
+    public boolean isDestroyed(){
+        return mDestroyed;
+    }
+
     private void updateCameraPositionIfNeeded(boolean shouldUpdateTarget) {
         if (mMap != null) {
             CameraPosition prevPosition = mMap.getCameraPosition();

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -22,8 +22,13 @@ import com.mapbox.services.commons.geojson.Point;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
 
 import javax.annotation.Nullable;
+
+import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 /**
  * Created by nickitaliano on 8/18/17.
@@ -297,12 +302,10 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     //endregion
 
     private static final class MapShadowNode extends LayoutShadowNode {
-        private Handler mMainHandler;
         private RCTMGLMapViewManager mViewManager;
 
         public MapShadowNode(RCTMGLMapViewManager viewManager) {
             mViewManager = viewManager;
-            mMainHandler = new Handler(Looper.getMainLooper());
         }
 
         @Override
@@ -311,16 +314,27 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
             diposeNativeMapView();
         }
 
+        /**
+         * We need this mapview to dispose (calls into nativeMap.destroy) before ReactNative starts tearing down the views in
+         * onDropViewInstance.
+         */
         private void diposeNativeMapView() {
             final RCTMGLMapView mapView = mViewManager.getByReactTag(getReactTag());
 
-            if (mapView != null) {
-                mMainHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        mapView.dispose();
-                    }
-                });
+            RunnableFuture<Void> task = new FutureTask<>(new Runnable() {
+                @Override
+                public void run() {
+                    mapView.dispose();
+                }
+            }, null);
+
+            runOnUiThread(task);
+
+            try {
+                task.get(); // this will block until Runnable completes
+            } catch (InterruptedException | ExecutionException e) {
+                // handle exception
+                Log.e(getClass().getSimpleName() , " diposeNativeMapView() exception destroying map view", e);
             }
         }
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -121,7 +121,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     public void setURL(URL url) {
         mURL = url;
 
-        if (mSource != null) {
+        if (mSource != null && mMapView != null && !mMapView.isDestroyed() ) {
             ((GeoJsonSource) mSource).setUrl(mURL);
         }
     }
@@ -129,7 +129,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     public void setShape(String geoJSONStr) {
         mShape = geoJSONStr;
 
-        if (mSource != null) {
+        if (mSource != null && mMapView != null && !mMapView.isDestroyed() ) {
             ((GeoJsonSource) mSource).setGeoJson(mShape);
         }
     }


### PR DESCRIPTION
This PR fixes a bug we found when using React-Navigation. We were trying to reset the navigation backstack from a stack such as ```[Map, ScreenX]``` to a stack such as ```[map, ScreenY]```. When using the reset action from React-Navigation, it will unmount and remount all components. This was a touchy operation with mapbox tearing down and recreating the native mapbox (c++). 

Before this fix, we had some Shapes that were changing their props as this navigation was unmounting and remounting the components that hold our mapview, and therefore the ShapeManager was receiving [prop updates](https://github.com/mapbox/react-native-mapbox-gl/blob/master/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java#L91), which was delegating to [setNativeGeoJsonSource](https://github.com/mapbox/react-native-mapbox-gl/blob/master/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java#L133) which trying to touch a native map that was recently destroyed! 

This PR will check to make sure that the mapview is not destroyed before we try and set the shape. 

This is simply a patch to cover up the symptoms we were seeing... perhaps this will expose a deeper issue, but I wanted to open this up and let you know how we've fixed it on our fork. 