### PR TITLE
Generated doc fix

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -6,6 +6,7 @@
 | ---- | :--: | :-----: | :------: | :----------: |
 | animated | `bool` | `false` | `false` | Animates changes between pitch and bearing |
 | centerCoordinate | `arrayOf` | `none` | `false` | Initial center coordinate on map [lng, lat] |
+| visibleCoordinateBounds | `arrayOf` | `none` | `false` | Initial bounds on map [[lng, lat], [lng, lat]] |
 | showUserLocation | `bool` | `none` | `false` | Shows the users location on the map |
 | userTrackingMode | `number` | `MapboxGL.UserTrackingModes.None` | `false` | The mode used to track the user location on the map |
 | userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |
@@ -43,6 +44,8 @@
 | onDidFinishRenderingMapFully | `func` | `none` | `false` | This event is triggered when the map fully finished rendering the map. |
 | onDidFinishLoadingStyle | `func` | `none` | `false` | This event is triggered when a style has finished loading. |
 | onUserTrackingModeChange | `func` | `none` | `false` | This event is triggered when the users tracking mode is changed. |
+| regionWillChangeDebounceTime | `number` | `10` | `false` | The emitted frequency of regionwillchange events |
+| regionDidChangeDebounceTime | `number` | `500` | `false` | The emitted frequency of regiondidchange events |
 
 ### methods
 #### getPointInView(coordinate)
@@ -58,6 +61,22 @@ Converts a geographic coordinate to a point in the given view’s coordinate sys
 
 ```javascript
 const pointInView = await this._map.getPointInView([-37.817070, 144.949901]);
+```
+
+
+#### getCoordinateFromView(point)
+
+Converts a point in the given view’s coordinate system to a geographic coordinate.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `point` | `Array` | `Yes` | A point expressed in the given view’s coordinate system. |
+
+
+
+```javascript
+const coordinate = await this._map.getCoordinateFromView([100, 100]);
 ```
 
 

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -9,7 +9,7 @@
 | snippet | `string` | `none` | `false` | The string containing the annotation’s snippet(subtitle). Not displayed in the default callout. |
 | selected | `bool` | `none` | `false` | Manually selects/deselects annotation<br/>@type {[type]} |
 | coordinate | `arrayOf` | `none` | `true` | The center point (specified as a map coordinate) of the annotation. |
-| anchor | `shape` | `{ x: 0.5, y: 0.5 }` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
+| anchor | `shape` | `{x: 0.5, y: 0.5}` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
 | onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param. |
 | onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected. |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1346,18 +1346,6 @@
     "description": "MapView backed by Mapbox Native GL",
     "methods": [
       {
-        "name": "setHandledMapChangedEvents",
-        "docblock": null,
-        "modifiers": [],
-        "params": [
-          {
-            "name": "props",
-            "type": null
-          }
-        ],
-        "returns": null
-      },
-      {
         "name": "getPointInView",
         "docblock": "Converts a geographic coordinate to a point in the given view’s coordinate system.\n\n@example\nconst pointInView = await this._map.getPointInView([-37.817070, 144.949901]);\n\n@param {Array<Number>} coordinate - A point expressed in the map view's coordinate system.\n@return {Array}",
         "modifiers": [

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -49,7 +49,9 @@ class MapView extends React.Component {
     /**
      * Initial bounds on map [[lng, lat], [lng, lat]]
      */
-    visibleCoordinateBounds: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    visibleCoordinateBounds: PropTypes.arrayOf(
+      PropTypes.arrayOf(PropTypes.number),
+    ),
 
     /**
      * Shows the users location on the map
@@ -307,14 +309,14 @@ class MapView extends React.Component {
   }
 
   componentDidMount() {
-    this.setHandledMapChangedEvents(this.props);
+    this._setHandledMapChangedEvents(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setHandledMapChangedEvents(nextProps);
+    this._setHandledMapChangedEvents(nextProps);
   }
 
-  setHandledMapChangedEvents(props) {
+  _setHandledMapChangedEvents(props) {
     if (isAndroid()) {
       const events = [];
 

--- a/scripts/autogenHelpers/MarkdownBuilder.js
+++ b/scripts/autogenHelpers/MarkdownBuilder.js
@@ -1,27 +1,25 @@
 const fs = require('fs');
 const path = require('path');
 const ejs = require('ejs');
-const docJSON = require('../../docs/docs.json');
 
 const TMPL_PATH = path.join(__dirname, '..', 'templates');
 const TMPL_FILE = fs.readFileSync(path.join(TMPL_PATH, 'component.md.ejs'), 'utf8');
 
 class MarkdownBuilder {
-  constructor () {
-    this.json = docJSON;
-  }
 
-  generateComponentFile (componentName) {
+  generateComponentFile (docJSON, componentName) {
     const tmpl = ejs.compile(TMPL_FILE, { strict: true });
-    const fileContents = tmpl({ component: this.json[componentName] });
+    const fileContents = tmpl({ component: docJSON[componentName] });
     fs.writeFileSync(path.join(__dirname, '..', '..', 'docs',  `${componentName}.md`), fileContents);
   }
 
   generate () {
-    const componentPaths = Object.keys(this.json);
+    const docJSONFile = fs.readFileSync(path.join(__dirname, '..', '..', 'docs', 'docs.json'), 'utf8');
+    const docJSON = JSON.parse(docJSONFile);
+    const componentPaths = Object.keys(docJSON);
 
     for (let componentPath of componentPaths) {
-      this.generateComponentFile(componentPath);
+      this.generateComponentFile(docJSON, componentPath);
     }
 
     console.log('Markdown is finish generating');


### PR DESCRIPTION
I found several issues when generating docs:

- The method `setHandledMapChangedEvents` introduced with ca2eb2d6cdd2547c461c3279fecda879d4fa7730 was picked up by `docs.json`. When trying to generating markdown using `component.md.ejs` it was trying to extract the method description and the generation failed with:

```json
(node:42425) UnhandledPromiseRejectionWarning: TypeError: ejs:19
    17| #### <%- getMarkdownMethodSignature(method) %>
    18| 
 >> 19| <%- replaceNewLine(method.description) %>
    20| 
    21| ##### arguments
    22| | Name | Type | Required | Description  |

Cannot read property 'replace' of undefined
```

- When running `npm run generate` the new / latest `docs.json` was not picked up by `MarkdownBuilder` as the `docs.json` was read during import phase via `autogenerate.js`