### PR TITLE
Fixed iOS memory leak discussed in #807

### DIFF
--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -37,7 +37,7 @@ static double const M2PI = M_PI * 2;
         return;
     }
     for (int i = 0; i < _reactSubviews.count; i++) {
-        [self removeReactSubview:(UIView *)_reactSubviews[i]];
+        [self removeFromMap:_reactSubviews[i]];
     }
 }
 


### PR DESCRIPTION
There're two issues in the original implementation:

1. In `- [RCTMGLMapView invalidate]`, it mutates the Array `_reactSubviews` during iteration, so not every element in `_reactSubviews` can be handled by `[RCTMGMapView removeReactSubview:]`.<br/> And the leaked `RCTMGLSource` instances strongly reference `RCTMGLMapView`, which causes the retain cycle never get released.
2. By calling `[self removeReactSubviews:(UIView *)_reactSubviews[i]];` in `- [RCTMGLMapView invalidate]`, `_reactSubviews` get changed. But [React Native depends on this](https://github.com/facebook/react-native/blob/bfcfe7961db0970e2575eafe2f3c9c668bd8940d/React/Modules/RCTUIManager.m#L436) to traversely clean `_viewRegistry` in `RCTUIManager`.

We just need to clean internal state in `- [RCTMGLMapView invalidate];`, leaving the `_reactSubviews` to be handled by `RCTUIManager`.