### PR TITLE
Avoir crash when URL is null (Vector/Shape/Raster Source)

### DIFF
--- a/javascript/components/RasterSource.js
+++ b/javascript/components/RasterSource.js
@@ -73,6 +73,9 @@ class RasterSource extends React.Component {
       tms: this.props.tms,
       attribution: this.props.attribution,
     };
+
+    if (!props.url) return null; // Avoid crash
+
     return (
       <RCTMGLRasterSource {...props}>
         {cloneReactChildrenWithProps(this.props.children, {

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -162,6 +162,9 @@ class ShapeSource extends React.Component {
       ...this._getImages(),
       onPress: undefined,
     };
+
+    if (!props.url) return null; // Avoid crash
+
     return (
       <RCTMGLShapeSource {...props}>
         {cloneReactChildrenWithProps(this.props.children, {

--- a/javascript/components/VectorSource.js
+++ b/javascript/components/VectorSource.js
@@ -57,6 +57,9 @@ class VectorSource extends React.Component {
       onMapboxVectorSourcePress: this.props.onPress,
       onPress: undefined,
     };
+
+    if (!props.url) return null; // Avoid crash
+
     return (
       <RCTMGLVectorSource {...props}>
         {cloneReactChildrenWithProps(this.props.children, {


### PR DESCRIPTION
Currently, if the url of a source is null or undefined, the app crashes (On Android at least).
This ensure that the url is defined and not null before trying to render the native component that crashes.