### PR TITLE
Remove logs from OnStatusChange in offline module (Android)

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -320,11 +320,6 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
 
             @Override
             public void onStatusChanged(OfflineRegionStatus status) {
-                // ignore status inactive updates
-                Log.d(REACT_CLASS, String.format("Status %d", status.getDownloadState()));
-                Log.d(REACT_CLASS, String.format("Required Resource count %d", status.getRequiredResourceCount()));
-                Log.d(REACT_CLASS, String.format("Completed Resource count %d", status.getCompletedResourceCount()));
-
                 if (shouldSendUpdate(System.currentTimeMillis(), status)) {
                     sendEvent(makeStatusEvent(name, status));
                     timestamp = System.currentTimeMillis();


### PR DESCRIPTION
When resuming several download, Android logcat get polluted with these logs:

`01-24 14:24:38.754  1856  1856 D RCTMGLOfflineModule: Status 1`
`01-24 14:24:38.754  1856  1856 D RCTMGLOfflineModule: Required Resource count 1104`
`01-24 14:24:38.754  1856  1856 D RCTMGLOfflineModule: Completed Resource count 1035`
