### PR TITLE
[Android] Region changed events improvements

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1,22 +1,18 @@
 package com.mapbox.rctmgl.components.mapview;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.location.Location;
 import android.os.Handler;
 import android.support.annotation.NonNull;
-import android.text.LoginFilter;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.MotionEvent;
 
-import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -39,9 +35,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.plugins.localization.LocalizationPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
@@ -380,12 +374,14 @@ public class RCTMGLMapView extends MapView implements
             mMap.moveCamera(CameraUpdateFactory.newCameraPosition(buildCamera()), new MapboxMap.CancelableCallback() {
                 @Override
                 public void onCancel() {
-                    sendRegionChangeEvent(false);
+                    sendRegionDidChangeEvent(false);
+                    mCameraChangeTracker.setReason(-1);
                 }
 
                 @Override
                 public void onFinish() {
-                    sendRegionChangeEvent(false);
+                    sendRegionDidChangeEvent(false);
+                    mCameraChangeTracker.setReason(-1);
                 }
             });
         }
@@ -407,39 +403,54 @@ public class RCTMGLMapView extends MapView implements
             markerViewManager.invalidateViewMarkersInVisibleRegion();
         }
 
-        final RCTMGLMapView self = this;
         mMap.addOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
-            long lastTimestamp = System.currentTimeMillis();
-            boolean lastAnimated = false; // Workaround for the event called twice
-
             @Override
             public void onCameraIdle() {
                 if (mPointAnnotations.size() > 0) {
                     markerViewManager.invalidateViewMarkersInVisibleRegion();
                 }
 
-                long curTimestamp = System.currentTimeMillis();
-                boolean curAnimated = mCameraChangeTracker.isAnimated();
-                if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
-                    // even if we don't send the change event, we need to set the reason...
-                    // this happens when you have multiple calls to setCamera very quickly. This method will short circuit,
-                    // and then the next time the user moves the map, it will think it is NOT from a user interaction , because
-                    // this flag was not reset
-                    mCameraChangeTracker.setReason(-1);
-                    return;
-                }
+                // if we have onCameraIdle during mCameraChangeTracker.isAnimating()
+                // it's a 'fling animation' after user gesture
 
-                sendRegionChangeEvent(curAnimated);
-                lastTimestamp = curTimestamp;
-                lastAnimated = curAnimated;
+                // don't send didChange event if we gonna still animate fling
+                // we should use fling listener or send didCHange but with isUserInteraction false
+                // region didn't finish changing yet
+
+                // what to send as 'animated' at the end if we have fling? probably false as
+                // whole region change was triggered by user gesture
+
+                // actually we should have proper reason set in onCameraMoveStarted
+
+                if (!mCameraChangeTracker.isAnimating()) {
+                    Log.d("MOVE_EVENT", "onCameraIdle SENDING DID_CHANGE EVENT isUserInteraction: " + mCameraChangeTracker.isUserInteraction() + " isAnimated: " + mCameraChangeTracker.isAnimated());
+                    sendRegionDidChangeEvent(mCameraChangeTracker.isAnimated());
+                    mCameraChangeTracker.setReason(-1);
+                } else {
+                    Log.d("MOVE_EVENT", "onCameraIdle NOT SENDING DID_CHANGE EVENT on fling");
+                }
             }
         });
 
         mMap.addOnCameraMoveStartedListener(new MapboxMap.OnCameraMoveStartedListener() {
             @Override
             public void onCameraMoveStarted(int reason) {
+                // actually now we don't send DID CHANGE event when we are animating fling
+                // and we don't reset reason, then we will not send WILL CHANGE when starting fling
                 if (mCameraChangeTracker.isEmpty()) {
+                    // was this condition here because it can be set by setCamera ?
+                    // setCamera will not trigger events for camera listeners ?
+                    // or other cause?
+                    // actually we can say if we are starting fling here if reason is set, was it an original condition intention here?
+
+                    // when is reason 2 send?
+                    // can we have SDK reason but not animated?
                     mCameraChangeTracker.setReason(reason);
+
+                    Log.d("MOVE_EVENT", "onCameraMoveStarted SENDING WILL_CHANGE EVENT reason: " + reason + " isUserInteraction: " + mCameraChangeTracker.isUserInteraction() + " isAnimated: " + mCameraChangeTracker.isAnimated());
+                    sendRegionWillChangeEvent(mCameraChangeTracker.isAnimated());
+                } else {
+                    Log.d("MOVE_EVENT", "onCameraMoveStarted NOT SENDING WILL_CHANGE EVENT on fling");
                 }
             }
         });
@@ -467,6 +478,8 @@ public class RCTMGLMapView extends MapView implements
 
             @Override
             public void onCameraMove() {
+                sendRegionIsChangingEvent();
+
                 int userTrackingMode = mUserLocation.getTrackingMode();
                 boolean isFollowWithCourseOrHeading = userTrackingMode == UserTrackingMode.FollowWithCourse || userTrackingMode == UserTrackingMode.FollowWithHeading;
 
@@ -511,29 +524,11 @@ public class RCTMGLMapView extends MapView implements
     public boolean onTouchEvent(MotionEvent ev) {
         boolean result = super.onTouchEvent(ev);
 
-        int eventAction = ev.getAction();
-
-        if (eventAction == MotionEvent.ACTION_DOWN) {
-            mChangeDelimiterSuppressionDepth = 0;
-        } else if (eventAction == MotionEvent.ACTION_MOVE) {
-            if (mChangeDelimiterSuppressionDepth == 0) {
-                mChangeDelimiterSuppressionDepth = 1;
-            }
-        } else if (eventAction == MotionEvent.ACTION_CANCEL) {
-            mChangeDelimiterSuppressionDepth = 0;
-        } else if (eventAction == MotionEvent.ACTION_UP) {
-            mChangeDelimiterSuppressionDepth = 0;
-        }
-
         if (result) {
             requestDisallowInterceptTouchEvent(true);
         }
 
         return result;
-    }
-
-    private boolean isSuppressingChangeDelimiters() {
-        return mChangeDelimiterSuppressionDepth > 1;
     }
 
     @Override
@@ -674,22 +669,19 @@ public class RCTMGLMapView extends MapView implements
 
         switch (changed) {
             case REGION_WILL_CHANGE:
-                if (!isSuppressingChangeDelimiters()) {
-                    mChangeDelimiterSuppressionDepth = 2;
-                    event = new MapChangeEvent(this, makeRegionPayload(false), EventTypes.REGION_WILL_CHANGE);
-                }
+                // Log.d("MOVE_EVENT", "REGION_WILL_CHANGE");
                 break;
             case REGION_WILL_CHANGE_ANIMATED:
-                event = new MapChangeEvent(this, makeRegionPayload(true), EventTypes.REGION_WILL_CHANGE);
+                mCameraChangeTracker.setIsAnimating(true);
+                Log.d("MOVE_EVENT onMapChanged", "REGION_WILL_CHANGE_ANIMATED");
                 break;
             case REGION_IS_CHANGING:
-                event = new MapChangeEvent(this, EventTypes.REGION_IS_CHANGING);
                 break;
             case REGION_DID_CHANGE:
-                mCameraChangeTracker.setRegionChangeAnimated(false);
                 break;
             case REGION_DID_CHANGE_ANIMATED:
-                mCameraChangeTracker.setRegionChangeAnimated(true);
+                mCameraChangeTracker.setIsAnimating(false);
+                Log.d("MOVE_EVENT onMapChanged", "REGION_DID_CHANGE_ANIMATED");
                 break;
             case WILL_START_LOADING_MAP:
                 event = new MapChangeEvent(this, EventTypes.WILL_START_LOADING_MAP);
@@ -840,14 +832,14 @@ public class RCTMGLMapView extends MapView implements
                 mLocationManger.disable();
 
                 if (mLocationLayer != null) {
-                   int trackingMode = mUserLocation.getTrackingMode();
+                    int trackingMode = mUserLocation.getTrackingMode();
 
-                   if (trackingMode != UserTrackingMode.NONE) {
-                       mUserLocation.setTrackingMode(UserTrackingMode.NONE);
-                       updateUserTrackingMode(UserTrackingMode.NONE);
-                   }
+                    if (trackingMode != UserTrackingMode.NONE) {
+                        mUserLocation.setTrackingMode(UserTrackingMode.NONE);
+                        updateUserTrackingMode(UserTrackingMode.NONE);
+                    }
 
-                   updateLocationLayer();
+                    updateLocationLayer();
                 }
             } else {
                 enableLocation();
@@ -1216,7 +1208,8 @@ public class RCTMGLMapView extends MapView implements
             postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    sendRegionChangeEvent(false);
+                    sendRegionDidChangeEvent(false);
+                    mCameraChangeTracker.setReason(-1);
                 }
             }, 200);
         }
@@ -1444,10 +1437,19 @@ public class RCTMGLMapView extends MapView implements
         return cameraPosition.bearing;
     }
 
-    private void sendRegionChangeEvent(boolean isAnimated) {
+    private void sendRegionDidChangeEvent(boolean isAnimated) {
         IEvent event = new MapChangeEvent(this, makeRegionPayload(isAnimated), EventTypes.REGION_DID_CHANGE);
         mManager.handleEvent(event);
-        mCameraChangeTracker.setReason(-1);
+    }
+
+    private void sendRegionWillChangeEvent(boolean isAnimated) {
+        IEvent event = new MapChangeEvent(this, makeRegionPayload(isAnimated), EventTypes.REGION_WILL_CHANGE);
+        mManager.handleEvent(event);
+    }
+
+    private void sendRegionIsChangingEvent() {
+        IEvent event = new MapChangeEvent(this, EventTypes.REGION_IS_CHANGING);
+        mManager.handleEvent(event);
     }
 
     private void sendUserLocationUpdateEvent(Location location) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1223,7 +1223,7 @@ public class RCTMGLMapView extends MapView implements
         }
     }
 
-    private WritableMap makeRegionPayload(boolean isAnimated) {
+    private WritableMap makeRegionPayload() {
         CameraPosition position = mMap.getCameraPosition();
         LatLng latLng = new LatLng(position.target.getLatitude(), position.target.getLongitude());
 
@@ -1231,7 +1231,7 @@ public class RCTMGLMapView extends MapView implements
         properties.putDouble("zoomLevel", position.zoom);
         properties.putDouble("heading", position.bearing);
         properties.putDouble("pitch", position.tilt);
-        properties.putBoolean("animated", isAnimated);
+        properties.putBoolean("animated", mCameraChangeTracker.isAnimated());
         properties.putBoolean("isUserInteraction", mCameraChangeTracker.isUserInteraction());
 
         VisibleRegion visibleRegion = mMap.getProjection().getVisibleRegion();
@@ -1443,7 +1443,7 @@ public class RCTMGLMapView extends MapView implements
             // payload events
             case EventTypes.REGION_WILL_CHANGE:
             case EventTypes.REGION_DID_CHANGE:
-                event = new MapChangeEvent(this, makeRegionPayload(mCameraChangeTracker.isAnimated()), eventType);
+                event = new MapChangeEvent(this, makeRegionPayload(), eventType);
                 break;
             default:
                 event = new MapChangeEvent(this, eventType);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -421,9 +421,9 @@ public class RCTMGLMapView extends MapView implements
                 long curTimestamp = System.currentTimeMillis();
                 boolean curAnimated = mCameraChangeTracker.isAnimated();
                 if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
-                      // even if we don't send the change event, we need to set the reason...
-                    //this happens when you have multiple calls to setCamera very quickly. This method will short circuit,
-                    //and then the next time the user moves the map, it will think it is NOT from a user interaction , because
+                    // even if we don't send the change event, we need to set the reason...
+                    // this happens when you have multiple calls to setCamera very quickly. This method will short circuit,
+                    // and then the next time the user moves the map, it will think it is NOT from a user interaction , because
                     // this flag was not reset
                     mCameraChangeTracker.setReason(-1);
                     return;
@@ -516,7 +516,9 @@ public class RCTMGLMapView extends MapView implements
         if (eventAction == MotionEvent.ACTION_DOWN) {
             mChangeDelimiterSuppressionDepth = 0;
         } else if (eventAction == MotionEvent.ACTION_MOVE) {
-            mChangeDelimiterSuppressionDepth++;
+            if (mChangeDelimiterSuppressionDepth == 0) {
+                mChangeDelimiterSuppressionDepth = 1;
+            }
         } else if (eventAction == MotionEvent.ACTION_CANCEL) {
             mChangeDelimiterSuppressionDepth = 0;
         } else if (eventAction == MotionEvent.ACTION_UP) {
@@ -531,7 +533,7 @@ public class RCTMGLMapView extends MapView implements
     }
 
     private boolean isSuppressingChangeDelimiters() {
-        return mChangeDelimiterSuppressionDepth > 2;
+        return mChangeDelimiterSuppressionDepth > 1;
     }
 
     @Override
@@ -673,13 +675,12 @@ public class RCTMGLMapView extends MapView implements
         switch (changed) {
             case REGION_WILL_CHANGE:
                 if (!isSuppressingChangeDelimiters()) {
+                    mChangeDelimiterSuppressionDepth = 2;
                     event = new MapChangeEvent(this, makeRegionPayload(false), EventTypes.REGION_WILL_CHANGE);
                 }
                 break;
             case REGION_WILL_CHANGE_ANIMATED:
-                if (!isSuppressingChangeDelimiters()) {
-                    event = new MapChangeEvent(this, makeRegionPayload(true), EventTypes.REGION_WILL_CHANGE);
-                }
+                event = new MapChangeEvent(this, makeRegionPayload(true), EventTypes.REGION_WILL_CHANGE);
                 break;
             case REGION_IS_CHANGING:
                 event = new MapChangeEvent(this, EventTypes.REGION_IS_CHANGING);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -375,14 +375,12 @@ public class RCTMGLMapView extends MapView implements
             mMap.moveCamera(CameraUpdateFactory.newCameraPosition(buildCamera()), new MapboxMap.CancelableCallback() {
                 @Override
                 public void onCancel() {
-                    handleMapChangedEvent(EventTypes.REGION_DID_CHANGE);
-                    mCameraChangeTracker.setReason(-1);
+                    sendRegionDidChangeEvent();
                 }
 
                 @Override
                 public void onFinish() {
-                    handleMapChangedEvent(EventTypes.REGION_DID_CHANGE);
-                    mCameraChangeTracker.setReason(-1);
+                    sendRegionDidChangeEvent();
                 }
             });
         }
@@ -425,8 +423,7 @@ public class RCTMGLMapView extends MapView implements
 
                 if (!mCameraChangeTracker.isAnimating()) {
                     Log.d("MOVE_EVENT", "onCameraIdle SENDING DID_CHANGE EVENT isUserInteraction: " + mCameraChangeTracker.isUserInteraction() + " isAnimated: " + mCameraChangeTracker.isAnimated());
-                    handleMapChangedEvent(EventTypes.REGION_DID_CHANGE);
-                    mCameraChangeTracker.setReason(-1);
+                    sendRegionDidChangeEvent();
                 } else {
                     Log.d("MOVE_EVENT", "onCameraIdle NOT SENDING DID_CHANGE EVENT on fling");
                 }
@@ -1204,8 +1201,7 @@ public class RCTMGLMapView extends MapView implements
             postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    handleMapChangedEvent(EventTypes.REGION_DID_CHANGE);
-                    mCameraChangeTracker.setReason(-1);
+                    sendRegionDidChangeEvent();
                 }
             }, 200);
         }
@@ -1431,6 +1427,11 @@ public class RCTMGLMapView extends MapView implements
     private double getMapRotation() {
         CameraPosition cameraPosition = mMap.getCameraPosition();
         return cameraPosition.bearing;
+    }
+
+    private void sendRegionDidChangeEvent() {
+        handleMapChangedEvent(EventTypes.REGION_DID_CHANGE);
+        mCameraChangeTracker.setReason(-1);
     }
 
     private void handleMapChangedEvent(String eventType) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -1,7 +1,5 @@
 package com.mapbox.rctmgl.components.mapview;
 
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import android.view.View;
 
@@ -19,7 +17,7 @@ import com.mapbox.rctmgl.utils.FilterParser;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
 import com.mapbox.services.commons.geojson.Point;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -244,6 +242,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_TAKE_SNAP = 7;
     public static final int METHOD_GET_ZOOM = 8;
     public static final int METHOD_GET_CENTER = 9;
+    public static final int METHOD_SET_HANDLED_MAP_EVENTS = 10;
 
     @Nullable
     @Override
@@ -258,6 +257,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("takeSnap", METHOD_TAKE_SNAP)
                 .put("getZoom", METHOD_GET_ZOOM)
                 .put("getCenter", METHOD_GET_CENTER)
+                .put( "setHandledMapChangedEvents", METHOD_SET_HANDLED_MAP_EVENTS)
                 .build();
     }
 
@@ -305,6 +305,15 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 break;
             case METHOD_GET_CENTER:
                 mapView.getCenter(args.getString(0));
+                break;
+            case METHOD_SET_HANDLED_MAP_EVENTS:
+                if(args != null) {
+                    ArrayList<String> eventsArray = new ArrayList<>();
+                    for (int i = 1; i < args.size(); i++) {
+                        eventsArray.add(args.getString(i));
+                    }
+                    mapView.setHandledMapChangedEvents(eventsArray);
+                }
                 break;
         }
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/helpers/CameraChangeTracker.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/helpers/CameraChangeTracker.java
@@ -8,27 +8,31 @@ import android.util.Log;
 
 public class CameraChangeTracker {
     public static final int USER_GESTURE = 1;
-    public static final int USER_ANIMATION = 2;
-    public static final int SDK = 3;
+    public static final int DEVELOPER_ANIMATION = 2;
+    public static final int SDK_ANIMATION = 3;
     public static final int EMPTY = -1;
 
-    private int reason;
-    private boolean isRegionChangeAnimated;
+    private int reason = EMPTY;
+    private boolean isAnimating;
 
     public void setReason(int reason) {
         this.reason = reason;
     }
 
-    public void setRegionChangeAnimated(boolean isRegionChangeAnimated) {
-        this.isRegionChangeAnimated = isRegionChangeAnimated;
+    public void setIsAnimating(boolean isAnimating) {
+        this.isAnimating = isAnimating;
     }
 
     public boolean isUserInteraction() {
-        return reason == USER_GESTURE || reason == USER_ANIMATION;
+        return reason == USER_GESTURE || reason == DEVELOPER_ANIMATION;
     }
 
     public boolean isAnimated() {
-        return isRegionChangeAnimated;
+        return reason == DEVELOPER_ANIMATION || reason == SDK_ANIMATION;
+    }
+
+    public boolean isAnimating() {
+        return this.isAnimating;
     }
 
     public boolean isEmpty() {

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -303,6 +303,37 @@ class MapView extends React.Component {
     this._preRefMapMethodQueue = [];
   }
 
+  componentDidMount() {
+    this.setHandledMapChangedEvents(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setHandledMapChangedEvents(nextProps);
+  }
+
+  setHandledMapChangedEvents(props) {
+    if (isAndroid()) {
+        const events = [];
+
+        if (props.onRegionWillChange) events.push(MapboxGL.EventTypes.RegionWillChange);
+        if (props.onRegionIsChanging) events.push(MapboxGL.EventTypes.RegionIsChanging);
+        if (props.onRegionDidChange) events.push(MapboxGL.EventTypes.RegionDidChange);
+        if (props.onUserLocationUpdate) events.push(MapboxGL.EventTypes.UserLocationUpdated);
+        if (props.onWillStartLoadingMap) events.push(MapboxGL.EventTypes.WillStartLoadingMap);
+        if (props.onDidFinishLoadingMap) events.push(MapboxGL.EventTypes.DidFinishLoadingMap);
+        if (props.onDidFailLoadingMap) events.push(MapboxGL.EventTypes.DidFailLoadingMap);
+        if (props.onWillStartRenderingFrame) events.push(MapboxGL.EventTypes.WillStartRenderingFrame);
+        if (props.onDidFinishRenderingFrame) events.push(MapboxGL.EventTypes.DidFinishRenderingFrame);
+        if (props.onDidFinishRenderingFrameFully) events.push(MapboxGL.EventTypes.DidFinishRenderingFrameFully);
+        if (props.onWillStartRenderingMap) events.push(MapboxGL.EventTypes.WillStartRenderingMap);
+        if (props.onDidFinishRenderingMap) events.push(MapboxGL.EventTypes.DidFinishRenderingMap);
+        if (props.onDidFinishRenderingMapFully) events.push(MapboxGL.EventTypes.DidFinishRenderingMapFully);
+        if (props.onDidFinishLoadingStyle) events.push(MapboxGL.EventTypes.DidFinishLoadingStyle);
+
+        this._runNativeCommand('setHandledMapChangedEvents', events);
+    }
+  }
+
   /**
    * Converts a geographic coordinate to a point in the given view’s coordinate system.
    *

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -712,19 +712,28 @@ class MapView extends React.Component {
   }
 
   _onChange(e) {
+    const { regionWillChangeDebounceTime, regionDidChangeDebounceTime } = this.props;
     const { type, payload } = e.nativeEvent;
     let propName = '';
 
     switch (type) {
       case MapboxGL.EventTypes.RegionWillChange:
-        this._onDebouncedRegionWillChange(payload);
-        return;
+        if (regionWillChangeDebounceTime > 0) {
+          this._onDebouncedRegionWillChange(payload);
+        } else {
+          propName = 'onRegionWillChange';
+        }
+        break;
       case MapboxGL.EventTypes.RegionIsChanging:
         propName = 'onRegionIsChanging';
         break;
       case MapboxGL.EventTypes.RegionDidChange:
-        this._onDebouncedRegionDidChange(payload);
-        return;
+        if (regionDidChangeDebounceTime > 0) {
+          this._onDebouncedRegionDidChange(payload);
+        } else {
+          propName = 'onRegionDidChange';
+        }
+        break;
       case MapboxGL.EventTypes.UserLocationUpdated:
         propName = 'onUserLocationUpdate';
         break;


### PR DESCRIPTION
I came to this PR from #1209 which I also need.

The thing is that ```onRegionWillChange``` didn't work always which this PR fixes.

Problem was that before ```onMapChange``` ```REGION_WILL_CHANGE``` event triggers, ```onTouchEvent``` with ```ACTION_MOVE``` is triggered multiple times, incrementing ```mChangeDelimiterSuppressionDepth``` and then ```REGION_WILL_CHANGE``` is suppressed before even first time sent to js.

I found no reason to suppress ```onRegionWillChange``` with ```animated``` flag, and I removed this check, actually they fire correctly when user do 'flick' gesture. It's triggered when sdk do scroll momentum after flick, or programmatically will animate to new region.

Actually my problem was to have own debouncing on didChange/willChange events and cancel _.debounce when user interacts with map (not talking about delays, yes, I found them without a word in docs :) ). Not sure I can do what I want since didChange debouncing will debounce on didChange event of course, but when user move, release finger and quickly want to swipe more, debounce will trigger didChange event, but I don't want to trigger it until user finish swiping. So if taking up finger, putting back and continue swiping I want to cancel didChange debounce to not trigger.

Now on ```REGION_WILL_CHANGE``` event (not animated, animated is after didChange) I can cancel my debouncing on didChange.

Other thing is what I didn't fix here (will put in issue) is that ```isUserInteraction``` is 
not set correctly, but have no idea how to properly fix it.
EDIT: PR updated with fix for it.
```onCameraMoveStarted``` actually sets correct reason which is used to set ```isUserInteraction``` but it fires after ```onMapChange``` ```REGION_WILL_CHANGE``` event (or other events).
With this PR I have log:
```
ACTION_MOVE
REGION_WILL_CHANGE (isUserInteraction() - false)
CameraMoveStartedListener true
REGION_WILL_CHANGE ANIMATED <- this is user momentum scroll animation
CameraMoveStartedListener true (true - mCameraChangeTracker.isUserInteraction())
// here I get didChange event in js, fetch some data,
// update store with new bounds, and fitBounds is triggered (in this case unnecessary)
REGION_WILL_CHANGE ANIMATED <- this is after fitBounds programmatically
CameraMoveStartedListener false (false - mCameraChangeTracker.isUserInteraction())
```
so ```REGION_WILL_CHANGE[_ANIMATED]``` are sent with incorrect ```isUserInteraction``` flag.
This problem is probably connected to #980 (iOS)

I hope I've tested and described everything correctly.