### PR TITLE
Fix a NullPointerException in weatherbug application.

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1274,6 +1274,9 @@ public class RCTMGLMapView extends MapView implements
 
     private WritableMap makeRegionPayload() {
         CameraPosition position = mMap.getCameraPosition();
+	if (position == null || position.target == null) {
+		return new WritableNativeMap();
+	}
         LatLng latLng = new LatLng(position.target.getLatitude(), position.target.getLongitude());
 
         WritableMap properties = new WritableNativeMap();


### PR DESCRIPTION
- Weatherbug application crashes using  latest version of react-native-mapbox-gl. The crash was resolved last year in this PR-
  https://github.com/nitaliano/react-native-mapbox-gl/pull/1392
(Please read details of the fixes in above link)

- However, this change got lost due to the commit:
 https://github.com/nitaliano/react-native-mapbox-gl/commit/2bc9841b443f8214e7c9f9c9357a6b8d37d32aaf#diff-83bd90811e16ee14c9357ca5dd70f50cR1226

@kristfal - Could we please re-introduce this fix asap so that we can launch our latest version of the app to playstore?

- Redoing this change to fix the issue.