### PR TITLE
Added EventDispatcher to dispatch events

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEvent.java
@@ -1,0 +1,28 @@
+package com.mapbox.rctmgl.components;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+import javax.annotation.Nullable;
+
+public class AbstractEvent extends Event<AbstractEvent> {
+    private String mEventName;
+    private WritableMap mEvent;
+
+    public AbstractEvent(int viewId, String eventName, @Nullable WritableMap event) {
+        super(viewId);
+        mEventName = eventName;
+        mEvent = event;
+    }
+
+    @Override
+    public String getEventName() {
+        return mEventName;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEvent);
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEventEmitter.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEventEmitter.java
@@ -1,24 +1,19 @@
 package com.mapbox.rctmgl.components;
 
-import android.app.Application;
 import android.view.ViewGroup;
 
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
-import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.mapbox.rctmgl.events.IEvent;
 
 /**
@@ -28,10 +23,9 @@ import com.mapbox.rctmgl.events.IEvent;
 abstract public class AbstractEventEmitter<T extends ViewGroup> extends ViewGroupManager<T> {
     private static final double BRIDGE_TIMEOUT_MS = 10;
     private Map<String, Long> mRateLimitedEvents;
-    private ReactApplicationContext mRCTAppContext;
+    private EventDispatcher mEventDispatcher;
 
     public AbstractEventEmitter(ReactApplicationContext reactApplicationContext) {
-        mRCTAppContext = reactApplicationContext;
         mRateLimitedEvents = new HashMap<>();
     }
 
@@ -44,7 +38,12 @@ abstract public class AbstractEventEmitter<T extends ViewGroup> extends ViewGrou
         }
 
         mRateLimitedEvents.put(eventCacheKey, System.currentTimeMillis());
-        getEventEmitter().receiveEvent(event.getID(), event.getKey(), event.toJSON());
+        mEventDispatcher.dispatchEvent(new AbstractEvent(event.getID(), event.getKey(), event.toJSON()));
+    }
+
+    @Override
+    protected void addEventEmitters(ThemedReactContext context, T view) {
+        mEventDispatcher = context.getNativeModule(UIManagerModule.class).getEventDispatcher();
     }
 
     @Nullable
@@ -61,45 +60,6 @@ abstract public class AbstractEventEmitter<T extends ViewGroup> extends ViewGrou
     }
 
     public abstract Map<String, String> customEvents();
-
-    /**
-     * React Native constructs the mRCTAppContext when the {@link ReactInstanceManager} starts up and creates the
-     * {@link NativeModule}s and {@link ViewManager}s. This happens on app fresh boot, but also anytime the JS VM 'restarts'.
-     * There are a few different cases when this instance manager will recreate the ReactContext...
-     *
-     * 1.) When a developer is on a debug build and 'reloads' the javascript.
-     * 2.) If using Codepush, it 'reloads' the react engine, which essentially does the same things as step 1.
-     *
-     * If RN ever reloads, It will reconstruct all of the CoreModules here {CoreModulesPackage#getNativeModules(ReactApplicationContext)}
-     * which reconstructs the all of the RN package's {{@link NativeModule}}s. It also should be in charge of recreating the
-     * View Managers... However, A recent change to React Native introduced a big bug with how these ViewManagers are recreated.
-     *
-     * If you look at this method, {@link ReactInstanceManager#getOrCreateViewManagers(ReactApplicationContext)}
-     * You will see that it will simply reuse the existing ViewManagers
-     * EVEN THOUGH THEY CONTAIN THE OLD ReactContexts !!!
-     *
-     * This was introduced with this commit.
-     * https://github.com/facebook/react-native/commit/4371d1e1d0318c3aa03738583a24b833f0a33ba1
-     *
-     * This means that the new View's that are constructed with this old react context contains a stale {@link CatalystInstance}.
-     *
-     * This class is a perfect example. In the case when RN was reloaded, it tries to get the RCTEventEmitter instance from an
-     * old {@link ReactContext}. This means that all events delegated to that emitter are posting to a dead thread! (you can
-     * check the logcat output you will see warnings from ReactNative that the events are posted on a dead thread)
-     *
-     * This code below is a simple band aid, assuming that your {@link Application} instance is a {@link ReactApplication}
-     *
-     * A better solution would be to decouple the event emitter from the ViewManagers. An even better solution, would be to fix
-     * this in React Native itself. When recreating the ReactContext, and it already has view managers, tell them to use the new
-     * ReactContext, instead of skipping over them entirely.
-     *
-     *
-     * @return the most recent {@link RCTEventEmitter} instance
-     */
-    private RCTEventEmitter getEventEmitter() {
-        return ((ReactApplication) mRCTAppContext.getApplicationContext()).getReactNativeHost().getReactInstanceManager()
-            .getCurrentReactContext().getJSModule(RCTEventEmitter.class);
-    }
 
     private boolean shouldDropEvent(String cacheKey, IEvent event) {
         Long lastEventTimestamp = mRateLimitedEvents.get(cacheKey);


### PR DESCRIPTION
I'm using expo and had issues with events not triggering because they don't implement ReactApplication.
I've changed the code so that it's based off of standard React-Native components and in my opinion this is the proper way to dispatch events.
This triggers the events properly with expo, but also for normal react-native projects.
 #1189