### PR TITLE
Fix a typo which causes onWillStartLoadingMap not get called.

### DIFF
--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -645,7 +645,7 @@ class MapView extends React.Component {
       case MapboxGL.EventTypes.UserLocationUpdated:
         propName = 'onUserLocationUpdate';
         break;
-      case MapboxGL.EventTypes.WillStartLoadinMap:
+      case MapboxGL.EventTypes.WillStartLoadingMap:
         propName = 'onWillStartLoadingMap';
         break;
       case MapboxGL.EventTypes.DidFinishLoadingMap:


### PR DESCRIPTION
We found that the `onWillStartLoadingMap` in `MapView` not get called.

It's caused by a typo in `_onChange` in `MapView.js`. This PR fixes it.