### PR TITLE
Podspec fix for people using CocoaPods for distribution and not NPM

### DIFF
--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -14,5 +14,7 @@ Pod::Spec.new do |s|
   s.source_files	= "ios/RCTMGL/**/*.{h,m}"
 
   s.vendored_frameworks = 'ios/Mapbox.framework'
+  s.preserve_paths = ['scripts']
+
   s.dependency 'React'
 end

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source_files	= "ios/RCTMGL/**/*.{h,m}"
 
   s.vendored_frameworks = 'ios/Mapbox.framework'
-  s.preserve_paths = ['scripts']
+  s.prepare_command = 'node scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.8'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
Typically during the install process `npm` calls `node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 3.7.8` to download the MapBox SDK: [here](https://github.com/mapbox/react-native-mapbox-gl/blob/master/package.json#L26)

However, when you install this library via CocoaPods (when [separating your JS / native code](http://artsy.github.io/blog/2018/04/17/making-a-components-pod/) ) then this script doesn't run. This allows CocoaPods consumers to also get a copy of the framework.

