### PR TITLE
Don't intercept touch event if scroll is disabled

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -542,7 +542,7 @@ public class RCTMGLMapView extends MapView implements
             mChangeDelimiterSuppressionDepth = 0;
         }
 
-        if (result) {
+        if (result && mScrollEnabled) {
             requestDisallowInterceptTouchEvent(true);
         }
 


### PR DESCRIPTION
We have a MapView ( with scroll disabled) in a vertical ScrollView. If the user touches on the mapView to scroll the parent view then nothing happens. If the users touches anywhere else in the scroll view, then it works fine.

Reason
Inside Mapview.onTouchEvent, we are stopping the propagation of the event to the parent view. As a result, nothing happen when we try to scroll the scroll view while touching the mapView. In order to temporary fix this, we added another condition to stop propagating the event . Only when scroll is enabled in the mapView, we disable propagating the event.

This-https://github.com/mapbox/react-native-mapbox-gl/issues/856  was an issue raised long back which was fixed by this PR-https://github.com/mapbox/react-native-mapbox-gl/pull/861. However, This PR causes a different issue though. Since the onTouchEvent() blindly requests to disallow intercept, even when the map is completely static, scroll events get captured in the map, and parent doesn't scroll. Outside the map, the parent container scrolls normally.