### PR TITLE
Bugfix/ios remote image crashes

### DIFF
--- a/ios/RCTMGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMGL.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C43CA5061F507BCC000B9CB7 /* RCTMGLMapTouchEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = C43CA5051F507BCC000B9CB7 /* RCTMGLMapTouchEvent.m */; };
 		C43CA50A1F50C145000B9CB7 /* RCTMGLEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = C43CA5091F50C145000B9CB7 /* RCTMGLEvent.m */; };
 		C43CA50D1F53A4EF000B9CB7 /* RCTMGLEventTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = C43CA50C1F53A4EF000B9CB7 /* RCTMGLEventTypes.m */; };
+		C45339CD204780EB00888553 /* RCTMGLImageQueueOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = C45339CC204780EB00888553 /* RCTMGLImageQueueOperation.m */; };
 		C470F5B81F9E79D400614A69 /* RCTMGLImageQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = C470F5B71F9E79D400614A69 /* RCTMGLImageQueue.m */; };
 		C470F6AC1FA11C9500614A69 /* MGLOfflineModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C470F6AB1FA11C9500614A69 /* MGLOfflineModule.m */; };
 		C4C87A601F844C820064AE95 /* FilterParser.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C87A5F1F844C820064AE95 /* FilterParser.m */; };
@@ -108,6 +109,8 @@
 		C43CA5091F50C145000B9CB7 /* RCTMGLEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMGLEvent.m; sourceTree = "<group>"; };
 		C43CA50B1F53A4EF000B9CB7 /* RCTMGLEventTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMGLEventTypes.h; sourceTree = "<group>"; };
 		C43CA50C1F53A4EF000B9CB7 /* RCTMGLEventTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMGLEventTypes.m; sourceTree = "<group>"; };
+		C45339CB204780EB00888553 /* RCTMGLImageQueueOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTMGLImageQueueOperation.h; sourceTree = "<group>"; };
+		C45339CC204780EB00888553 /* RCTMGLImageQueueOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMGLImageQueueOperation.m; sourceTree = "<group>"; };
 		C470F5B61F9E79D400614A69 /* RCTMGLImageQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTMGLImageQueue.h; sourceTree = "<group>"; };
 		C470F5B71F9E79D400614A69 /* RCTMGLImageQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMGLImageQueue.m; sourceTree = "<group>"; };
 		C470F6AA1FA11C9500614A69 /* MGLOfflineModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLOfflineModule.h; sourceTree = "<group>"; };
@@ -344,6 +347,8 @@
 				C41DCC9C1FBBA8F000895BB4 /* FilterList.m */,
 				C416014E20112B5200006116 /* RNMBImageUtils.h */,
 				C416014F20112B5200006116 /* RNMBImageUtils.m */,
+				C45339CB204780EB00888553 /* RCTMGLImageQueueOperation.h */,
+				C45339CC204780EB00888553 /* RCTMGLImageQueueOperation.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -510,6 +515,7 @@
 				C4C87B7E1F8FEC090064AE95 /* RCTMGLPointAnnotation.m in Sources */,
 				C4EAF1271F6083C70016DEE8 /* CameraUpdateItem.m in Sources */,
 				C470F5B81F9E79D400614A69 /* RCTMGLImageQueue.m in Sources */,
+				C45339CD204780EB00888553 /* RCTMGLImageQueueOperation.m in Sources */,
 				C4D144531F4E190C00396F26 /* MGLModule.m in Sources */,
 				C4C87B7B1F8FEBF50064AE95 /* RCTMGLPointAnnotationManager.m in Sources */,
 				C43CA50A1F50C145000B9CB7 /* RCTMGLEvent.m in Sources */,

--- a/ios/RCTMGL/RCTMGLImageQueueOperation.h
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.h
@@ -1,0 +1,16 @@
+//
+//  RCTMGLImageQueueOperation.h
+//  RCTMGL
+//
+//  Created by Nick Italiano on 2/28/18.
+//  Copyright © 2018 Mapbox Inc. All rights reserved.
+//
+#import <React/RCTImageLoader.h>
+
+@interface RCTMGLImageQueueOperation : NSBlockOperation
+
+@property (nonatomic, weak) RCTBridge *bridge;
+@property (nonatomic, copy) RCTImageLoaderCompletionBlock completionHandler;
+@property (nonatomic, copy) NSURLRequest *urlRequest;
+
+@end

--- a/ios/RCTMGL/RCTMGLImageQueueOperation.m
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.m
@@ -1,0 +1,35 @@
+//
+//  RCTMGLImageQueueOperation.m
+//  RCTMGL
+//
+//  Created by Nick Italiano on 2/28/18.
+//  Copyright © 2018 Mapbox Inc. All rights reserved.
+//
+
+#import "RCTMGLImageQueueOperation.h"
+
+@implementation RCTMGLImageQueueOperation
+{
+    RCTImageLoaderCancellationBlock cancellationBlock;
+}
+
+- (void)start
+{
+    if (self.isCancelled) {
+        return;
+    }
+    
+    __weak RCTMGLImageQueueOperation *weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        cancellationBlock = [weakSelf.bridge.imageLoader loadImageWithURLRequest:weakSelf.urlRequest callback:weakSelf.completionHandler];
+    });
+}
+
+- (void)cancel
+{
+    if (cancellationBlock != nil) {
+        cancellationBlock();
+    }
+}
+
+@end

--- a/ios/RCTMGL/RCTMGLUtils.m
+++ b/ios/RCTMGL/RCTMGLUtils.m
@@ -85,8 +85,8 @@ static double const MS_TO_S = 0.001;
         return;
     }
     
-
     __block NSUInteger imagesLeftToLoad = imageNames.count;
+    __weak MGLStyle *weakStyle = style;
     
     void (^imageLoadedBlock)() = ^{
         imagesLeftToLoad--;
@@ -101,8 +101,10 @@ static double const MS_TO_S = 0.001;
         
         if (foundImage == nil) {
             [RCTMGLImageQueue.sharedInstance addImage:objects[imageName] bridge:bridge completionHandler:^(NSError *error, UIImage *image) {
-                [style setImage:image forName:imageName];
-                imageLoadedBlock();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakStyle setImage:image forName:imageName];
+                    imageLoadedBlock();
+                });
             }];
         } else {
             imageLoadedBlock();


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/920#issuecomment-368691849

* [iOS] Fixes random crash with remote images in symbol layer
* [iOS] Fixes crash when switching between styleURLs with a SymbolLayer rendered on the map with `iconImage` set.

Thanks @atarsha for the support and sample project!