### PR TITLE
Adds Example of VectorSource with a Third Party Tileset

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -44,6 +44,7 @@ import QueryAtPoint from './components/QueryAtPoint';
 import QueryWithRect from './components/QueryWithRect';
 import ShapeSourceIcon from './components/ShapeSourceIcon';
 import CustomVectorSource from './components/CustomVectorSource';
+import ThirdPartyVectorTileSource from './components/ThirdPartyVectorTileSource';
 import ShowPointAnnotation from './components/ShowPointAnnotation';
 import CreateOfflineRegion from './components/CreateOfflineRegion';
 import DriveTheLine from './components/DriveTheLine';
@@ -123,6 +124,7 @@ const Examples = [
   new ExampleItem('Query Features Bounding Box', QueryWithRect),
   new ExampleItem('Shape Source From Icon', ShapeSourceIcon),
   new ExampleItem('Custom Vector Source', CustomVectorSource),
+  new ExampleItem('Third Party Vector Tile Source', ThirdPartyVectorTileSource),
   new ExampleItem('Show Point Annotation', ShowPointAnnotation),
   new ExampleItem('Create Offline Region', CreateOfflineRegion),
   new ExampleItem('Animation Along a Line', DriveTheLine),

--- a/example/src/components/ThirdPartyVectorTileSource.js
+++ b/example/src/components/ThirdPartyVectorTileSource.js
@@ -9,15 +9,14 @@ import sheet from '../styles/sheet';
 const styles = MapboxGL.StyleSheet.create({
   line: {
     lineCap: "round",
-    lineJoin: "rouncd",
+    lineJoin: "round",
     lineOpacity: 0.6,
     lineColor: "rgb(53, 175, 109)",
     lineWidth: 2
   },
 });
 
-const VECTOR_SOURCE_URL =
-  'https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt';
+const TILEJSON_URL = "https://s3.amazonaws.com/tgaw/tilejson.json";
 
 // This example ported to React Native:
 // https://www.mapbox.com/mapbox-gl-js/example/third-party/
@@ -32,10 +31,11 @@ class ThirdPartyVectorTileSource extends React.PureComponent {
         <MapboxGL.MapView
           zoomLevel={12}
           centerCoordinate={[-87.622088, 41.878781]}
+          styleURL="mapbox://styles/mapbox/light-v9"
           style={sheet.matchParent}>
           <MapboxGL.VectorSource
             id="customTileSourceExample"
-            url={VECTOR_SOURCE_URL}>
+            url={TILEJSON_URL}>
             <MapboxGL.LineLayer
               id="customTileSourceLine"
               sourceLayerID="mapillary-sequences"

--- a/example/src/components/ThirdPartyVectorTileSource.js
+++ b/example/src/components/ThirdPartyVectorTileSource.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import MapboxGL from '@mapbox/react-native-mapbox-gl';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+
+import sheet from '../styles/sheet';
+
+const styles = MapboxGL.StyleSheet.create({
+  line: {
+    lineCap: "round",
+    lineJoin: "rouncd",
+    lineOpacity: 0.6,
+    lineColor: "rgb(53, 175, 109)",
+    lineWidth: 2
+  },
+});
+
+const VECTOR_SOURCE_URL =
+  'https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt';
+
+// This example ported to React Native:
+// https://www.mapbox.com/mapbox-gl-js/example/third-party/
+class ThirdPartyVectorTileSource extends React.PureComponent {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  render() {
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+          zoomLevel={12}
+          centerCoordinate={[-87.622088, 41.878781]}
+          style={sheet.matchParent}>
+          <MapboxGL.VectorSource
+            id="customTileSourceExample"
+            url={VECTOR_SOURCE_URL}>
+            <MapboxGL.LineLayer
+              id="customTileSourceLine"
+              sourceLayerID="mapillary-sequences"
+              style={styles.line}
+            />
+          </MapboxGL.VectorSource>
+        </MapboxGL.MapView>
+      </Page>
+    );
+  }
+}
+
+export default ThirdPartyVectorTileSource;


### PR DESCRIPTION
**This PR**

Adds a new example `ThirdPartyVectorTileSource.js` showing how to use `VectorSource` to consume a custom tileset. In https://github.com/mapbox/react-native-mapbox-gl/issues/1448 I described an issue I ran into trying to do this. It's not an issue with the library, but I was confused by what I needed to do.

The key thing that I missed from the docs was that I needed to use a [TileJSON](https://github.com/mapbox/tilejson-spec/tree/master/2.1.0) file for the `url` property of `VectorSource`. I was incorrectly trying to use the tile url directly.

**How to Test**
- Check out this branch
- `cd example && npm i`
- `npm start`
- `react-native run-ios`
- In the examples list, look for "Third Party Vector Tile Source"

The example should show a map centered on Chicago with green lines indicating...I'm not real sure what the data is, but there should be a bunch of green lines.

**example screenshot**
<img width="327" alt="example" src="https://user-images.githubusercontent.com/233859/50112497-58d9a600-020d-11e9-92cb-ca86b83f4579.png">
