### PR TITLE
Handle error when URL isn't reachable for bitmap

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
@@ -49,6 +49,7 @@ public class BitmapUtils {
             addImage(url, bitmap);
         } catch (Exception e) {
             Log.w(LOG_TAG, e.getLocalizedMessage());
+            bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8); // Returns a transparent bitmap
         }
 
         return bitmap;


### PR DESCRIPTION
This fixes Issue #1309 when the URL isn't reachable.