### PR TITLE
Second "onCameraIdle" event rejected on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -401,7 +401,8 @@ public class RCTMGLMapView extends MapView implements
         final RCTMGLMapView self = this;
         mMap.addOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
             long lastTimestamp = System.currentTimeMillis();
-
+		boolean lastAnimated = false; // Workaround for the event called twice
+		
             @Override
             public void onCameraIdle() {
                 if (mPointAnnotations.size() > 0) {
@@ -409,14 +410,17 @@ public class RCTMGLMapView extends MapView implements
                 }
 
                 long curTimestamp = System.currentTimeMillis();
-                if (curTimestamp - lastTimestamp < 500) {
+		boolean curAnimated = mCameraChangeTracker.isAnimated();
+                if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
                     return;
                 }
-
-                sendRegionChangeEvent(mCameraChangeTracker.isAnimated());
+		
+                sendRegionChangeEvent(curAnimated);
                 lastTimestamp = curTimestamp;
+		lastAnimated = curAnimated;
             }
         });
+		
 
         mMap.addOnCameraMoveStartedListener(new MapboxMap.OnCameraMoveStartedListener() {
             @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -401,8 +401,8 @@ public class RCTMGLMapView extends MapView implements
         final RCTMGLMapView self = this;
         mMap.addOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
             long lastTimestamp = System.currentTimeMillis();
-		boolean lastAnimated = false; // Workaround for the event called twice
-		
+            boolean lastAnimated = false; // Workaround for the event called twice
+
             @Override
             public void onCameraIdle() {
                 if (mPointAnnotations.size() > 0) {
@@ -410,17 +410,16 @@ public class RCTMGLMapView extends MapView implements
                 }
 
                 long curTimestamp = System.currentTimeMillis();
-		boolean curAnimated = mCameraChangeTracker.isAnimated();
+                boolean curAnimated = mCameraChangeTracker.isAnimated();
                 if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
                     return;
                 }
-		
+
                 sendRegionChangeEvent(curAnimated);
                 lastTimestamp = curTimestamp;
-		lastAnimated = curAnimated;
+                lastAnimated = curAnimated;
             }
         });
-		
 
         mMap.addOnCameraMoveStartedListener(new MapboxMap.OnCameraMoveStartedListener() {
             @Override


### PR DESCRIPTION
There is an issue in the Android SDK, the "onCameraIdle" event is thrown twice. In the wrapper, there is a minimal delay set to avoid calling onRegionDidChange twice for the same event.
This is a workaround to avoid the second (and real) event to be dismissed because it's happening too fast.

In fact, the issue is really in the Android SDK but it seems to be corrected in a new version of the SDK. So this PR is just a Workaround before upgrading the Android SDK.
