### PR TITLE
Bump to 6.1.1

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@mapbox/geo-viewport": "^0.2.2",
-    "@mapbox/react-native-mapbox-gl": "file:../mapbox-react-native-mapbox-gl-6.1.0.tgz",
+    "@mapbox/react-native-mapbox-gl": "file:../mapbox-react-native-mapbox-gl-6.1.1.tgz",
     "@turf/along": "^4.7.3",
     "@turf/bearing": "^5.0.0",
     "@turf/distance": "^5.0.0",
@@ -22,6 +22,7 @@
     "@turf/nearest": "^4.7.3",
     "install": "^0.10.1",
     "mapbox": "^1.0.0-beta9",
+    "moment": "^2.22.0",
     "npm": "^5.3.0",
     "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/react-native-mapbox-gl",
   "description": "A Mapbox GL react native module for creating custom maps",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "Bobby Sudekum",
   "main": "./javascript/index.js",
   "keywords": [


### PR DESCRIPTION
## Bugfixes
* [iOS] Better `Mapbox.framework` detection and also fixes issues with `yarn add` and `yarn remove` https://github.com/mapbox/react-native-mapbox-gl/pull/1151
* [All] Fixes user defined hitbox on `VectorSource` and `ShapeSource` not being respected https://github.com/mapbox/react-native-mapbox-gl/issues/1142

## Features
* [ALL] Adds support for resolving style values for users so instead of `MapboxGL.LineJoin.Round` users can just specify `round` https://github.com/mapbox/react-native-mapbox-gl/pull/1119
* [Android] Fixes onWillStartLoadingMap not being called https://github.com/mapbox/react-native-mapbox-gl/pull/1105
* [Android] First set of fixes to help add support for `onRegionWillChange` to behave more like iOS, there still needs more work to be done, but the event at least fires sometimes correctly now https://github.com/mapbox/react-native-mapbox-gl/pull/1132
* [All] Exposes `setTelemetryEnabled` and `isTelemetryEnabled` https://github.com/mapbox/react-native-mapbox-gl/pull/1096
* [All] Adds support for locale map labeling https://github.com/mapbox/react-native-mapbox-gl/pull/1038
* [JS] Formatted whole JS codebase https://github.com/mapbox/react-native-mapbox-gl/pull/1118
* [JS] Added support for `prettier`, `lint-staged`, and `husky` https://github.com/mapbox/react-native-mapbox-gl/issues/931
* [README] Add developer group to README https://github.com/mapbox/react-native-mapbox-gl/pull/1101

## Breaking Changes
None