### PR TITLE
Fixes #1327, tileSize option not being used on iOS

### DIFF
--- a/ios/RCTMGL/RCTMGLRasterSource.m
+++ b/ios/RCTMGL/RCTMGLRasterSource.m
@@ -29,6 +29,10 @@
         options[MGLTileSourceOptionMinimumZoomLevel] = _minZoomLevel;
     }
     
+    if (_tileSize != nil) {
+        options[MGLTileSourceOptionTileSize] = _tileSize;
+    }
+
     if (_tms) {
         options[MGLTileSourceOptionTileCoordinateSystem] = [NSNumber numberWithUnsignedInteger:MGLTileCoordinateSystemTMS];
     }


### PR DESCRIPTION
Fixes #1327.  tileSize option simply wasn't being passed in to the MGLRasterSource

Comparing the watercolor example

Before:
![simulator screen shot - iphone 8 - 2018-08-16 at 22 30 40](https://user-images.githubusercontent.com/81816/44249442-b816a380-a1a4-11e8-871d-d026f326642c.png)

After:
![simulator screen shot - iphone 8 - 2018-08-16 at 22 29 44](https://user-images.githubusercontent.com/81816/44249450-c2d13880-a1a4-11e8-8518-d1ab88ce485c.png)
