### PR TITLE
Added support for initial visibleCoordinateBounds

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -9,12 +9,14 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.rctmgl.components.AbstractEventEmitter;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.utils.ConvertUtils;
 import com.mapbox.rctmgl.utils.FilterParser;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
+import com.mapbox.services.commons.geojson.FeatureCollection;
 import com.mapbox.services.commons.geojson.Point;
 
 import java.util.ArrayList;
@@ -195,6 +197,15 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         Point centerCoordinate = GeoJSONUtils.toPointGeometry(featureJSONStr);
         if (centerCoordinate != null) {
             mapView.setReactCenterCoordinate(centerCoordinate);
+        }
+    }
+
+    @ReactProp(name="visibleCoordinateBounds")
+    public void setVisibleCoordinateBounds(RCTMGLMapView mapView, String featureJSONStr) {
+        FeatureCollection collection = FeatureCollection.fromJson(featureJSONStr);
+        LatLngBounds bounds = GeoJSONUtils.toLatLngBounds(collection);
+        if (bounds != null) {
+            mapView.setReactVisibleCoordinateBounds(bounds);
         }
     }
 

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -6,7 +6,6 @@
 | ---- | :--: | :-----: | :------: | :----------: |
 | animated | `bool` | `false` | `false` | Animates changes between pitch and bearing |
 | centerCoordinate | `arrayOf` | `none` | `false` | Initial center coordinate on map [lng, lat] |
-| visibleCoordinateBounds | `arrayOf` | `none` | `false` | Initial coordinate bounds on map [[lng, lat], [lng, lat]] |
 | showUserLocation | `bool` | `none` | `false` | Shows the users location on the map |
 | userTrackingMode | `number` | `MapboxGL.UserTrackingModes.None` | `false` | The mode used to track the user location on the map |
 | userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |
@@ -61,22 +60,6 @@ Converts a geographic coordinate to a point in the given view’s coordinate sys
 const pointInView = await this._map.getPointInView([-37.817070, 144.949901]);
 ```
 
-#### getCoordinateFromView(point)
-
-Converts a point in the given view’s coordinate system to a geographic coordinate.
-
-##### arguments
-| Name | Type | Required | Description  |
-| ---- | :--: | :------: | :----------: |
-| `point` | `Array` | `Yes` | A point expressed in the given view’s coordinate system. |
-
-
-
-```javascript
-const coordinate = await this._map.getCoordinateFromView([100, 100]);
-```
-
-
 
 #### getVisibleBounds()
 
@@ -108,7 +91,7 @@ Returns an array of rendered map features that intersect with a given point.
 
 
 ```javascript
-const features = await this._map.queryRenderedFeaturesAtPoint([30, 40], ['==', 'type', 'Point'], ['id1', 'id2'])
+this._map.queryRenderedFeaturesAtPoint([30, 40], ['==', 'type', 'Point'], ['id1', 'id2'])
 ```
 
 
@@ -126,7 +109,7 @@ Returns an array of rendered map features that intersect with the given rectangl
 
 
 ```javascript
-const features = await this._map.queryRenderedFeaturesInRect([30, 40, 20, 10], ['==', 'type', 'Point'], ['id1', 'id2'])
+this._map.queryRenderedFeaturesInRect([30, 40, 20, 10], ['==', 'type', 'Point'], ['id1', 'id2'])
 ```
 
 

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -6,6 +6,7 @@
 | ---- | :--: | :-----: | :------: | :----------: |
 | animated | `bool` | `false` | `false` | Animates changes between pitch and bearing |
 | centerCoordinate | `arrayOf` | `none` | `false` | Initial center coordinate on map [lng, lat] |
+| visibleCoordinateBounds | `arrayOf` | `none` | `false` | Initial coordinate bounds on map [[lng, lat], [lng, lat]] |
 | showUserLocation | `bool` | `none` | `false` | Shows the users location on the map |
 | userTrackingMode | `number` | `MapboxGL.UserTrackingModes.None` | `false` | The mode used to track the user location on the map |
 | userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -106,7 +106,7 @@ Sets the value at which download status events will be sent over the React Nativ
 
 
 ```javascript
-MapboxGL.offlineManager.setProgressEventThrottle(500);
+MapboxGL.setProgressEventThrottle(500);
 ```
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1346,6 +1346,18 @@
     "description": "MapView backed by Mapbox Native GL",
     "methods": [
       {
+        "name": "setHandledMapChangedEvents",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "props",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
         "name": "getPointInView",
         "docblock": "Converts a geographic coordinate to a point in the given view’s coordinate system.\n\n@example\nconst pointInView = await this._map.getPointInView([-37.817070, 144.949901]);\n\n@param {Array<Number>} coordinate - A point expressed in the map view's coordinate system.\n@return {Array}",
         "modifiers": [
@@ -1369,6 +1381,32 @@
         "description": "Converts a geographic coordinate to a point in the given view’s coordinate system.",
         "examples": [
           "\nconst pointInView = await this._map.getPointInView([-37.817070, 144.949901]);\n\n"
+        ]
+      },
+      {
+        "name": "getCoordinateFromView",
+        "docblock": "Converts a point in the given view’s coordinate system to a geographic coordinate.\n\n@example\nconst coordinate = await this._map.getCoordinateFromView([100, 100]);\n\n@param {Array<Number>} point - A point expressed in the given view’s coordinate system.\n@return {Array}",
+        "modifiers": [
+          "async"
+        ],
+        "params": [
+          {
+            "name": "point",
+            "description": "A point expressed in the given view’s coordinate system.",
+            "type": {
+              "name": "Array"
+            }
+          }
+        ],
+        "returns": {
+          "description": null,
+          "type": {
+            "name": "Array"
+          }
+        },
+        "description": "Converts a point in the given view’s coordinate system to a geographic coordinate.",
+        "examples": [
+          "\nconst coordinate = await this._map.getCoordinateFromView([100, 100]);\n\n"
         ]
       },
       {
@@ -1712,6 +1750,13 @@
         "description": "Initial center coordinate on map [lng, lat]"
       },
       {
+        "name": "visibleCoordinateBounds",
+        "required": false,
+        "type": "arrayOf",
+        "default": "none",
+        "description": "Initial bounds on map [[lng, lat], [lng, lat]]"
+      },
+      {
         "name": "showUserLocation",
         "required": false,
         "type": "bool",
@@ -1969,6 +2014,20 @@
         "type": "func",
         "default": "none",
         "description": "This event is triggered when the users tracking mode is changed."
+      },
+      {
+        "name": "regionWillChangeDebounceTime",
+        "required": false,
+        "type": "number",
+        "default": "10",
+        "description": "The emitted frequency of regionwillchange events"
+      },
+      {
+        "name": "regionDidChangeDebounceTime",
+        "required": false,
+        "type": "number",
+        "default": "500",
+        "description": "The emitted frequency of regiondidchange events"
       }
     ],
     "composes": [
@@ -2019,7 +2078,7 @@
         "name": "anchor",
         "required": false,
         "type": "shape",
-        "default": "{ x: 0.5, y: 0.5 }",
+        "default": "{x: 0.5, y: 0.5}",
         "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
       },
       {

--- a/example/src/components/FitBounds.js
+++ b/example/src/components/FitBounds.js
@@ -9,16 +9,15 @@ import TabBarPage from './common/TabBarPage';
 class FitBounds extends React.Component {
   static propTypes = {...BaseExamplePropTypes};
 
+  houseBounds = [[-74.135379, 40.795909], [-74.135449, 40.795578]];
+  townBounds = [[-74.12641, 40.797968], [-74.143727, 40.772177]];
+
   constructor(props) {
     super(props);
 
-    const houseBounds = [[-74.135379, 40.795909], [-74.135449, 40.795578]];
-
-    const townBounds = [[-74.12641, 40.797968], [-74.143727, 40.772177]];
-
     this._bounds = [
-      {label: 'Fit House', data: houseBounds},
-      {label: 'Fit Town', data: townBounds},
+      {label: 'Fit House', data: this.houseBounds},
+      {label: 'Fit Town', data: this.townBounds},
     ];
 
     this.onFitBounds = this.onFitBounds.bind(this);
@@ -37,9 +36,9 @@ class FitBounds extends React.Component {
       >
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
-          zoomLevel={18}
+          contentInset={10}
+          visibleCoordinateBounds={this.houseBounds}
           maxZoomLevel={19}
-          centerCoordinate={[-74.135426, 40.795765]}
           styleURL={MapboxGL.StyleURL.Satellite}
           style={sheet.matchParent}
         />

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -37,6 +37,7 @@
 @property (nonatomic, assign) BOOL reactZoomEnabled;
 
 @property (nonatomic, copy) NSString *reactCenterCoordinate;
+@property (nonatomic, copy) NSString *reactVisibleCoordinateBounds;
 @property (nonatomic, copy) NSString *reactStyleURL;
 
 @property (nonatomic, assign) BOOL isUserInteraction;

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -80,6 +80,7 @@ RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)
 RCT_REMAP_VIEW_PROPERTY(centerCoordinate, reactCenterCoordinate, NSString)
+RCT_REMAP_VIEW_PROPERTY(visibleCoordinateBounds, reactVisibleCoordinateBounds, NSString)
 RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 
 RCT_REMAP_VIEW_PROPERTY(userTrackingMode, reactUserTrackingMode, int)

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -47,6 +47,11 @@ class MapView extends React.Component {
     centerCoordinate: PropTypes.arrayOf(PropTypes.number),
 
     /**
+     * Initial bounds on map [[lng, lat], [lng, lat]]
+     */
+    visibleCoordinateBounds: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+
+    /**
      * Shows the users location on the map
      */
     showUserLocation: PropTypes.bool,
@@ -839,6 +844,18 @@ class MapView extends React.Component {
     return toJSONString(makePoint(this.props.centerCoordinate));
   }
 
+  _getVisibleCoordinateBounds() {
+    if (!this.props.visibleCoordinateBounds) {
+      return;
+    }
+    return toJSONString(
+      makeLatLngBounds(
+        this.props.visibleCoordinateBounds[0],
+        this.props.visibleCoordinateBounds[1],
+      ),
+    );
+  }
+
   _getContentInset() {
     if (!this.props.contentInset) {
       return;
@@ -871,6 +888,7 @@ class MapView extends React.Component {
     const props = {
       ...this.props,
       centerCoordinate: this._getCenterCoordinate(),
+      visibleCoordinateBounds: this._getVisibleCoordinateBounds(),
       contentInset: this._getContentInset(),
       style: styles.matchParent,
     };


### PR DESCRIPTION
I needed a way to set the initial bounds of the map without knowing the center + zoom level.

The only way to do this is via `fitBounds` but I noticed that this is slow because we need to wait for `_nativeRef` to become available via `render() -> ref` (...and some internal overhead).

I thought it would be better / easier to expose a way we can provide the initial bounds via props:

```jsx
<MapboxGL.MapView
  visibleCoordinateBounds={[[lng, lat], [lng, lat]]}
/>
```

Result:
- `fitBounds`: ~3100ms
- `visibleCoordinateBounds`: ~1300ms

_Results may vary obviously :)_ 
&nbsp;
<details>
 <summary>Video</summary>

![fitbounds](https://user-images.githubusercontent.com/706368/41508009-e40bd9b0-723d-11e8-9ceb-da6913de7d44.gif)
</details>
&nbsp;
<details>
  <summary>Example code</summary>

```jsx
import React, { Component } from 'react';
import { View, StyleSheet, Text } from 'react-native';
import MapboxGL from '@mapbox/react-native-mapbox-gl';

const amsterdam = [[5.005031180158994, 52.48911836591171], [4.785304619816316, 52.25099210071684]]

export default class App extends Component {
  constructor(props){
    super(props)
    this.state = {
      renderTimeMap1: '?',
      renderTimeMap2: '?'
    }
  }

  componentDidMount() {
    start = new Date().getTime()
  }

  captureRef = (map) => {
    this.zoomToBounds(map)
  }
  
  async zoomToBounds(map) {
    // Trick to make sure _nativeRef is available
    // This needs fixing!!! fitBounds should be queud via _preRefMapMethodQueue just like getCenter
    // Though for performance it doesn't make much difference (I tested it)
    const _ = await map.getCenter()
    map.fitBounds(amsterdam[0], amsterdam[1], 0, 0)
  }

  handleOnDidFinishRenderingMapFully1 = () => {
    const renderTimeMap1 = new Date().getTime() - start
    this.setState({ renderTimeMap1 })
  }

  handleOnDidFinishRenderingMapFully2 = () => {
    const renderTimeMap2 = new Date().getTime() - start
    this.setState({ renderTimeMap2 })
  }

  render() {
    return (
      <View style={{flex: 1}}>
        <MapboxGL.MapView
          style={{ flex: 1 }}
          ref={this.captureRef}
          onDidFinishRenderingMapFully={this.handleOnDidFinishRenderingMapFully1}
        />
        <MapboxGL.MapView
          style={{ flex: 1 }}
          visibleCoordinateBounds={amsterdam}
          onDidFinishRenderingMapFully={this.handleOnDidFinishRenderingMapFully2}
        />
        <View style={[StyleSheet.absoluteFillObject, {flexDirection: 'column', justifyContent: 'space-around', alignItems: 'center'}]}>
          <Text style={{backgroundColor: '#fff'}}>fitBounds: {this.state.renderTimeMap1}ms</Text>
          <Text style={{backgroundColor: '#fff'}}>visibleCoordinateBounds: {this.state.renderTimeMap2}ms</Text>
        </View>
      </View>
    );
  }
}
```
</details