### PR TITLE
Release 6.1.0

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@mapbox/geo-viewport": "^0.2.2",
-    "@mapbox/react-native-mapbox-gl": "file:../mapbox-react-native-mapbox-gl-6.0.3.tgz",
+    "@mapbox/react-native-mapbox-gl": "file:../mapbox-react-native-mapbox-gl-6.1.0.tgz",
     "@turf/along": "^4.7.3",
     "@turf/bearing": "^5.0.0",
     "@turf/distance": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/react-native-mapbox-gl",
   "description": "A Mapbox GL react native module for creating custom maps",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "author": "Bobby Sudekum",
   "main": "./javascript/index.js",
   "keywords": [


### PR DESCRIPTION
## Bugfixes
* [Android] Fixes ANR when calling `onDestroy` after the MapView has been removed https://github.com/mapbox/react-native-mapbox-gl/pull/1033
* [iOS] Fixes random crash with remote images on a symbol layer, with style url changes https://github.com/mapbox/react-native-mapbox-gl/pull/1080
* [All] Fixes timing issue that would cause map to randomly overflow parent container https://github.com/mapbox/react-native-mapbox-gl/issues/1027
* [Android] Fixes filter not being supplied to `Layer` when switching between style urls https://github.com/mapbox/react-native-mapbox-gl/pull/1040

## Features
* Adds support for `onUserLocationUpdate` https://github.com/mapbox/react-native-mapbox-gl/pull/1011

## Breaking Changes
* [Android] Changes the default MapView to a `TextureView` instead of a `GLSurfaceView`. `textureMode` no longer exists as a map prop due to this change, we've added a `surfaceView` prop if you would like to use a `GLSurfaceView` https://github.com/mapbox/react-native-mapbox-gl/pull/1090