### PR TITLE
NullpointerException fix in RCTMGLMapView, when the camera position h…

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1258,6 +1258,9 @@ public class RCTMGLMapView extends MapView implements
 
     private WritableMap makeRegionPayload(boolean isAnimated) {
         CameraPosition position = mMap.getCameraPosition();
+        if (position == null || position.target == null) {
+            return new WritableNativeMap();
+        }
         LatLng latLng = new LatLng(position.target.getLatitude(), position.target.getLongitude());
 
         WritableMap properties = new WritableNativeMap();


### PR DESCRIPTION
We were getting this crash in our weatherbug application-
Stack traces:
 
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'double com.mapbox.mapboxsdk.geometry.LatLng.getLatitude()' on a null object reference
 
com.mapbox.rctmgl.components.mapview.RCTMGLMapView.makeRegionPayload (Unknown Source:10)
com.mapbox.rctmgl.components.mapview.RCTMGLMapView.sendRegionChangeEvent (Unknown Source:2)
com.mapbox.rctmgl.components.mapview.RCTMGLMapView.access$700 (Unknown Source)
com.mapbox.rctmgl.components.mapview.RCTMGLMapView$3.onCameraIdle (Unknown Source:58)
com.mapbox.mapboxsdk.maps.CameraChangeDispatcher$4.run (Unknown Source:66)
android.os.Handler.handleCallback (Handler.java:789)
android.os.Handler.dispatchMessage (Handler.java:98)
android.os.Looper.loop (Looper.java:164)
android.app.ActivityThread.main (ActivityThread.java:6938)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)

So, added null check for this.