### PR TITLE
remove check for nil filter

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -161,9 +161,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         mFilter = buildFilter(filterList);
 
         if (mLayer != null) {
-            if (mFilter != null) {
-                updateFilter(mFilter);
-            }
+            updateFilter(mFilter);
         }
     }
 

--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -79,9 +79,7 @@
     if (_styleLayer != nil) {
         NSPredicate *predicate = [self buildFilters];
         
-        if (predicate != nil) {
-            [self updateFilter:predicate];
-        }
+        [self updateFilter:predicate];
     }
 }
 


### PR DESCRIPTION
Related to #1160 

This fixes the problem in iOS for me. However, Android is throwing this error:
![image](https://user-images.githubusercontent.com/1326248/38443273-680661f0-39a8-11e8-9dda-f195942ea696.png)

I'm not experienced with Java but did a bit of digging. Couldn't find out where the issue was. I almost think that it's upstream in the mapbox sdk or something.