### PR TITLE
Added showAttribution method to MapView

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1042,6 +1042,11 @@ public class RCTMGLMapView extends MapView implements
         mManager.handleEvent(event);
     }
 
+    public void showAttribution() {
+        View attributionView = findViewById(com.mapbox.mapboxsdk.R.id.attributionView);
+        attributionView.callOnClick();
+    }
+
     public void init() {
         setStyleUrl(mStyleURL);
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -254,6 +254,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_GET_ZOOM = 8;
     public static final int METHOD_GET_CENTER = 9;
     public static final int METHOD_SET_HANDLED_MAP_EVENTS = 10;
+    public static final int METHOD_SHOW_ATTRIBUTION = 11;
 
     @Nullable
     @Override
@@ -269,6 +270,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("getZoom", METHOD_GET_ZOOM)
                 .put("getCenter", METHOD_GET_CENTER)
                 .put( "setHandledMapChangedEvents", METHOD_SET_HANDLED_MAP_EVENTS)
+                .put("showAttribution", METHOD_SHOW_ATTRIBUTION)
                 .build();
     }
 
@@ -325,6 +327,9 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                     }
                     mapView.setHandledMapChangedEvents(eventsArray);
                 }
+                break;
+            case METHOD_SHOW_ATTRIBUTION:
+                mapView.showAttribution();
                 break;
         }
     }

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -277,4 +277,14 @@ const center = await this._map.getCenter();
 ```
 
 
+#### showAttribution()
+
+Show the attribution and telemetry action sheet.<br/>If you implement a custom attribution button, you should add this action to the button.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1720,6 +1720,15 @@
         "examples": [
           "\nconst center = await this._map.getCenter();\n\n"
         ]
+      },
+      {
+        "name": "showAttribution",
+        "docblock": "Show the attribution and telemetry action sheet.\nIf you implement a custom attribution button, you should add this action to the button.",
+        "modifiers": [],
+        "params": [],
+        "returns": null,
+        "description": "Show the attribution and telemetry action sheet.\nIf you implement a custom attribution button, you should add this action to the button.",
+        "examples": []
       }
     ],
     "props": [

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -323,6 +323,24 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber*)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        
+        if (![view isKindOfClass:[RCTMGLMapView class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+        
+        __weak RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
+        [reactMapView showAttribution:reactMapView];
+        resolve(nil);
+    }];
+}
+
 #pragma mark - UIGestureRecognizers
 
 - (void)didTapMap:(UITapGestureRecognizer *)recognizer

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -640,6 +640,14 @@ class MapView extends React.Component {
     return res.center;
   }
 
+  /**
+   * Show the attribution and telemetry action sheet.
+   * If you implement a custom attribution button, you should add this action to the button.
+   */
+  showAttribution() {
+    return this._runNativeCommand('showAttribution');
+  }
+
   _runNativeCommand(methodName, args = []) {
     if (!this._nativeRef) {
       return new Promise(resolve => {


### PR DESCRIPTION
Shows the attribution and telemetry action sheet / dialog via `MapboxGL.MapView.showAttribution()`. If the users implements a custom attribution button, they can use this method to display the built-in attribution dialog / sheet.

It provides a similar API that is already available on the iOS platform:
https://www.mapbox.com/ios-sdk/api/4.0.2/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(im)showAttribution:

And on Android via: 
https://www.mapbox.com/android-docs/api/map-sdk/6.1.3/com/mapbox/mapboxsdk/maps/AttributionDialogManager.html
> Note that the `AttributionDialogManager` only became a public API recently. Therefore I used `com.mapbox.mapboxsdk.R.id.attributionView` for now to provide the same functionality with the current 5.x release.