### PR TITLE
bug fix: isScrollGesturesEnabled

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1093,7 +1093,7 @@ public class RCTMGLMapView extends MapView implements
         // Gesture settings
         UiSettings uiSettings = mMap.getUiSettings();
 
-        if (mScrollEnabled != null && uiSettings.isRotateGesturesEnabled() != mScrollEnabled) {
+        if (mScrollEnabled != null && uiSettings.isScrollGesturesEnabled() != mScrollEnabled) {
             uiSettings.setScrollGesturesEnabled(mScrollEnabled);
         }
 


### PR DESCRIPTION
bug fix: isScrollGesturesEnabled instead of isRotateGesturesEnabled for updating scrollEnabled Map View.
I wrote my opinion [issues 1271](https://github.com/mapbox/react-native-mapbox-gl/issues/1271)