### PR TITLE
Ability to use PlistBuddy to determine framework version

### DIFF
--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -3,7 +3,11 @@
 cd ios/
 
 VERSION=$1
-CURRENT_VERSION=$(cat .framework_version)
+if type /usr/libexec/PlistBuddy &> /dev/null; then
+  CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :MGLSemanticVersionString" Mapbox.framework/Info.plist)
+else
+  CURRENT_VERSION=$(cat .framework_version)
+fi
 
 if [ "$VERSION" == "$CURRENT_VERSION" ]; then
   echo "The newest version is already installed. Exiting."


### PR DESCRIPTION
For me I had a case where the version in `.framework_version` and the actual version of the framework was different, causing the script to think that it already had the latest version.

Here it looks at the version inside the framework itself by using `PlistBuddy` if available.