### PR TITLE
Dynamic version for Android Support Library and OKHTTP

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -31,10 +31,14 @@ dependencies {
 }
 ```
 
-Update Android SDK version if you did `react-native init`, we want to be on `26` or higher.
-* `compileSdkVersion 26`
-* `buildToolsVersion "26.0.1"`
+Update Android SDK version if you did `react-native init`, we want to be on `28` or higher.
+* `compileSdkVersion 28`
+* `buildToolsVersion "28.0.3"`
 * `targetSdkVersion 26`
+
+You can also set the Support Library version or the okhttp version as well if you use other modules that depend on them:
+* `supportLibVersion "28.0.0"`
+* `okhttpVersion "3.12.1"`
 
 ### settings.gradle
 

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -5,8 +5,8 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 26)
-    buildToolsVersion safeExtGet("buildToolsVersion", '26.0.1')
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    buildToolsVersion safeExtGet("buildToolsVersion", '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
@@ -34,10 +34,10 @@ dependencies {
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.3@aar'
 
     // Dependencies
-    implementation 'com.android.support:support-vector-drawable:28.0.0'
-    implementation 'com.android.support:support-annotations:28.0.0'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+    implementation "com.android.support:support-vector-drawable:${safeExtGet('supportLibVersion', '28.0.0')}"
+    implementation "com.android.support:support-annotations:${safeExtGet('supportLibVersion', '28.0.0')}"
+    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
+    implementation "com.squareup.okhttp3:okhttp:${safeExtGet('okhttpVersion', '3.12.1')}"
 
     // Mapbox plugins
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization:0.1.0'


### PR DESCRIPTION
Hey, so I was having problems building with master, and it was because I was compiling with version 27 and Mapbox was forcing version 28 of the Support Library. 

You get issues like this: https://stackoverflow.com/questions/49280632/error9-5-error-resource-androidattr-dialogcornerradius-not-found 

So I had to force my compileSdkVersion to 28. 

Eventually I made the supportLibVersion dynamic and also the okhttp version since some people were having issues. Bumped the compile version to 28 since it makes sense to have the same as the support library. 