### PR TITLE
Fixes hitbox on ShapeSource and VectorSource

### DIFF
--- a/example/src/components/CustomIcon.js
+++ b/example/src/components/CustomIcon.js
@@ -30,6 +30,7 @@ class CustomIcon extends React.Component {
     };
 
     this.onPress = this.onPress.bind(this);
+    this.onSourceLayerPress = this.onSourceLayerPress.bind(this);
   }
 
   async onPress(e) {
@@ -39,6 +40,11 @@ class CustomIcon extends React.Component {
         MapboxGL.geoUtils.makeFeature(e.geometry),
       ),
     });
+  }
+
+  onSourceLayerPress(e) {
+    const feature = e.nativeEvent.payload;
+    console.log('You pressed a layer here is your feature', feature); // eslint-disable-line
   }
 
   render() {
@@ -52,6 +58,8 @@ class CustomIcon extends React.Component {
           style={sheet.matchParent}>
           <MapboxGL.ShapeSource
             id="symbolLocationSource"
+            hitbox={{ width: 20, height: 20 }}
+            onPress={this.onSourceLayerPress}
             shape={this.state.featureCollection}>
             <MapboxGL.SymbolLayer
               id="symbolLocationSymbols"

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -150,6 +150,7 @@ class ShapeSource extends React.Component {
       id: this.props.id,
       url: this.props.url,
       shape: this._getShape(),
+      hitbox: this.props.hitbox,
       hasPressListener: isFunction(this.props.onPress),
       onMapboxShapeSourcePress: this.props.onPress,
       cluster: this.props.cluster ? 1 : 0,

--- a/javascript/components/VectorSource.js
+++ b/javascript/components/VectorSource.js
@@ -52,6 +52,7 @@ class VectorSource extends React.Component {
     const props = {
       id: this.props.id,
       url: this.props.url,
+      hitbox: this.props.hitbox,
       hasPressListener: isFunction(this.props.onPress),
       onMapboxVectorSourcePress: this.props.onPress,
       onPress: undefined,


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/1142

The hitbox was only using the default `44x44` pixel value, so when a user would try to override that value the default value was still being used. This PR makes sure that we are passing the user defined value over the bridge into our native code so the hitbox get's applied properly