### PR TITLE
fallback for case when children is already an array

### DIFF
--- a/javascript/utils/index.js
+++ b/javascript/utils/index.js
@@ -69,6 +69,8 @@ export function cloneReactChildrenWithProps(children, propsToAdd = {}) {
 
   if (!Array.isArray(children)) {
     foundChildren = [children];
+  } else {
+    foundChildren = children
   }
 
   const filteredChildren = foundChildren.filter(child => !!child); // filter out falsy children, since some can be null


### PR DESCRIPTION
This is a small fix that ensures `foundChildren` won't be null when the filter method is called in the case where `children` is already an array.

Closes #1524