### PR TITLE
Improved handling of map feature / layer removal

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -266,7 +266,12 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public void removeFeature(int childPosition) {
-        AbstractMapFeature feature = mFeatures.get(childPosition);
+        AbstractMapFeature feature;
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            feature = mQueuedFeatures.get(childPosition);
+        } else {
+            feature = mFeatures.get(childPosition);
+        }
 
         if (feature == null) {
             return;
@@ -286,14 +291,28 @@ public class RCTMGLMapView extends MapView implements
         }
 
         feature.removeFromMap(this);
-        mFeatures.remove(feature);
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            mQueuedFeatures.remove(feature);
+        } else {
+            mFeatures.remove(feature);
+        }
     }
 
     public int getFeatureCount() {
-        return mFeatures.size();
+        int totalCount = 0;
+
+        if (mQueuedFeatures != null) {
+            totalCount = mQueuedFeatures.size();
+        }
+
+        totalCount += mFeatures.size();
+        return totalCount;
     }
 
     public AbstractMapFeature getFeatureAt(int i) {
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            return mQueuedFeatures.get(i);
+        }
         return mFeatures.get(i);
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -48,6 +48,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     private Integer mMaxZoom;
     private Integer mBuffer;
     private Double mTolerance;
+    private boolean mRemoved = false;
 
     private List<Map.Entry<String, String>> mImages;
     private List<Map.Entry<String, BitmapDrawable>> mNativeImages;
@@ -59,6 +60,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
 
     @Override
     public void addToMap(final RCTMGLMapView mapView) {
+        mRemoved = false;
         if (!hasNativeImages() && !hasImages()) {
             super.addToMap(mapView);
             return;
@@ -78,6 +80,8 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
             DownloadMapImageTask.OnAllImagesLoaded imagesLoadedCallback = new DownloadMapImageTask.OnAllImagesLoaded() {
                 @Override
                 public void onAllImagesLoaded() {
+                    // don't add the ShapeSource when the it was removed while loading images
+                    if (mRemoved) return;
                     RCTMGLShapeSource.super.addToMap(mapView);
                 }
             };
@@ -93,6 +97,8 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     @Override
     public void removeFromMap(RCTMGLMapView mapView) {
         super.removeFromMap(mapView);
+        mRemoved = true;
+        if (mMap == null) return;
 
         if (hasImages()) {
             for (Map.Entry<String, String> image : mImages) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
@@ -1,7 +1,6 @@
 package com.mapbox.rctmgl.components.styles.sources;
 
 import android.content.Context;
-import android.util.SparseArray;
 import android.view.View;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -142,7 +141,12 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
                 layer.removeFromMap(mMapView);
             }
         }
-        mMap.removeSource(mSource);
+        if (mQueuedLayers != null) {
+            mQueuedLayers.clear();
+        }
+        if (mMap != null && mSource != null) {
+            mMap.removeSource(mSource);
+        }
     }
 
     public void addLayer(View childView, int childPosition) {
@@ -159,13 +163,19 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
     }
 
     public void removeLayer(int childPosition) {
-        if (childPosition >= mLayers.size()) {
-            return;
+        RCTLayer layer;
+        if (mQueuedLayers != null && mQueuedLayers.size() > 0) {
+            layer = mQueuedLayers.get(childPosition);
+        } else {
+            layer = mLayers.get(childPosition);
         }
-        removeLayerFromMap(mLayers.get(childPosition), childPosition);
+        removeLayerFromMap(layer, childPosition);
     }
 
     public RCTLayer getLayerAt(int childPosition) {
+        if (mQueuedLayers != null && mQueuedLayers.size() > 0) {
+            return mQueuedLayers.get(childPosition);
+        }
         return mLayers.get(childPosition);
     }
 
@@ -181,11 +191,14 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
     }
 
     protected void removeLayerFromMap(RCTLayer layer, int childPosition) {
-        if (mMapView == null || layer == null) {
-            return;
+        if (mMapView != null && layer != null) {
+            layer.removeFromMap(mMapView);
         }
-        layer.removeFromMap(mMapView);
-        mLayers.remove(childPosition);
+        if (mQueuedLayers != null && mQueuedLayers.size() > 0) {
+            mQueuedLayers.remove(childPosition);
+        } else {
+            mLayers.remove(childPosition);
+        }
     }
 
     public abstract T makeSource();

--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -113,7 +113,9 @@
 
 - (void)removeFromMap:(MGLStyle *)style
 {
-    [style removeLayer:_styleLayer];
+    if (_styleLayer != nil) {
+        [style removeLayer:_styleLayer];
+    }
 }
 
 - (MGLStyleLayer*)makeLayer:(MGLStyle*)style

--- a/ios/RCTMGL/RCTMGLSource.m
+++ b/ios/RCTMGL/RCTMGLSource.m
@@ -105,7 +105,9 @@ NSString *const DEFAULT_SOURCE_ID = @"composite";
     }
     
     if (![RCTMGLSource isDefaultSource:_id]) {
-        [_map.style removeSource:_source];
+        if (_source != nil) {
+            [_map.style removeSource:_source];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/react-native-mapbox-gl/issues/1273

After reporting the above issue I found that both Android / iOS SDK's had difficulties removing map features and / or source layers when they were not yet added to the map due either async availability of the `MapView` or, in case of the ShapeSource, enqueued layers due to pending images.

In general I could easily reproduce the errors by quickly toggling on/off map feature such as the example snippet provided in the issue mentioned above.

With this change `RCTMGLMapView` takes into account `mQueuedFeatures` when the ViewManager is trying to manipulate the view hierarchy before the MapView (`mMap`) became available which would otherwise throw the error:
> Trying to remove a view index above child count 0 view tag: 7

I also updated `RCTSource` to take into account queued layers. This especially affects `RCTMGLShapeSource` since it awaits for all images to be loaded before layers are being added to the map. Which would otherwise throw the below error.

```javascript
Attempt to invoke virtual method 'com.mapbox.mapboxsdk.style.sources.Source com.mapbox.mapboxsdk.maps.MapboxMap.removeSource(com.mapbox.mapboxsdk.style.sources.Source)' on a null object reference
removeFromMap
    RCTSource.java:145
removeFromMap
    RCTMGLShapeSource.java:95
removeFeature
    RCTMGLMapView.java:288
removeViewAt
    RCTMGLMapViewManager.java:90
removeViewAt
    RCTMGLMapViewManager.java:37
manageChildren
    NativeViewHierarchyManager.java:378
...
```

I notices that a similar error also occurred on iOS so I added another commit to fix those:

```objc
Exception thrown while executing UI block: The style layer (null) cannot be removed from the style. Make sure the style layer was created as a member of a concrete subclass of MGLStyleLayer.

__44-[RCTUIManager flushUIBlocksWithCompletion:]_block_invoke
    RCTUIManager.m:1095
__44-[RCTUIManager flushUIBlocksWithCompletion:]_block_invoke.536
__RCTExecuteOnMainQueue_block_invoke
_dispatch_call_block_and_release
_dispatch_client_callout
_dispatch_main_queue_callback_4CF
__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
__CFRunLoopRun
CFRunLoopRunSpecific
GSEventRunModal
UIApplicationMain
main
start
```
