### PR TITLE
[fix] fix pointannotation flying to left top when it's layout changes

### DIFF
--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -52,6 +52,9 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
     [super reactSetFrame:frame];
 
     if (isMapSetBeforeFrame) {
+        if ([self _isFrameSet]) {
+            [_map removeAnnotation:self];
+        }
         [self _addAnnotation];
     }
 }

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -15,7 +15,6 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 
 @implementation RCTMGLPointAnnotation
 {
-    BOOL isMapSetBeforeFrame;
     UITapGestureRecognizer *customViewTap;
 }
 
@@ -48,15 +47,12 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 
 - (void)reactSetFrame:(CGRect)frame
 {
-    if ([self _isFrameSet]) {
+    if ([_map.annotations containsObject:self]) {
         [_map removeAnnotation:self];
     }
-    [self _setCenterOffset:frame];
     [super reactSetFrame:frame];
-
-    if (isMapSetBeforeFrame) {
-        [self _addAnnotation];
-    }
+    [self _setCenterOffset:frame];
+    [self _addAnnotation];
 }
 
 - (void)setAnchor:(NSDictionary<NSString *, NSNumber *> *)anchor
@@ -76,7 +72,6 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
         // prevents annotations from flying in from the top left corner
         // if the frame hasn't been set yet
         if (![self _isFrameSet]) {
-            isMapSetBeforeFrame = YES;
             return;
         }
 

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -48,13 +48,13 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 
 - (void)reactSetFrame:(CGRect)frame
 {
+    if ([self _isFrameSet]) {
+        [_map removeAnnotation:self];
+    }
     [self _setCenterOffset:frame];
     [super reactSetFrame:frame];
 
     if (isMapSetBeforeFrame) {
-        if ([self _isFrameSet]) {
-            [_map removeAnnotation:self];
-        }
         [self _addAnnotation];
     }
 }

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -49,7 +49,9 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 - (void)reactSetFrame:(CGRect)frame
 {
     [self _setCenterOffset:frame];
-    [super reactSetFrame:frame];
+    if (![self _isFrameSet]) {
+        [super reactSetFrame:frame];
+    }
 
     if (isMapSetBeforeFrame) {
         [self _addAnnotation];

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -49,9 +49,7 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 - (void)reactSetFrame:(CGRect)frame
 {
     [self _setCenterOffset:frame];
-    if (![self _isFrameSet]) {
-        [super reactSetFrame:frame];
-    }
+    [super reactSetFrame:frame];
 
     if (isMapSetBeforeFrame) {
         [self _addAnnotation];


### PR DESCRIPTION
if children of annotation have unknown size, when the content inside changes, reactSetFrame is called, then it will fly to the left top.  

I have an example.
![image](https://lh3.googleusercontent.com/UlSh54ENac2RZKMlzqr13ThGB_VzmTe2A2WXZmgq5TeNquxj8NXRQ800eWUy7K8JxcKk-ur6Ef_T2ihX9Y2x=w2880-h1300-rw)   
by the way, when will annotation view be implemented?  : )