### PR TITLE
Update type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -342,6 +342,7 @@ interface CalloutProps {
     url?: string;
     onPress?: () => void;
     hitbox?: any;
+    title?: string;
 }
 
 interface VectorSourceProps {
@@ -365,7 +366,7 @@ interface ShapeSourceProps {
     tolerance?: number;
     images?: any;
     onPress?: () => void;
-    hitbox: any;
+    hitbox?: any;
 }
 
 interface RasterSourceProps {


### PR DESCRIPTION
Modify hitbox property for ShapeSourceProps as optional to match react proptypes. Checked code to verify it does not assume hitbox to be non-null, and purpose of hitbox is to override the default of 44x44.

Modify CalloutProps to include title, used in Callout.js line 109.