### PR TITLE
Fixed Trying to remove a view index above child count 0

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -264,7 +264,12 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public void removeFeature(int childPosition) {
-        AbstractMapFeature feature = mFeatures.get(childPosition);
+        AbstractMapFeature feature;
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            feature = mQueuedFeatures.get(childPosition);
+        } else {
+            feature = mFeatures.get(childPosition);
+        }
 
         if (feature == null) {
             return;
@@ -285,13 +290,26 @@ public class RCTMGLMapView extends MapView implements
 
         feature.removeFromMap(this);
         mFeatures.remove(feature);
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            mQueuedFeatures.remove(feature);
+        }
     }
 
     public int getFeatureCount() {
-        return mFeatures.size();
+        int totalCount = 0;
+
+        if (mQueuedFeatures != null) {
+            totalCount = mQueuedFeatures.size();
+        }
+
+        totalCount += mFeatures.size();
+        return totalCount;
     }
 
     public AbstractMapFeature getFeatureAt(int i) {
+        if (mQueuedFeatures != null && mQueuedFeatures.size() > 0) {
+            return mQueuedFeatures.get(i);
+        }
         return mFeatures.get(i);
     }
 


### PR DESCRIPTION
Fixes a regressed issue: https://github.com/nitaliano/react-native-mapbox-gl/issues/1579

A PR fixing the issue was initially accepted in PR https://github.com/nitaliano/react-native-mapbox-gl/pull/1274 but parts of it were lost in a recent merge (see above issue)