### PR TITLE
[Android] Prevent onLayout from being called while app is in paused state

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -527,6 +527,13 @@ public class RCTMGLMapView extends MapView implements
     }
 
     @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        if (!mPaused) {
+            super.onLayout(changed, left, top, right, bottom);
+        }
+    }
+
+    @Override
     public void onMapClick(@NonNull LatLng point) {
         boolean isEventCaptured = false;
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/1106

This will prevent us from trying to update the MapView in a paused state with a negative width and height