### PR TITLE
Make the MapView Native class extendable on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -34,7 +34,11 @@ import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.VisibleRegion;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapView.OnMapChangedListener;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.MapboxMap.OnMapClickListener;
+import com.mapbox.mapboxsdk.maps.MapboxMap.OnMapLongClickListener;
+import com.mapbox.mapboxsdk.maps.MapboxMap.OnMarkerViewClickListener;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
@@ -63,6 +67,7 @@ import com.mapbox.rctmgl.events.MapUserTrackingModeEvent;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
 import com.mapbox.rctmgl.location.LocationManager;
+import com.mapbox.rctmgl.location.LocationManager.OnUserLocationChange;
 import com.mapbox.rctmgl.location.UserLocation;
 import com.mapbox.rctmgl.location.UserLocationLayerConstants;
 import com.mapbox.rctmgl.location.UserLocationVerticalAlignment;
@@ -92,13 +97,13 @@ import javax.annotation.Nullable;
 
 @SuppressWarnings({"MissingPermission"})
 public class RCTMGLMapView extends MapView implements
-        OnMapReadyCallback, MapboxMap.OnMapClickListener, MapboxMap.OnMapLongClickListener,
-        MapView.OnMapChangedListener, MapboxMap.OnMarkerViewClickListener {
+        OnMapReadyCallback, OnMapClickListener, OnMapLongClickListener,
+        OnMapChangedListener, OnMarkerViewClickListener, OnUserLocationChange {
     public static final String LOG_TAG = RCTMGLMapView.class.getSimpleName();
 
     public static final int USER_LOCATION_CAMERA_MOVE_DURATION = 1000;
 
-    private RCTMGLMapViewManager mManager;
+    protected RCTMGLMapViewManager mManager;
     private Context mContext;
     private Handler mHandler;
     private LifecycleEventListener mLifeCycleListener;
@@ -114,9 +119,9 @@ public class RCTMGLMapView extends MapView implements
     private CameraChangeTracker mCameraChangeTracker = new CameraChangeTracker();
     private Map<Integer, ReadableArray> mPreRenderMethodMap = new HashMap<>();
 
-    private MapboxMap mMap;
-    private LocationManager mLocationManger;
-    private UserLocation mUserLocation;
+    protected MapboxMap mMap;
+    protected LocationManager mLocationManger;
+    protected UserLocation mUserLocation;
 
     private LocationLayerPlugin mLocationLayer;
     private LocalizationPlugin mLocalizationPlugin;
@@ -151,24 +156,6 @@ public class RCTMGLMapView extends MapView implements
 
     private int mChangeDelimiterSuppressionDepth;
 
-    private LocationManager.OnUserLocationChange mLocationChangeListener = new LocationManager.OnUserLocationChange() {
-        @Override
-        public void onLocationChange(Location nextLocation) {
-            if (mMap == null || mLocationLayer == null || !mShowUserLocation) {
-                return;
-            }
-
-            float distToNextLocation = mUserLocation.getDistance(nextLocation);
-            mLocationLayer.onLocationChanged(nextLocation);
-            mUserLocation.setCurrentLocation(nextLocation);
-
-            if (mUserTrackingState == UserTrackingState.POSSIBLE || distToNextLocation > 0.0f) {
-                updateUserLocation(true);
-            }
-            sendUserLocationUpdateEvent(nextLocation);
-        }
-    };
-
     public RCTMGLMapView(Context context, RCTMGLMapViewManager manager, MapboxMapOptions options) {
         super(context, options);
 
@@ -184,7 +171,7 @@ public class RCTMGLMapView extends MapView implements
 
         mUserLocation = new UserLocation();
         mLocationManger = new LocationManager(context);
-        mLocationManger.setOnLocationChangeListener(mLocationChangeListener);
+        mLocationManger.setOnLocationChangeListener(this);
 
         mSources = new HashMap<>();
         mPointAnnotations = new HashMap<>();
@@ -196,6 +183,23 @@ public class RCTMGLMapView extends MapView implements
         setLifecycleListeners();
 
         addOnMapChangedListener(this);
+    }
+
+
+    @Override
+    public void onLocationChange(Location nextLocation) {
+        if (mMap == null || mLocationLayer == null || !mShowUserLocation) {
+            return;
+        }
+
+        float distToNextLocation = mUserLocation.getDistance(nextLocation);
+        mLocationLayer.onLocationChanged(nextLocation);
+        mUserLocation.setCurrentLocation(nextLocation);
+
+        if (mUserTrackingState == UserTrackingState.POSSIBLE || distToNextLocation > 0.0f) {
+            updateUserLocation(true);
+        }
+        sendUserLocationUpdateEvent(nextLocation);
     }
 
     @Override
@@ -421,6 +425,11 @@ public class RCTMGLMapView extends MapView implements
                 long curTimestamp = System.currentTimeMillis();
                 boolean curAnimated = mCameraChangeTracker.isAnimated();
                 if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
+                      // even if we don't send the change event, we need to set the reason...
+                    //this happens when you have multiple calls to setCamera very quickly. This method will short circuit,
+                    //and then the next time the user moves the map, it will think it is NOT from a user interaction , because
+                    // this flag was not reset
+                    mCameraChangeTracker.setReason(-1);
                     return;
                 }
 
@@ -1205,7 +1214,7 @@ public class RCTMGLMapView extends MapView implements
 
         Location lastKnownLocation = mLocationManger.getLastKnownLocation();
         if (lastKnownLocation != null) {
-            mLocationChangeListener.onLocationChange(lastKnownLocation);
+            onLocationChange(lastKnownLocation);
 
             postDelayed(new Runnable() {
                 @Override
@@ -1216,7 +1225,7 @@ public class RCTMGLMapView extends MapView implements
         }
     }
 
-    private void updateLocationLayer() {
+    protected void updateLocationLayer() {
         if (mLocationLayer == null) {
             mLocationLayer = new LocationLayerPlugin(this, mMap, mLocationManger.getEngine());
         }
@@ -1444,7 +1453,7 @@ public class RCTMGLMapView extends MapView implements
         mCameraChangeTracker.setReason(-1);
     }
 
-    private void sendUserLocationUpdateEvent(Location location) {
+    protected void sendUserLocationUpdateEvent(Location location) {
         if(location == null){
             return;
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -8,6 +8,7 @@ import android.view.View;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.MapBuilder.Builder;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -245,20 +246,27 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_GET_ZOOM = 8;
     public static final int METHOD_GET_CENTER = 9;
 
+    /**
+     * make this overridable for subclasses to add their own methods
+     */
+    protected Builder<String, Integer> getMapBuilder(){
+        return MapBuilder.<String, Integer>builder()
+            .put("setCamera", METHOD_SET_CAMERA)
+            .put("queryRenderedFeaturesAtPoint", METHOD_QUERY_FEATURES_POINT)
+            .put("queryRenderedFeaturesInRect", METHOD_QUERY_FEATURES_RECT)
+            .put("getVisibleBounds", METHOD_VISIBLE_BOUNDS)
+            .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
+            .put("getCoordinateFromView", METHOD_GET_COORDINATE_FROM_VIEW)
+            .put("takeSnap", METHOD_TAKE_SNAP)
+            .put("getZoom", METHOD_GET_ZOOM)
+            .put("getCenter", METHOD_GET_CENTER);
+
+    }
+
     @Nullable
     @Override
     public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.<String, Integer>builder()
-                .put("setCamera", METHOD_SET_CAMERA)
-                .put("queryRenderedFeaturesAtPoint", METHOD_QUERY_FEATURES_POINT)
-                .put("queryRenderedFeaturesInRect", METHOD_QUERY_FEATURES_RECT)
-                .put("getVisibleBounds", METHOD_VISIBLE_BOUNDS)
-                .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
-                .put("getCoordinateFromView", METHOD_GET_COORDINATE_FROM_VIEW)
-                .put("takeSnap", METHOD_TAKE_SNAP)
-                .put("getZoom", METHOD_GET_ZOOM)
-                .put("getCenter", METHOD_GET_CENTER)
-                .build();
+        return getMapBuilder().build();
     }
 
     @Override

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -607,7 +607,16 @@ class MapView extends React.Component {
     return res.center;
   }
 
+
+  /**
+   * Make this class extensible. This will allow subclasses to point to their own native map class (extending from the existing RCTMGLMapView in native)
+   */
+  _getNativeModuleName() {
+    return NATIVE_MODULE_NAME;
+  }
+
   _runNativeCommand(methodName, args = []) {
+    const nativeModuleName = this._getNativeModuleName();
     if (!this._nativeRef) {
       return new Promise((resolve) => {
         this._preRefMapMethodQueue.push({
@@ -622,11 +631,11 @@ class MapView extends React.Component {
         const callbackID = '' + Date.now();
         this._addAddAndroidCallback(callbackID, resolve);
         args.unshift(callbackID);
-        runNativeCommand(NATIVE_MODULE_NAME, methodName, this._nativeRef, args);
+        runNativeCommand(nativeModuleName, methodName, this._nativeRef, args);
       });
     }
     return runNativeCommand(
-      NATIVE_MODULE_NAME,
+      nativeModuleName,
       methodName,
       this._nativeRef,
       args,


### PR DESCRIPTION
We want to make some core changes to how MapView instance, and would like to create a subclass of RCTMGLMapView.java. We made these changes on our fork and it works great!

The gist of these changes is making a few private members/methods protected so the child class can interact with them. 

The main motivating factor for these changes was to make the location engine stay active regardless whether `showUserLocation` was enabled or not. 