### PR TITLE
Add method to get geographic coordinate from view point

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -981,6 +981,21 @@ public class RCTMGLMapView extends MapView implements
         mManager.handleEvent(event);
     }
 
+    public void getCoordinateFromView(String callbackID, PointF pointInView) {
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
+
+        LatLng mapCoordinate = mMap.getProjection().fromScreenLocation(pointInView);
+        WritableMap payload = new WritableNativeMap();
+
+        WritableArray array = new WritableNativeArray();
+        array.pushDouble(mapCoordinate.getLongitude());
+        array.pushDouble(mapCoordinate.getLatitude());
+        payload.putArray("coordinateFromView", array);
+        event.setPayload(payload);
+
+        mManager.handleEvent(event);
+    }
+
     public void takeSnap(final String callbackID, final boolean writeToDisk) {
         final AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -240,9 +240,10 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_QUERY_FEATURES_RECT = 3;
     public static final int METHOD_VISIBLE_BOUNDS = 4;
     public static final int METHOD_GET_POINT_IN_VIEW = 5;
-    public static final int METHOD_TAKE_SNAP = 6;
-    public static final int METHOD_GET_ZOOM = 7;
-    public static final int METHOD_GET_CENTER = 8;
+    public static final int METHOD_GET_COORDINATE_FROM_VIEW = 6;
+    public static final int METHOD_TAKE_SNAP = 7;
+    public static final int METHOD_GET_ZOOM = 8;
+    public static final int METHOD_GET_CENTER = 9;
 
     @Nullable
     @Override
@@ -253,6 +254,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("queryRenderedFeaturesInRect", METHOD_QUERY_FEATURES_RECT)
                 .put("getVisibleBounds", METHOD_VISIBLE_BOUNDS)
                 .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
+                .put("getCoordinateFromView", METHOD_GET_COORDINATE_FROM_VIEW)
                 .put("takeSnap", METHOD_TAKE_SNAP)
                 .put("getZoom", METHOD_GET_ZOOM)
                 .put("getCenter", METHOD_GET_CENTER)
@@ -291,6 +293,9 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 break;
             case METHOD_GET_POINT_IN_VIEW:
                 mapView.getPointInView(args.getString(0), GeoJSONUtils.toLatLng(args.getArray(1)));
+                break;
+            case METHOD_GET_COORDINATE_FROM_VIEW:
+                mapView.getCoordinateFromView(args.getString(0), ConvertUtils.toPointF(args.getArray(1)));
                 break;
             case METHOD_TAKE_SNAP:
                 mapView.takeSnap(args.getString(0), args.getBoolean(1));

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -60,6 +60,22 @@ Converts a geographic coordinate to a point in the given view’s coordinate sys
 const pointInView = await this._map.getPointInView([-37.817070, 144.949901]);
 ```
 
+#### getCoordinateFromView(point)
+
+Converts a point in the given view’s coordinate system to a geographic coordinate.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `point` | `Array` | `Yes` | A point expressed in the given view’s coordinate system. |
+
+
+
+```javascript
+const coordinate = await this._map.getCoordinateFromView([100, 100]);
+```
+
+
 
 #### getVisibleBounds()
 

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -120,6 +120,29 @@ RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(getCoordinateFromView:(nonnull NSNumber*)reactTag
+                  atPoint:(CGPoint)point
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    
+    if (![view isKindOfClass:[RCTMGLMapView class]]) {
+      RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+      return;
+    }
+    
+    RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
+    
+    CLLocationCoordinate2D coordinate = [reactMapView convertPoint:point
+                                            toCoordinateFromView:reactMapView];
+    
+    resolve(@{ @"coordinateFromView": @[@(coordinate.longitude), @(coordinate.latitude)] });
+  }];
+}
+
+
 RCT_EXPORT_METHOD(takeSnap:(nonnull NSNumber*)reactTag
                   writeToDisk:(BOOL)writeToDisk
                   resolver:(RCTPromiseResolveBlock)resolve

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -318,6 +318,20 @@ class MapView extends React.Component {
   }
 
   /**
+   * Converts a point in the given view’s coordinate system to a geographic coordinate.
+   *
+   * @example
+   * const coordinate = await this._map.getCoordinateFromView([100, 100]);
+   *
+   * @param {Array<Number>} point - A point expressed in the given view’s coordinate system.
+   * @return {Array}
+   */
+  async getCoordinateFromView(point) {
+    const res = await this._runNativeCommand('getCoordinateFromView', [point]);
+    return res.coordinateFromView;
+  }
+
+  /**
    * The coordinate bounds(ne, sw) visible in the users’s viewport.
    *
    * @example


### PR DESCRIPTION
Adds the `getCoordinateFromView(point)` method to the mapview, which returns a coordinate from a point in the map view.

Addresses https://github.com/mapbox/react-native-mapbox-gl/issues/1014