### PR TITLE
Get visible bounds in view coordinates

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -93,6 +93,22 @@ const visibleBounds = await this._map.getVisibleBounds();
 ```
 
 
+#### getVisibleBoundsInViewCoordinates()
+
+The user's viewport bounds in the given view's coordinate system.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
+
+```javascript
+const visibleBounds = await this._map.getVisibleBoundsInViewCoordinates();
+```
+
+
 #### queryRenderedFeaturesAtPoint(coordinate[, filter][, layerIDs])
 
 Returns an array of rendered map features that intersect with a given point.

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -345,6 +345,27 @@ class MapView extends React.Component {
   }
 
   /**
+   * The user's viewport bounds in the given view's coordinate system.
+   *
+   * @example
+   * const visibleBounds = await this._map.getVisibleBoundsInViewCoordinates();
+   *
+   * @return {Array}
+   */
+  async getVisibleBoundsInViewCoordinates() {
+    const bounds = await this.getVisibleBounds();
+    const viewCoords = [
+      await this.getPointInView(bounds[0]),
+      await this.getPointInView(bounds[1]),
+    ];
+    const maxX = Math.max(viewCoords[0][0], viewCoords[1][0]);
+    const minX = Math.min(viewCoords[0][0], viewCoords[1][0]);
+    const maxY = Math.max(viewCoords[0][1], viewCoords[1][1]);
+    const minY = Math.min(viewCoords[0][1], viewCoords[1][1]);
+    return [maxY, maxX, minY, minX];
+  }
+
+  /**
    * Returns an array of rendered map features that intersect with a given point.
    *
    * @example


### PR DESCRIPTION
Adds the method *getVisibleBoundsInViewCoordinates* to *MapboxGL.MapView*.
Currently, in order to get features visible in the map you have to call *getVisibleBounds* which returns the coordinate bounds visible in the user's viewport, convert those coordinates to view coordinates via *getPointInView* and then use *queryRenderedFeaturesInRect* with those coordinates.
*getVisibleBoundsInViewCoordinates* aims to make this process easier by removing the conversion step between world coordinates and view coordinates.