### PR TITLE
Consistent SymbolLayer icon scale across packager vs. static bundle

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
@@ -1,11 +1,8 @@
 package com.mapbox.rctmgl.utils;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
-import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -39,8 +36,6 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, String>, V
     @SafeVarargs
     @Override
     protected final List<Map.Entry<String, Bitmap>> doInBackground(Map.Entry<String, String>... objects) {
-        Resources resources = mContext.getResources();
-        DisplayMetrics metrics = resources.getDisplayMetrics();
         List<Map.Entry<String, Bitmap>> images = new ArrayList<>();
 
         for (Map.Entry<String, String> object : objects) {
@@ -48,14 +43,14 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, String>, V
 
             if (uri.contains("://")) { // has scheme attempt to get bitmap from url
                 try {
-                    Bitmap bitmap = BitmapUtils.getBitmapFromURL(uri, getBitmapOptions(metrics));
+                    Bitmap bitmap = BitmapUtils.getBitmapFromURL(uri, null);
                     images.add(new AbstractMap.SimpleEntry<String, Bitmap>(object.getKey(), bitmap));
                 } catch (Exception e) {
                     Log.w(LOG_TAG, e.getLocalizedMessage());
                 }
             } else {
                 // local asset required from JS require('image.png') or import icon from 'image.png' while in release mode
-                Bitmap bitmap = BitmapUtils.getBitmapFromResource(mContext, uri, getBitmapOptions(metrics));
+                Bitmap bitmap = BitmapUtils.getBitmapFromResource(mContext, uri, null);
                 images.add(new AbstractMap.SimpleEntry<String, Bitmap>(object.getKey(), bitmap));
             }
         }
@@ -76,13 +71,5 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, String>, V
         if (mCallback != null) {
             mCallback.onAllImagesLoaded();
         }
-    }
-
-    private BitmapFactory.Options getBitmapOptions(DisplayMetrics metrics) {
-        BitmapFactory.Options options = new BitmapFactory.Options();
-        options.inScreenDensity = metrics.densityDpi;
-        options.inTargetDensity = metrics.densityDpi;
-        options.inDensity = DisplayMetrics.DENSITY_DEFAULT;
-        return options;
     }
 }

--- a/ios/RCTMGL/RCTMGLImageQueueOperation.m
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.m
@@ -21,7 +21,14 @@
     
     __weak RCTMGLImageQueueOperation *weakSelf = self;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        cancellationBlock = [weakSelf.bridge.imageLoader loadImageWithURLRequest:weakSelf.urlRequest callback:weakSelf.completionHandler];
+        cancellationBlock = [weakSelf.bridge.imageLoader loadImageWithURLRequest:weakSelf.urlRequest
+                                                                            size:CGSizeZero
+                                                                           scale:UIScreen.mainScreen.scale
+                                                                         clipped:YES
+                                                                      resizeMode:RCTResizeModeStretch
+                                                                   progressBlock:nil
+                                                                partialLoadBlock:nil
+                                                                 completionBlock:weakSelf.completionHandler];
     });
 }
 


### PR DESCRIPTION
Fixes #1203
- Consistent icon size across packager vs. static bundles when using static image resource with multiple densities
- Loads and renders icons at the original scale on both platforms 
