### PR TITLE
correct coordinate type on interface PointAnnotationProps to Array<number>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -323,7 +323,7 @@ interface PointAnnotationProps {
     title?: string;
     snippet?: string;
     selected?: boolean;
-    coordinate: Array<string>;
+    coordinate: Array<number>;
     anchor?: Point;
     onSelected?: () => void;
     onDeselected?: () => void;


### PR DESCRIPTION
github issue: https://github.com/nitaliano/react-native-mapbox-gl/issues/1559

change coordinate type on interface PointAnnotationProps from Array string to Array number.