### PR TITLE
[fix] Fix isUserInteraction for onRegionWillChange

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -477,7 +477,7 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 - (void)mapView:(MGLMapView *)mapView regionWillChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
 {
-    ((RCTMGLMapView *) mapView).isUserInteraction = (bool)(reason & ~MGLCameraChangeReasonProgrammatic);
+    ((RCTMGLMapView *) mapView).isUserInteraction = (BOOL)(reason & ~MGLCameraChangeReasonProgrammatic);
     
     NSDictionary *payload = [self _makeRegionPayload:mapView animated:animated];
     [self reactMapDidChange:mapView eventType:RCT_MAPBOX_REGION_WILL_CHANGE_EVENT andPayload:payload];
@@ -490,7 +490,7 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 - (void)mapView:(MGLMapView *)mapView regionDidChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
 {
-    ((RCTMGLMapView *) mapView).isUserInteraction = (bool)(reason & ~MGLCameraChangeReasonProgrammatic);
+    ((RCTMGLMapView *) mapView).isUserInteraction = (BOOL)(reason & ~MGLCameraChangeReasonProgrammatic);
     
     NSDictionary *payload = [self _makeRegionPayload:mapView animated:animated];
     [self reactMapDidChange:mapView eventType:RCT_MAPBOX_REGION_DID_CHANGE andPayload:payload];

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -477,7 +477,7 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 - (void)mapView:(MGLMapView *)mapView regionWillChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
 {
-    ((RCTMGLMapView *) mapView).isUserInteraction = !(reason & MGLCameraChangeReasonProgrammatic);
+    ((RCTMGLMapView *) mapView).isUserInteraction = (bool)(reason & ~MGLCameraChangeReasonProgrammatic);
     
     NSDictionary *payload = [self _makeRegionPayload:mapView animated:animated];
     [self reactMapDidChange:mapView eventType:RCT_MAPBOX_REGION_WILL_CHANGE_EVENT andPayload:payload];
@@ -490,7 +490,7 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
 
 - (void)mapView:(MGLMapView *)mapView regionDidChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
 {
-    ((RCTMGLMapView *) mapView).isUserInteraction = !(reason & MGLCameraChangeReasonProgrammatic);
+    ((RCTMGLMapView *) mapView).isUserInteraction = (bool)(reason & ~MGLCameraChangeReasonProgrammatic);
     
     NSDictionary *payload = [self _makeRegionPayload:mapView animated:animated];
     [self reactMapDidChange:mapView eventType:RCT_MAPBOX_REGION_DID_CHANGE andPayload:payload];

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -424,14 +424,6 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
     [self fireEvent:event withCallback:reactMapView.onUserTrackingModeChange];
 }
 
-/*- (BOOL)mapView:(MGLMapView *)mapView shouldChangeFromCamera:(MGLMapCamera *)oldCamera toCamera:(MGLMapCamera *)newCamera
-{
-    RCTMGLMapView *reactMapView = (RCTMGLMapView *)mapView;
-    reactMapView.isUserInteraction = YES;
-    return YES;
-}
- */
-
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
 {
     if ([annotation isKindOfClass:[RCTMGLPointAnnotation class]]) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/mapbox/react-native-mapbox-gl"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.0",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.8",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",


### PR DESCRIPTION
This fixes https://github.com/mapbox/react-native-mapbox-gl/issues/980

`regionWillChangeAnimated` was getting called before `shouldChangeFromCamera`, so the `isUserInteraction` was always false.

This looks at the `MGLCameraChangeReason` bitmask with the updated Mapbox.framework library to make sure the reason bitmask includes any non-programmatic one (like a gesture or panning).